### PR TITLE
Execution core lineage foundation

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -139,6 +139,7 @@ from apps.api.services.report_service import (
     get_report_visual,
 )
 from apps.api.services.agent_output_service import build_agent_output_summary
+from apps.api.services._trace_refs import parse_source_refs
 from apps.api.services.scheduler_service import get_scheduler_overview
 from apps.runtime.state_machine import (
     ACTIVE_DAGSTER_RUN_STATUSES,
@@ -2577,7 +2578,7 @@ def _agent_inspection_item(row, snapshot_payload: dict[str, Any] | None) -> dict
         },
         "input": {
             "input_snapshot_ids": row.input_snapshot_ids or {},
-            "source_refs": row.source_refs or [],
+            "source_refs": [source_ref.model_dump(mode="json") for source_ref in parse_source_refs(row.source_refs)],
             "payload": input_payload,
         },
         "output": {

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -53,6 +53,7 @@ from apps.api.schemas.playbook import (
     PlaybookTemplateListResponse,
     PlaybookTemplateVersion,
 )
+from apps.api.schemas.artifact import ArtifactDetailResponse
 from apps.api.schemas.strategy import StrategyAssetListResponse
 from apps.api.schemas.source_trace import SourceTraceResponse
 from apps.api.schemas.report import ReportAnalysisInputs, ReportArtifact, ReportDetail
@@ -120,6 +121,7 @@ from apps.api.services.daily_analysis_followup_service import (
 from apps.api.services.daily_analysis_followup_task_service import create_daily_analysis_followup_tasks
 from apps.api.services.execution_event_api import get_run_events
 from apps.api.services.feishu_jin10_message_monitor_service import get_feishu_jin10_message_monitor
+from apps.api.services.artifact_service import get_artifact_detail_response
 from apps.api.services.source_service import get_data_status_summary
 from apps.api.services.source_trace_service import (
     get_source_trace_by_report_id,
@@ -880,6 +882,20 @@ def api_run_artifacts(run_id: str, db: Session = Depends(get_db)):
     if artifacts is None:
         raise HTTPException(status_code=404, detail="Run not found")
     return artifacts
+
+
+@app.get("/api/artifacts/{artifact_id}", response_model=ArtifactDetailResponse)
+def api_artifact_detail(artifact_id: str, db: Session = Depends(get_db)) -> ArtifactDetailResponse:
+    """返回单个 registry artifact 的上下文详情。"""
+    try:
+        uuid.UUID(artifact_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid artifact_id format")
+
+    artifact = get_artifact_detail_response(db, artifact_id)
+    if artifact is None:
+        raise HTTPException(status_code=404, detail="Artifact not found")
+    return artifact
 
 
 @app.get("/api/runs/{run_id}/events")

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -97,6 +97,7 @@ from apps.api.services import (
     event_flow_action_service,
     ingestion_action_service,
     ingestion_source_test_service,
+    pipeline_contract_service,
     playbook_service,
     review_service,
     settings_service,
@@ -536,6 +537,12 @@ def api_memory_context(task: str) -> MemoryContextResponse:
 
 
 PREMARKET_STEPS = PREMARKET_STEP_ORDER
+
+
+@app.get("/api/pipelines/premarket/contract")
+def api_premarket_pipeline_contract() -> dict[str, Any]:
+    """Return the read-only canonical premarket step topology contract."""
+    return pipeline_contract_service.build_premarket_pipeline_contract()
 
 
 @app.post("/tasks/premarket", response_model=TaskCreateResponse)

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -118,6 +118,7 @@ from apps.api.services.daily_analysis_followup_service import (
     get_daily_analysis_followups_latest,
 )
 from apps.api.services.daily_analysis_followup_task_service import create_daily_analysis_followup_tasks
+from apps.api.services.execution_event_api import get_run_events
 from apps.api.services.feishu_jin10_message_monitor_service import get_feishu_jin10_message_monitor
 from apps.api.services.source_service import get_data_status_summary
 from apps.api.services.source_trace_service import (
@@ -136,8 +137,14 @@ from apps.api.services.report_service import (
 )
 from apps.api.services.agent_output_service import build_agent_output_summary
 from apps.api.services.scheduler_service import get_scheduler_overview
+from apps.runtime.state_machine import (
+    ACTIVE_DAGSTER_RUN_STATUSES,
+    map_dagster_status_to_task_status,
+    transition_task_run,
+)
 from database.models.engine import SessionLocal, get_db
 from database.models.analysis import ensure_analysis_tables
+from database.models.execution import ensure_execution_tables
 from database.models.report import ensure_report_tables
 from database.models.task import TaskRun, TaskStatus, TaskStep, ensure_task_tables
 
@@ -150,7 +157,6 @@ _JIN10_FLASH_CACHE_MAX_AGE_SECONDS = 60
 _PREMARKET_ACTIVE_TASK_STALE_AFTER = timedelta(
     hours=int(os.getenv("PREMARKET_ACTIVE_TASK_STALE_AFTER_HOURS", "6"))
 )
-_DAGSTER_ACTIVE_RUN_STATUSES = {"QUEUED", "STARTING", "STARTED", "CANCELING"}
 
 
 def _run_premarket_scheduled() -> None:
@@ -197,13 +203,14 @@ def _cleanup_stale_active_premarket_tasks(db: Session, *, now: datetime | None =
     for task in active_runs:
         ref_time = _premarket_active_task_ref_time(task)
         if ref_time is not None and current_time - ref_time > _PREMARKET_ACTIVE_TASK_STALE_AFTER:
-            task.status = TaskStatus.stale
-            task.ended_at = current_time
-            task.error_summary = (
-                f"Marked stale after exceeding active timeout ({_PREMARKET_ACTIVE_TASK_STALE_AFTER})."
+            transition_task_run(
+                db,
+                task,
+                TaskStatus.stale,
+                source="api",
+                reason=f"active_timeout_exceeded:{_PREMARKET_ACTIVE_TASK_STALE_AFTER}",
+                error_message=task.error or "Legacy premarket task timed out before Dagster migration verification.",
             )
-            if not task.error:
-                task.error = "Legacy premarket task timed out before Dagster migration verification."
             stale_marked = True
             continue
         if stale_marked:
@@ -240,20 +247,13 @@ def _find_active_dagster_premarket_run(dagster_url: str) -> dict[str, str] | Non
     runs = data.get("data", {}).get("runsOrError", {}).get("results", [])
     for run in runs:
         status = str(run.get("status") or "").upper()
-        if status in _DAGSTER_ACTIVE_RUN_STATUSES:
+        if status in ACTIVE_DAGSTER_RUN_STATUSES:
             return {"run_id": str(run.get("runId")), "status": status}
     return None
 
 
 def _dagster_status_to_task_status(status: str | None) -> str:
-    value = str(status or "").upper()
-    if value in {"QUEUED", "STARTING", "STARTED", "CANCELING"}:
-        return "running"
-    if value == "SUCCESS":
-        return "success"
-    if value in {"FAILURE", "CANCELED", "CANCELLED"}:
-        return "failed"
-    return "pending"
+    return map_dagster_status_to_task_status(status)
 
 
 def _timestamp_to_utc(value: float | int | None) -> datetime | None:
@@ -340,6 +340,7 @@ async def lifespan(_app: FastAPI):
         db = SessionLocal()
         try:
             ensure_task_tables(db)
+            ensure_execution_tables(db)
             ensure_analysis_tables(db)
             ensure_report_tables(db)
         except Exception:
@@ -879,6 +880,20 @@ def api_run_artifacts(run_id: str, db: Session = Depends(get_db)):
     if artifacts is None:
         raise HTTPException(status_code=404, detail="Run not found")
     return artifacts
+
+
+@app.get("/api/runs/{run_id}/events")
+def api_run_events(run_id: str, db: Session = Depends(get_db)):
+    """返回某次运行的执行事件时间线。"""
+    try:
+        uuid.UUID(run_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid run_id format")
+
+    run = task_service.get_task_run(db, run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return get_run_events(db, run_id)
 
 
 # ── API: Scheduler Center ──

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -124,6 +124,7 @@ from apps.api.services.feishu_jin10_message_monitor_service import get_feishu_ji
 from apps.api.services.artifact_service import get_artifact_detail_response
 from apps.api.services.source_service import get_data_status_summary
 from apps.api.services.source_trace_service import (
+    get_source_trace_by_artifact_id,
     get_source_trace_by_report_id,
     get_source_trace_by_snapshot_id,
     get_source_trace_by_strategy_card_id,
@@ -941,6 +942,20 @@ def api_source_trace_by_report(report_id: str, db: Session = Depends(get_db)) ->
 def api_source_trace_by_strategy(strategy_card_id: str, db: Session = Depends(get_db)) -> SourceTraceResponse:
     """按 strategy_card_id 反查关联 run/snapshot/source/artifact。"""
     trace = get_source_trace_by_strategy_card_id(db, strategy_card_id)
+    if trace is None:
+        raise HTTPException(status_code=404, detail="Source trace not found")
+    return trace
+
+
+@app.get("/api/source-trace/by-artifact/{artifact_id}", response_model=SourceTraceResponse)
+def api_source_trace_by_artifact(artifact_id: str, db: Session = Depends(get_db)) -> SourceTraceResponse:
+    """按 artifact_id 反查关联 snapshot/source/artifact 溯源视图。"""
+    try:
+        uuid.UUID(artifact_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid artifact_id format")
+
+    trace = get_source_trace_by_artifact_id(db, artifact_id)
     if trace is None:
         raise HTTPException(status_code=404, detail="Source trace not found")
     return trace

--- a/apps/api/schemas/artifact.py
+++ b/apps/api/schemas/artifact.py
@@ -15,4 +15,5 @@ class ArtifactDetailResponse(TraceableResponse):
     task_id: str | None = None
     task_name: str | None = None
     stage: str | None = None
+    input_refs: list[ArtifactRef] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)

--- a/apps/api/schemas/artifact.py
+++ b/apps/api/schemas/artifact.py
@@ -1,0 +1,18 @@
+"""Artifact detail API schemas."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field
+
+from .common import TraceableResponse
+from .source_trace import ArtifactRef
+
+
+class ArtifactDetailResponse(TraceableResponse):
+    artifact: ArtifactRef
+    task_id: str | None = None
+    task_name: str | None = None
+    stage: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/apps/api/services/_trace_refs.py
+++ b/apps/api/services/_trace_refs.py
@@ -109,6 +109,9 @@ def coerce_artifact_type(raw_type: str | None, file_path: str) -> ArtifactType:
         normalized.endswith("analysis.md")
         or normalized.endswith("final_report.md")
         or normalized.endswith("agent_analysis_report.md")
+        or normalized.endswith("options_report.md")
+        or normalized.endswith("options_analysis.md")
+        or normalized.endswith("options_analysis_agent_report.md")
     ):
         return ArtifactType.analysis_md
     if (

--- a/apps/api/services/_trace_refs.py
+++ b/apps/api/services/_trace_refs.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from typing import Any
+
+from apps.api.schemas.common import ArtifactType
+from apps.api.schemas.source_trace import ArtifactRef, SourceRef
+
+
+def parse_source_refs(raw: Any) -> list[SourceRef]:
+    payload = _normalize_payload(raw)
+    if not isinstance(payload, list):
+        return []
+
+    refs: list[SourceRef] = []
+    for index, item in enumerate(payload):
+        if not isinstance(item, dict):
+            continue
+        source_name = str(item.get("source_name") or item.get("source") or item.get("source_id") or f"source-{index}")
+        source_id = str(item.get("source_id") or f"{source_name}:{index}")
+        source_type = str(item.get("source_type") or item.get("type") or "unknown")
+        refs.append(
+            SourceRef(
+                source_id=source_id,
+                source_name=source_name,
+                source_type=source_type,
+                data_date=item.get("data_date"),
+                endpoint=item.get("endpoint"),
+                captured_at=item.get("captured_at"),
+                file_path=item.get("file_path"),
+                sha256=item.get("sha256"),
+                url=item.get("url"),
+                status=item.get("status"),
+            )
+        )
+    return refs
+
+
+def parse_artifact_refs(raw: Any) -> list[ArtifactRef]:
+    payload = _normalize_payload(raw)
+    if not isinstance(payload, list):
+        return []
+
+    artifacts: list[ArtifactRef] = []
+    for index, item in enumerate(payload):
+        if isinstance(item, dict):
+            file_path = item.get("file_path")
+            if not file_path:
+                continue
+            artifacts.append(
+                ArtifactRef(
+                    artifact_id=str(item.get("artifact_id") or f"{file_path}:{index}"),
+                    artifact_type=coerce_artifact_type(item.get("artifact_type"), str(file_path)),
+                    file_path=str(file_path),
+                    version=item.get("version"),
+                    generated_at=item.get("generated_at"),
+                    sha256=item.get("sha256"),
+                )
+            )
+        elif isinstance(item, str):
+            artifacts.append(artifact_ref_from_path(item, artifact_id=f"{item}:{index}"))
+    return artifacts
+
+
+def artifact_ref_from_path(path: str, *, artifact_id: str) -> ArtifactRef:
+    return ArtifactRef(
+        artifact_id=artifact_id,
+        artifact_type=coerce_artifact_type(None, path),
+        file_path=path,
+    )
+
+
+def dedupe_artifact_refs(artifacts: Iterable[ArtifactRef]) -> list[ArtifactRef]:
+    seen: set[tuple[str, str]] = set()
+    deduped: list[ArtifactRef] = []
+    for artifact in artifacts:
+        key = (artifact.file_path, artifact.artifact_type.value)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(artifact)
+    return deduped
+
+
+def dedupe_source_refs(sources: Iterable[SourceRef]) -> list[SourceRef]:
+    seen: set[tuple[str, str]] = set()
+    deduped: list[SourceRef] = []
+    for source in sources:
+        key = (source.source_id, source.source_type)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(source)
+    return deduped
+
+
+def coerce_artifact_type(raw_type: str | None, file_path: str) -> ArtifactType:
+    if raw_type:
+        try:
+            return ArtifactType(raw_type)
+        except ValueError:
+            pass
+
+    normalized = file_path.lower()
+    if normalized.endswith("source.md"):
+        return ArtifactType.source_md
+    if normalized.endswith("analysis.md"):
+        return ArtifactType.analysis_md
+    if normalized.endswith("visual.html"):
+        return ArtifactType.visual_html
+    if normalized.endswith("report_structured.json"):
+        return ArtifactType.structured_json
+    if "/raw/" in normalized:
+        return ArtifactType.raw_file
+    if "/parsed/" in normalized:
+        return ArtifactType.parsed_file
+    if "/features/" in normalized:
+        return ArtifactType.feature_json
+    if normalized.endswith(".png") or normalized.endswith(".jpg") or normalized.endswith(".jpeg"):
+        return ArtifactType.chart_snapshot
+    return ArtifactType.structured_json
+
+
+def _normalize_payload(raw: Any) -> Any:
+    if raw is None or raw == "":
+        return None
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+    return raw
+

--- a/apps/api/services/_trace_refs.py
+++ b/apps/api/services/_trace_refs.py
@@ -103,11 +103,19 @@ def coerce_artifact_type(raw_type: str | None, file_path: str) -> ArtifactType:
             pass
 
     normalized = file_path.lower()
-    if normalized.endswith("source.md"):
+    if normalized.endswith("source.md") or normalized.endswith("raw_article_report.md"):
         return ArtifactType.source_md
-    if normalized.endswith("analysis.md"):
+    if (
+        normalized.endswith("analysis.md")
+        or normalized.endswith("final_report.md")
+        or normalized.endswith("agent_analysis_report.md")
+    ):
         return ArtifactType.analysis_md
-    if normalized.endswith("visual.html"):
+    if (
+        normalized.endswith("visual.html")
+        or normalized.endswith("daily_analysis.html")
+        or normalized.endswith("options_visual_report.html")
+    ):
         return ArtifactType.visual_html
     if normalized.endswith("report_structured.json"):
         return ArtifactType.structured_json
@@ -131,4 +139,3 @@ def _normalize_payload(raw: Any) -> Any:
         except json.JSONDecodeError:
             return None
     return raw
-

--- a/apps/api/services/_trace_refs.py
+++ b/apps/api/services/_trace_refs.py
@@ -25,12 +25,12 @@ def parse_source_refs(raw: Any) -> list[SourceRef]:
                 source_id=source_id,
                 source_name=source_name,
                 source_type=source_type,
-                data_date=item.get("data_date"),
+                data_date=item.get("data_date") or item.get("report_date"),
                 endpoint=item.get("endpoint"),
                 captured_at=item.get("captured_at"),
                 file_path=item.get("file_path"),
                 sha256=item.get("sha256"),
-                url=item.get("url"),
+                url=item.get("url") or item.get("source_url"),
                 status=item.get("status"),
             )
         )

--- a/apps/api/services/agent_output_service.py
+++ b/apps/api/services/agent_output_service.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from typing import Any
 
 from apps.api.schemas.claim import Claim, ClaimReview, ClaimReviewVerdict, ClaimType
-from apps.api.schemas.source_trace import ArtifactRef, SourceRef
+from apps.api.services._trace_refs import (
+    artifact_ref_from_path,
+    coerce_artifact_type,
+    parse_source_refs,
+)
 
 
 _BIAS_LABELS = {
@@ -141,7 +145,7 @@ def normalize_claims(raw_claims: Any) -> list[dict[str, Any]]:
         if not text:
             continue
         claim_type = _coerce_claim_type(item.get("claim_type"))
-        source_refs = _parse_source_refs(item.get("source_refs"))
+        source_refs = parse_source_refs(item.get("source_refs"))
         evidence_refs = _parse_evidence_refs(item.get("evidence_refs"))
         confidence = _coerce_confidence(item.get("confidence"))
         claims.append(
@@ -210,32 +214,6 @@ def _optional_string(raw: Any) -> str | None:
     return text or None
 
 
-def _parse_source_refs(raw: Any) -> list[SourceRef]:
-    if not isinstance(raw, list):
-        return []
-    refs: list[SourceRef] = []
-    for index, item in enumerate(raw):
-        if not isinstance(item, dict):
-            continue
-        source_name = str(item.get("source_name") or item.get("source") or item.get("source_id") or f"source-{index}")
-        source_id = str(item.get("source_id") or f"{source_name}:{index}")
-        refs.append(
-            SourceRef(
-                source_id=source_id,
-                source_name=source_name,
-                source_type=str(item.get("source_type") or item.get("type") or "unknown"),
-                data_date=item.get("data_date"),
-                endpoint=item.get("endpoint"),
-                captured_at=item.get("captured_at"),
-                file_path=item.get("file_path"),
-                sha256=item.get("sha256"),
-                url=item.get("url"),
-                status=item.get("status"),
-            )
-        )
-    return refs
-
-
 def _parse_evidence_refs(raw: Any) -> list[dict[str, Any]]:
     if not isinstance(raw, list):
         return []
@@ -243,10 +221,9 @@ def _parse_evidence_refs(raw: Any) -> list[dict[str, Any]]:
     for index, item in enumerate(raw):
         if isinstance(item, str):
             refs.append(
-                ArtifactRef(
+                artifact_ref_from_path(
+                    item,
                     artifact_id=f"evidence-{index + 1}",
-                    artifact_type=_coerce_artifact_type(None, item),
-                    file_path=item,
                 ).model_dump(mode="json")
             )
             continue
@@ -254,50 +231,22 @@ def _parse_evidence_refs(raw: Any) -> list[dict[str, Any]]:
             continue
         file_path = item.get("file_path") or item.get("artifact_path") or item.get("path")
         if file_path:
+            artifact_id = str(item.get("artifact_id") or f"evidence-{index + 1}")
             refs.append(
-                ArtifactRef(
-                    artifact_id=str(item.get("artifact_id") or f"evidence-{index + 1}"),
-                    artifact_type=_coerce_artifact_type(item.get("artifact_type"), str(file_path)),
-                    file_path=str(file_path),
-                    version=item.get("version"),
-                    generated_at=item.get("generated_at"),
-                    sha256=item.get("sha256"),
-                ).model_dump(mode="json")
+                artifact_ref_from_path(
+                    str(file_path),
+                    artifact_id=artifact_id,
+                )
+                .model_copy(
+                    update={
+                        "artifact_type": coerce_artifact_type(item.get("artifact_type"), str(file_path)),
+                        "version": item.get("version"),
+                        "generated_at": item.get("generated_at"),
+                        "sha256": item.get("sha256"),
+                    }
+                )
+                .model_dump(mode="json")
             )
             continue
-        source_name = str(item.get("source_name") or item.get("source") or item.get("source_id") or f"source-{index}")
-        source_id = str(item.get("source_id") or f"{source_name}:{index}")
-        refs.append(
-            SourceRef(
-                source_id=source_id,
-                source_name=source_name,
-                source_type=str(item.get("source_type") or item.get("type") or "unknown"),
-                data_date=item.get("data_date"),
-                endpoint=item.get("endpoint"),
-                captured_at=item.get("captured_at"),
-                file_path=item.get("file_path"),
-                sha256=item.get("sha256"),
-                url=item.get("url"),
-                status=item.get("status"),
-            ).model_dump(mode="json")
-        )
+        refs.extend(source_ref.model_dump(mode="json") for source_ref in parse_source_refs([item]))
     return refs
-
-
-def _coerce_artifact_type(raw_type: Any, file_path: str) -> str:
-    from apps.api.schemas.common import ArtifactType
-
-    if raw_type:
-        try:
-            return ArtifactType(str(raw_type)).value
-        except ValueError:
-            pass
-
-    normalized = file_path.lower()
-    if normalized.endswith(".md"):
-        return ArtifactType.analysis_md.value
-    if normalized.endswith(".html"):
-        return ArtifactType.visual_html.value
-    if normalized.endswith(".json"):
-        return ArtifactType.structured_json.value
-    return ArtifactType.raw_file.value

--- a/apps/api/services/agent_output_service.py
+++ b/apps/api/services/agent_output_service.py
@@ -6,6 +6,8 @@ from apps.api.schemas.claim import Claim, ClaimReview, ClaimReviewVerdict, Claim
 from apps.api.services._trace_refs import (
     artifact_ref_from_path,
     coerce_artifact_type,
+    dedupe_artifact_refs,
+    parse_artifact_refs,
     parse_source_refs,
 )
 
@@ -80,9 +82,9 @@ def build_agent_output_summary(row) -> dict[str, Any]:
     if generated_by is None:
         generated_by = "llm" if row.llm_model else "rule"
 
-    artifact_refs = payload.get("artifact_refs")
-    if artifact_refs is None:
-        artifact_refs = payload.get("source_artifact_refs") or []
+    artifact_refs = _normalize_artifact_refs(
+        payload.get("artifact_refs") if payload.get("artifact_refs") is not None else payload.get("source_artifact_refs"),
+    )
     source_refs = [source_ref.model_dump(mode="json") for source_ref in parse_source_refs(row.source_refs)]
 
     claims = normalize_claims(payload.get("claims"))
@@ -251,3 +253,9 @@ def _parse_evidence_refs(raw: Any) -> list[dict[str, Any]]:
             continue
         refs.extend(source_ref.model_dump(mode="json") for source_ref in parse_source_refs([item]))
     return refs
+
+
+def _normalize_artifact_refs(raw: Any) -> list[dict[str, Any]]:
+    if raw is None:
+        return []
+    return [artifact.model_dump(mode="json") for artifact in dedupe_artifact_refs(parse_artifact_refs(raw))]

--- a/apps/api/services/agent_output_service.py
+++ b/apps/api/services/agent_output_service.py
@@ -83,6 +83,7 @@ def build_agent_output_summary(row) -> dict[str, Any]:
     artifact_refs = payload.get("artifact_refs")
     if artifact_refs is None:
         artifact_refs = payload.get("source_artifact_refs") or []
+    source_refs = [source_ref.model_dump(mode="json") for source_ref in parse_source_refs(row.source_refs)]
 
     claims = normalize_claims(payload.get("claims"))
     claim_reviews = normalize_claim_reviews(payload.get("claim_reviews"))
@@ -110,7 +111,7 @@ def build_agent_output_summary(row) -> dict[str, Any]:
         "watchlist": row.watchlist or [],
         "invalid_conditions": row.invalid_conditions or [],
         "input_snapshot_ids": row.input_snapshot_ids or {},
-        "source_refs": row.source_refs or [],
+        "source_refs": source_refs,
         "artifact_refs": artifact_refs,
         "market_phase": payload.get("market_phase"),
         "regime_drivers": payload.get("regime_drivers"),

--- a/apps/api/services/artifact_service.py
+++ b/apps/api/services/artifact_service.py
@@ -7,8 +7,14 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from apps.api.schemas.artifact import ArtifactDetailResponse
-from apps.api.schemas.common import ArtifactType
-from apps.api.schemas.source_trace import ArtifactRef, SourceRef
+from apps.api.schemas.source_trace import ArtifactRef
+from apps.api.services._trace_refs import (
+    artifact_ref_from_path,
+    coerce_artifact_type,
+    dedupe_artifact_refs,
+    parse_artifact_refs,
+    parse_source_refs,
+)
 from database.models.execution import RunArtifact
 from database.models.task import TaskRun, TaskStep
 
@@ -23,15 +29,15 @@ def get_artifact_detail_response(db: Session, artifact_id: str) -> ArtifactDetai
 
     artifact = ArtifactRef(
         artifact_id=str(row.artifact_id),
-        artifact_type=_coerce_artifact_type(row.artifact_type, row.file_path),
+        artifact_type=coerce_artifact_type(row.artifact_type, row.file_path),
         file_path=row.file_path,
         generated_at=row.created_at,
         sha256=row.sha256,
     )
-    source_refs = _parse_source_refs(row.source_refs)
+    source_refs = parse_source_refs(row.source_refs)
     if not source_refs and step is not None:
-        source_refs = _parse_source_refs(step.source_refs)
-    input_refs = _parse_artifact_refs(step.input_refs) if step is not None else []
+        source_refs = parse_source_refs(step.source_refs)
+    input_refs = parse_artifact_refs(step.input_refs) if step is not None else []
     related_artifacts = _build_related_artifacts(artifact, step=step)
 
     return ArtifactDetailResponse(
@@ -58,126 +64,14 @@ def _parse_metadata(raw: str | None) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
-def _parse_source_refs(raw: str | None) -> list[SourceRef]:
-    if not raw:
-        return []
-    try:
-        payload = json.loads(raw)
-    except json.JSONDecodeError:
-        return []
-    if not isinstance(payload, list):
-        return []
-
-    refs: list[SourceRef] = []
-    for index, item in enumerate(payload):
-        if not isinstance(item, dict):
-            continue
-        source_name = str(item.get("source_name") or item.get("source") or item.get("source_id") or f"source-{index}")
-        source_id = str(item.get("source_id") or f"{source_name}:{index}")
-        source_type = str(item.get("source_type") or item.get("type") or "unknown")
-        refs.append(
-            SourceRef(
-                source_id=source_id,
-                source_name=source_name,
-                source_type=source_type,
-                data_date=item.get("data_date"),
-                endpoint=item.get("endpoint"),
-                captured_at=item.get("captured_at"),
-                file_path=item.get("file_path"),
-                sha256=item.get("sha256"),
-                url=item.get("url"),
-                status=item.get("status"),
-            )
-        )
-    return refs
-
-
-def _parse_artifact_refs(raw: str | None) -> list[ArtifactRef]:
-    if not raw:
-        return []
-    try:
-        payload = json.loads(raw)
-    except json.JSONDecodeError:
-        return []
-    if not isinstance(payload, list):
-        return []
-
-    artifacts: list[ArtifactRef] = []
-    for index, item in enumerate(payload):
-        if isinstance(item, dict):
-            file_path = item.get("file_path")
-            if not file_path:
-                continue
-            artifacts.append(
-                ArtifactRef(
-                    artifact_id=str(item.get("artifact_id") or f"{file_path}:{index}"),
-                    artifact_type=_coerce_artifact_type(item.get("artifact_type"), file_path),
-                    file_path=file_path,
-                    version=item.get("version"),
-                    generated_at=item.get("generated_at"),
-                    sha256=item.get("sha256"),
-                )
-            )
-        elif isinstance(item, str):
-            artifacts.append(_artifact_from_path(item, artifact_id=f"{item}:{index}"))
-    return artifacts
-
-
-def _artifact_from_path(path: str, *, artifact_id: str) -> ArtifactRef:
-    return ArtifactRef(
-        artifact_id=artifact_id,
-        artifact_type=_coerce_artifact_type(None, path),
-        file_path=path,
-    )
-
-
 def _build_related_artifacts(current: ArtifactRef, *, step: TaskStep | None) -> list[ArtifactRef]:
     if step is None:
         return [current]
     artifacts = [
         current,
-        *_parse_artifact_refs(step.output_refs),
-        *_parse_artifact_refs(step.artifact_refs),
+        *parse_artifact_refs(step.output_refs),
+        *parse_artifact_refs(step.artifact_refs),
     ]
     if step.output_ref:
-        artifacts.append(_artifact_from_path(step.output_ref, artifact_id=f"{step.id}:output_ref"))
-    return _dedupe_artifacts(artifacts)
-
-
-def _dedupe_artifacts(artifacts: list[ArtifactRef]) -> list[ArtifactRef]:
-    seen: set[tuple[str, str]] = set()
-    deduped: list[ArtifactRef] = []
-    for artifact in artifacts:
-        key = (artifact.file_path, artifact.artifact_type.value)
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(artifact)
-    return deduped
-
-
-def _coerce_artifact_type(raw_type: str | None, file_path: str) -> ArtifactType:
-    if raw_type:
-        try:
-            return ArtifactType(raw_type)
-        except ValueError:
-            pass
-
-    normalized = file_path.lower()
-    if normalized.endswith("source.md"):
-        return ArtifactType.source_md
-    if normalized.endswith("analysis.md"):
-        return ArtifactType.analysis_md
-    if normalized.endswith("visual.html"):
-        return ArtifactType.visual_html
-    if normalized.endswith("report_structured.json"):
-        return ArtifactType.structured_json
-    if "/raw/" in normalized:
-        return ArtifactType.raw_file
-    if "/parsed/" in normalized:
-        return ArtifactType.parsed_file
-    if "/features/" in normalized:
-        return ArtifactType.feature_json
-    if normalized.endswith(".png") or normalized.endswith(".jpg") or normalized.endswith(".jpeg"):
-        return ArtifactType.chart_snapshot
-    return ArtifactType.structured_json
+        artifacts.append(artifact_ref_from_path(step.output_ref, artifact_id=f"{step.id}:output_ref"))
+    return dedupe_artifact_refs(artifacts)

--- a/apps/api/services/artifact_service.py
+++ b/apps/api/services/artifact_service.py
@@ -31,6 +31,8 @@ def get_artifact_detail_response(db: Session, artifact_id: str) -> ArtifactDetai
     source_refs = _parse_source_refs(row.source_refs)
     if not source_refs and step is not None:
         source_refs = _parse_source_refs(step.source_refs)
+    input_refs = _parse_artifact_refs(step.input_refs) if step is not None else []
+    related_artifacts = _build_related_artifacts(artifact, step=step)
 
     return ArtifactDetailResponse(
         run_id=str(row.run_id) if row.run_id else None,
@@ -39,8 +41,9 @@ def get_artifact_detail_response(db: Session, artifact_id: str) -> ArtifactDetai
         task_id=str(step.id) if step is not None else str(row.task_id) if row.task_id else None,
         task_name=step.name if step is not None else None,
         stage=step.stage if step is not None else None,
+        input_refs=input_refs,
         source_refs=source_refs,
-        artifact_refs=[artifact],
+        artifact_refs=related_artifacts,
         metadata=_parse_metadata(row.metadata_json),
     )
 
@@ -87,6 +90,70 @@ def _parse_source_refs(raw: str | None) -> list[SourceRef]:
             )
         )
     return refs
+
+
+def _parse_artifact_refs(raw: str | None) -> list[ArtifactRef]:
+    if not raw:
+        return []
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(payload, list):
+        return []
+
+    artifacts: list[ArtifactRef] = []
+    for index, item in enumerate(payload):
+        if isinstance(item, dict):
+            file_path = item.get("file_path")
+            if not file_path:
+                continue
+            artifacts.append(
+                ArtifactRef(
+                    artifact_id=str(item.get("artifact_id") or f"{file_path}:{index}"),
+                    artifact_type=_coerce_artifact_type(item.get("artifact_type"), file_path),
+                    file_path=file_path,
+                    version=item.get("version"),
+                    generated_at=item.get("generated_at"),
+                    sha256=item.get("sha256"),
+                )
+            )
+        elif isinstance(item, str):
+            artifacts.append(_artifact_from_path(item, artifact_id=f"{item}:{index}"))
+    return artifacts
+
+
+def _artifact_from_path(path: str, *, artifact_id: str) -> ArtifactRef:
+    return ArtifactRef(
+        artifact_id=artifact_id,
+        artifact_type=_coerce_artifact_type(None, path),
+        file_path=path,
+    )
+
+
+def _build_related_artifacts(current: ArtifactRef, *, step: TaskStep | None) -> list[ArtifactRef]:
+    if step is None:
+        return [current]
+    artifacts = [
+        current,
+        *_parse_artifact_refs(step.output_refs),
+        *_parse_artifact_refs(step.artifact_refs),
+    ]
+    if step.output_ref:
+        artifacts.append(_artifact_from_path(step.output_ref, artifact_id=f"{step.id}:output_ref"))
+    return _dedupe_artifacts(artifacts)
+
+
+def _dedupe_artifacts(artifacts: list[ArtifactRef]) -> list[ArtifactRef]:
+    seen: set[tuple[str, str]] = set()
+    deduped: list[ArtifactRef] = []
+    for artifact in artifacts:
+        key = (artifact.file_path, artifact.artifact_type.value)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(artifact)
+    return deduped
 
 
 def _coerce_artifact_type(raw_type: str | None, file_path: str) -> ArtifactType:

--- a/apps/api/services/artifact_service.py
+++ b/apps/api/services/artifact_service.py
@@ -12,6 +12,7 @@ from apps.api.services._trace_refs import (
     artifact_ref_from_path,
     coerce_artifact_type,
     dedupe_artifact_refs,
+    dedupe_source_refs,
     parse_artifact_refs,
     parse_source_refs,
 )
@@ -35,8 +36,8 @@ def get_artifact_detail_response(db: Session, artifact_id: str) -> ArtifactDetai
         sha256=row.sha256,
     )
     source_refs = parse_source_refs(row.source_refs)
-    if not source_refs and step is not None:
-        source_refs = parse_source_refs(step.source_refs)
+    if step is not None:
+        source_refs = dedupe_source_refs([*source_refs, *parse_source_refs(step.source_refs)])
     input_refs = parse_artifact_refs(step.input_refs) if step is not None else []
     related_artifacts = _build_related_artifacts(artifact, step=step)
 

--- a/apps/api/services/artifact_service.py
+++ b/apps/api/services/artifact_service.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from apps.api.schemas.artifact import ArtifactDetailResponse
+from apps.api.schemas.common import ArtifactType
+from apps.api.schemas.source_trace import ArtifactRef, SourceRef
+from database.models.execution import RunArtifact
+from database.models.task import TaskRun, TaskStep
+
+
+def get_artifact_detail_response(db: Session, artifact_id: str) -> ArtifactDetailResponse | None:
+    row = db.query(RunArtifact).filter(RunArtifact.artifact_id == uuid.UUID(artifact_id)).first()
+    if row is None:
+        return None
+
+    run = db.query(TaskRun).filter(TaskRun.id == row.run_id).first() if row.run_id else None
+    step = db.query(TaskStep).filter(TaskStep.id == row.task_id).first() if row.task_id else None
+
+    artifact = ArtifactRef(
+        artifact_id=str(row.artifact_id),
+        artifact_type=_coerce_artifact_type(row.artifact_type, row.file_path),
+        file_path=row.file_path,
+        generated_at=row.created_at,
+        sha256=row.sha256,
+    )
+    source_refs = _parse_source_refs(row.source_refs)
+    if not source_refs and step is not None:
+        source_refs = _parse_source_refs(step.source_refs)
+
+    return ArtifactDetailResponse(
+        run_id=str(row.run_id) if row.run_id else None,
+        snapshot_id=run.snapshot_id if run is not None else None,
+        artifact=artifact,
+        task_id=str(step.id) if step is not None else str(row.task_id) if row.task_id else None,
+        task_name=step.name if step is not None else None,
+        stage=step.stage if step is not None else None,
+        source_refs=source_refs,
+        artifact_refs=[artifact],
+        metadata=_parse_metadata(row.metadata_json),
+    )
+
+
+def _parse_metadata(raw: str | None) -> dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _parse_source_refs(raw: str | None) -> list[SourceRef]:
+    if not raw:
+        return []
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(payload, list):
+        return []
+
+    refs: list[SourceRef] = []
+    for index, item in enumerate(payload):
+        if not isinstance(item, dict):
+            continue
+        source_name = str(item.get("source_name") or item.get("source") or item.get("source_id") or f"source-{index}")
+        source_id = str(item.get("source_id") or f"{source_name}:{index}")
+        source_type = str(item.get("source_type") or item.get("type") or "unknown")
+        refs.append(
+            SourceRef(
+                source_id=source_id,
+                source_name=source_name,
+                source_type=source_type,
+                data_date=item.get("data_date"),
+                endpoint=item.get("endpoint"),
+                captured_at=item.get("captured_at"),
+                file_path=item.get("file_path"),
+                sha256=item.get("sha256"),
+                url=item.get("url"),
+                status=item.get("status"),
+            )
+        )
+    return refs
+
+
+def _coerce_artifact_type(raw_type: str | None, file_path: str) -> ArtifactType:
+    if raw_type:
+        try:
+            return ArtifactType(raw_type)
+        except ValueError:
+            pass
+
+    normalized = file_path.lower()
+    if normalized.endswith("source.md"):
+        return ArtifactType.source_md
+    if normalized.endswith("analysis.md"):
+        return ArtifactType.analysis_md
+    if normalized.endswith("visual.html"):
+        return ArtifactType.visual_html
+    if normalized.endswith("report_structured.json"):
+        return ArtifactType.structured_json
+    if "/raw/" in normalized:
+        return ArtifactType.raw_file
+    if "/parsed/" in normalized:
+        return ArtifactType.parsed_file
+    if "/features/" in normalized:
+        return ArtifactType.feature_json
+    if normalized.endswith(".png") or normalized.endswith(".jpg") or normalized.endswith(".jpeg"):
+        return ArtifactType.chart_snapshot
+    return ArtifactType.structured_json

--- a/apps/api/services/execution_event_service.py
+++ b/apps/api/services/execution_event_service.py
@@ -40,7 +40,7 @@ def emit_execution_event(
         created_at=datetime.now(timezone.utc),
     )
     db.add(event)
-    db.commit()
+    db.flush()
     return event
 
 

--- a/apps/api/services/pipeline_contract_service.py
+++ b/apps/api/services/pipeline_contract_service.py
@@ -1,0 +1,18 @@
+"""Read-only contract service for canonical premarket step topology."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from apps.premarket import get_premarket_pipeline_contract, get_premarket_step_contract
+
+
+def build_premarket_pipeline_contract() -> dict[str, Any]:
+    """Return the canonical premarket DAG contract as an API-friendly payload."""
+    return get_premarket_pipeline_contract()
+
+
+def get_premarket_step_contract_view(step_name: str) -> dict[str, Any] | None:
+    """Return one canonical premarket step contract as a plain dict."""
+    contract = get_premarket_step_contract(step_name)
+    return None if contract is None else contract.to_dict()

--- a/apps/api/services/report_service.py
+++ b/apps/api/services/report_service.py
@@ -14,8 +14,9 @@ from apps.api.schemas.common import ArtifactType, DataStatus, ReportLifecycleSta
 from apps.api.schemas.report import ReportAnalysisAgentOutput, ReportAnalysisInputs, ReportDeterministicInput
 from apps.api.schemas.report import ReportArtifact as ReportArtifactSchema
 from apps.api.schemas.report import ReportDetail
-from apps.api.schemas.source_trace import ArtifactRef, SnapshotRef, SourceRef
+from apps.api.schemas.source_trace import ArtifactRef, SnapshotRef
 from apps.api.services._storage import _PROJECT_ROOT, _iso, _latest_asset_date_run, _try_db_session
+from apps.api.services._trace_refs import coerce_artifact_type, dedupe_artifact_refs, dedupe_source_refs, parse_source_refs
 from apps.api.services.agent_output_service import build_agent_output_summary
 from apps.analysis.macro.regime import classify_macro_regime
 from database.models.analysis import AgentOutput, AnalysisSnapshot, FinalAnalysisResult
@@ -124,14 +125,14 @@ def get_report_analysis_inputs(db: Session, report_id: str) -> ReportAnalysisInp
             )
         )
 
-    source_refs = _dedupe_sources(
+    source_refs = dedupe_source_refs(
         [
             *detail.source_refs,
             *[source for item in deterministic_inputs for source in item.source_refs],
             *[source for item in all_agent_outputs for source in item.source_refs],
         ]
     )
-    artifact_refs = _dedupe_artifacts(
+    artifact_refs = dedupe_artifact_refs(
         [
             *detail.artifacts,
             *[artifact for item in deterministic_inputs for artifact in item.artifact_refs],
@@ -236,7 +237,7 @@ def _build_report_agent_output(row: AgentOutput) -> ReportAnalysisAgentOutput:
         risk_points=[str(item) for item in summary["risk_points"]],
         watchlist=[str(item) for item in summary["watchlist"]],
         invalid_conditions=[str(item) for item in summary["invalid_conditions"]],
-        source_refs=_parse_source_refs(summary["source_refs"]),
+        source_refs=parse_source_refs(summary["source_refs"]),
         artifact_refs=_normalize_agent_artifact_refs(summary["artifact_refs"], agent_output_id=summary["agent_output_id"]),
         claims=summary["claims"],
         claim_reviews=summary["claim_reviews"],
@@ -251,7 +252,7 @@ def _build_report_agent_output(row: AgentOutput) -> ReportAnalysisAgentOutput:
 
 def _build_analysis_snapshot_input(snapshot: AnalysisSnapshot) -> ReportDeterministicInput:
     sections = _snapshot_sections(snapshot.payload)
-    source_refs = _parse_source_refs(snapshot.source_refs)
+    source_refs = parse_source_refs(snapshot.source_refs)
     snapshot_ref = SnapshotRef(
         snapshot_id=snapshot.snapshot_id,
         snapshot_type="analysis",
@@ -303,7 +304,7 @@ def _build_input_snapshot_items(
                 input_snapshot_ids=_normalize_snapshot_ids(snapshot.input_snapshot_ids),
             )
             sections = _snapshot_sections(snapshot.payload)
-            source_refs = _parse_source_refs(snapshot.source_refs)
+            source_refs = parse_source_refs(snapshot.source_refs)
             artifact_refs = [
                 ArtifactRef(
                     artifact_id=f"{snapshot.snapshot_id}:snapshot",
@@ -367,7 +368,7 @@ def _build_agent_fallback_inputs(agent_rows: list[AgentOutput]) -> list[ReportDe
                     input_snapshot_ids=_normalize_snapshot_ids(row.input_snapshot_ids),
                 ),
                 sections=sorted(input_payload.keys()) if isinstance(input_payload, dict) else [],
-                source_refs=_parse_source_refs(row.source_refs),
+                source_refs=parse_source_refs(row.source_refs),
                 artifact_refs=[],
                 payload=input_payload if isinstance(input_payload, dict) else None,
             )
@@ -408,7 +409,7 @@ def _build_report_detail_from_item(item: ReportItem, artifacts: list[ReportArtif
         run_id=item.run_id,
         snapshot_id=item.snapshot_id,
         data_status=data_status,
-        source_refs=_parse_source_refs(item.source_refs),
+        source_refs=parse_source_refs(item.source_refs),
         artifact_refs=schema_artifacts,
         warnings=warnings,
         report_id=item.report_id,
@@ -480,7 +481,7 @@ def _legacy_final_report_detail(row: FinalAnalysisResult) -> ReportDetail | None
         run_id=row.run_id,
         snapshot_id=row.snapshot_id,
         data_status=DataStatus.partial,
-        source_refs=_parse_source_refs(row.source_refs),
+        source_refs=parse_source_refs(row.source_refs),
         artifact_refs=artifacts,
         warnings=[
             WarningItem(
@@ -712,7 +713,7 @@ def _pick_legacy_analysis_artifact(artifacts: list[ReportArtifactSchema]) -> Rep
 def _to_report_artifact_schema(artifact: ReportArtifactModel) -> ReportArtifactSchema:
     return _artifact_schema(
         artifact_id=artifact.artifact_id,
-        artifact_type=_coerce_artifact_type(artifact.artifact_type, artifact.file_path),
+        artifact_type=coerce_artifact_type(artifact.artifact_type, artifact.file_path),
         file_path=artifact.file_path,
         generated_at=artifact.generated_at or artifact.updated_at or artifact.created_at,
         sha256=artifact.sha256,
@@ -764,12 +765,12 @@ def _normalize_agent_artifact_refs(raw_refs: Any, *, agent_output_id: str) -> li
     for index, item in enumerate(raw_refs, start=1):
         if isinstance(item, str):
             file_path = item
-            artifact_type = _coerce_artifact_type(None, file_path)
+            artifact_type = coerce_artifact_type(None, file_path)
         elif isinstance(item, dict):
             file_path = item.get("file_path") or item.get("artifact_path") or item.get("path")
             if not file_path:
                 continue
-            artifact_type = _coerce_artifact_type(item.get("artifact_type"), str(file_path))
+            artifact_type = coerce_artifact_type(item.get("artifact_type"), str(file_path))
         else:
             continue
         artifacts.append(
@@ -779,24 +780,7 @@ def _normalize_agent_artifact_refs(raw_refs: Any, *, agent_output_id: str) -> li
                 file_path=str(file_path),
             )
         )
-    return _dedupe_artifacts(artifacts)
-
-
-def _coerce_artifact_type(raw_type: str | None, file_path: str) -> ArtifactType:
-    if raw_type:
-        try:
-            return ArtifactType(raw_type)
-        except ValueError:
-            pass
-
-    normalized = file_path.lower()
-    if normalized.endswith("source.md") or normalized.endswith("raw_article_report.md"):
-        return ArtifactType.source_md
-    if normalized.endswith("analysis.md") or normalized.endswith("final_report.md") or normalized.endswith("agent_analysis_report.md"):
-        return ArtifactType.analysis_md
-    if normalized.endswith("visual.html") or normalized.endswith("daily_analysis.html") or normalized.endswith("options_visual_report.html"):
-        return ArtifactType.visual_html
-    return ArtifactType.structured_json
+    return dedupe_artifact_refs(artifacts)
 
 
 def _coerce_data_status(raw: str | None) -> DataStatus:
@@ -883,54 +867,6 @@ def _normalize_snapshot_ids(raw: Any) -> list[str]:
     return list(dict.fromkeys(snapshot_ids))
 
 
-def _parse_source_refs(raw: Any) -> list[SourceRef]:
-    if not isinstance(raw, list):
-        return []
-    refs: list[SourceRef] = []
-    for index, item in enumerate(raw):
-        if not isinstance(item, dict):
-            continue
-        source_name = str(item.get("source_name") or item.get("source") or item.get("source_id") or f"source-{index}")
-        source_id = str(item.get("source_id") or f"{source_name}:{index}")
-        refs.append(
-            SourceRef(
-                source_id=source_id,
-                source_name=source_name,
-                source_type=str(item.get("source_type") or item.get("type") or "unknown"),
-                data_date=item.get("data_date"),
-                endpoint=item.get("endpoint"),
-                captured_at=item.get("captured_at"),
-                file_path=item.get("file_path"),
-                sha256=item.get("sha256"),
-                url=item.get("url"),
-                status=item.get("status"),
-            )
-        )
-    return refs
-
-
-def _dedupe_sources(sources: list[SourceRef]) -> list[SourceRef]:
-    seen: set[tuple[str, str]] = set()
-    deduped: list[SourceRef] = []
-    for source in sources:
-        key = (source.source_id, source.source_type)
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(source)
-    return deduped
-
-
-def _dedupe_artifacts(artifacts: list[ArtifactRef]) -> list[ArtifactRef]:
-    seen: set[tuple[str, str]] = set()
-    deduped: list[ArtifactRef] = []
-    for artifact in artifacts:
-        key = (artifact.file_path, artifact.artifact_type.value)
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(artifact)
-    return deduped
 
 
 def _find_run_dir(base: Path, report_id: str) -> tuple[str, Path] | None:

--- a/apps/api/services/review_service.py
+++ b/apps/api/services/review_service.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from sqlalchemy.orm import Session
 
 from apps.api.schemas.review import ReviewItem as ReviewItemSchema
-from apps.api.schemas.source_trace import ArtifactRef, SourceRef
+from apps.api.schemas.source_trace import ArtifactRef
+from apps.api.services._trace_refs import coerce_artifact_type, parse_source_refs
 from database.models.analysis import ReviewItem
 from database.queries.review import (
     get_review_item,
@@ -96,7 +97,7 @@ def build_review_item_response(item: ReviewItem) -> ReviewItemSchema:
         reason=item.reason,
         impact_modules=list(item.impact_modules or []),
         impact_report_ids=[str(value) for value in (item.impact_report_ids or [])],
-        source_refs=_parse_source_refs(item.source_refs),
+        source_refs=parse_source_refs(item.source_refs),
         evidence_refs=_parse_artifact_refs(item.evidence_refs),
         suggested_action=item.suggested_action,
         status=item.status,
@@ -111,32 +112,6 @@ def build_review_item_response(item: ReviewItem) -> ReviewItemSchema:
         updated_at=item.updated_at,
         resolved_at=item.resolved_at,
     )
-
-
-def _parse_source_refs(raw: list[dict] | None) -> list[SourceRef]:
-    refs: list[SourceRef] = []
-    for index, item in enumerate(raw or []):
-        if not isinstance(item, dict):
-            continue
-        source_name = str(item.get("source_name") or item.get("source") or item.get("source_id") or f"source-{index}")
-        source_id = str(item.get("source_id") or f"{source_name}:{index}")
-        refs.append(
-            SourceRef(
-                source_id=source_id,
-                source_name=source_name,
-                source_type=str(item.get("source_type") or item.get("type") or "unknown"),
-                data_date=item.get("data_date") or item.get("report_date"),
-                endpoint=item.get("endpoint"),
-                captured_at=item.get("captured_at"),
-                file_path=item.get("file_path"),
-                sha256=item.get("sha256"),
-                url=item.get("url") or item.get("source_url"),
-                status=item.get("status"),
-            )
-        )
-    return refs
-
-
 def _parse_artifact_refs(raw: list[dict] | None) -> list[ArtifactRef]:
     refs: list[ArtifactRef] = []
     for index, item in enumerate(raw or []):
@@ -157,7 +132,7 @@ def _parse_artifact_refs(raw: list[dict] | None) -> list[ArtifactRef]:
         refs.append(
             ArtifactRef(
                 artifact_id=str(item.get("artifact_id") or f"evidence-{index + 1}"),
-                artifact_type=str(item.get("artifact_type") or _infer_artifact_type(str(file_path))),
+                artifact_type=str(item.get("artifact_type") or coerce_artifact_type(None, str(file_path))),
                 file_path=str(file_path),
                 version=item.get("version"),
                 generated_at=item.get("generated_at"),
@@ -165,12 +140,3 @@ def _parse_artifact_refs(raw: list[dict] | None) -> list[ArtifactRef]:
             )
         )
     return refs
-
-
-def _infer_artifact_type(path: str) -> str:
-    normalized = path.lower()
-    if normalized.endswith(".json"):
-        return "structured_json"
-    if normalized.endswith(".html"):
-        return "visual_html"
-    return "analysis_md"

--- a/apps/api/services/source_service.py
+++ b/apps/api/services/source_service.py
@@ -624,6 +624,77 @@ def _source_health_state(source: dict[str, Any]) -> str:
     return "unavailable"
 
 
+def _source_readiness_state(source: dict[str, Any]) -> dict[str, str]:
+    metadata = source.get("metadata") if isinstance(source.get("metadata"), dict) else {}
+    status = str(source.get("status") or "").strip().lower()
+    health_state = str(source.get("health_state") or metadata.get("health_state") or "").strip().lower()
+    configured = bool(source.get("configured"))
+    raw_ingested = bool(source.get("raw_ingested"))
+    parsed = bool(source.get("parsed"))
+    analysis_ready = bool(source.get("analysis_ready"))
+    error_message = str(source.get("error_message") or "").strip()
+
+    if not configured:
+        return {
+            "readiness_state": "not_configured",
+            "gate_state": "closed",
+            "gating_reason": "not_configured",
+        }
+
+    if error_message:
+        return {
+            "readiness_state": "blocked",
+            "gate_state": "closed",
+            "gating_reason": "error_message",
+        }
+
+    if status in {"error", "failed"}:
+        return {
+            "readiness_state": "blocked",
+            "gate_state": "closed",
+            "gating_reason": f"status_{status}",
+        }
+
+    if health_state in {"unavailable", "error", "failed"}:
+        return {
+            "readiness_state": "blocked",
+            "gate_state": "closed",
+            "gating_reason": f"health_{health_state}",
+        }
+
+    if analysis_ready and status == "ok" and health_state in {"", "healthy"}:
+        return {
+            "readiness_state": "ready",
+            "gate_state": "open",
+            "gating_reason": "analysis_ready",
+        }
+
+    if status in {"partial", "stale", "warn", "rate_limited"} or health_state in {"degraded", "cooldown"} or raw_ingested or parsed or analysis_ready:
+        if health_state == "cooldown":
+            reason = "health_cooldown"
+        elif status in {"partial", "stale", "warn", "rate_limited"}:
+            reason = f"status_{status}"
+        elif analysis_ready:
+            reason = "analysis_ready_partial"
+        elif parsed:
+            reason = "parsed_only"
+        elif raw_ingested:
+            reason = "raw_only"
+        else:
+            reason = "pipeline_incomplete"
+        return {
+            "readiness_state": "degraded",
+            "gate_state": "degraded",
+            "gating_reason": reason,
+        }
+
+    return {
+        "readiness_state": "blocked",
+        "gate_state": "closed",
+        "gating_reason": "pipeline_incomplete",
+    }
+
+
 def _source_latest_health_at(source: dict[str, Any]) -> str | None:
     metadata = source.get("metadata") if isinstance(source.get("metadata"), dict) else {}
     cooldown = metadata.get("latest_cooldown") if isinstance(metadata.get("latest_cooldown"), dict) else {}
@@ -779,6 +850,9 @@ def _augment_source_observability(source: dict[str, Any]) -> dict[str, Any]:
     health_state = _source_health_state(result)
     metadata["health_state"] = health_state
     result["health_state"] = health_state
+    readiness = _source_readiness_state(result)
+    metadata.update(readiness)
+    result.update(readiness)
     return result
 
 

--- a/apps/api/services/source_service.py
+++ b/apps/api/services/source_service.py
@@ -403,6 +403,7 @@ def _latest_news_feature_artifacts() -> dict[str, Any]:
             "artifact_path": artifact_paths.get("brief_artifact_path")
             or artifact_paths.get("impact_assessments_artifact_path")
             or artifact_paths.get("event_candidates_artifact_path"),
+            "collection_diagnostics_artifact_mtime": _path_mtime_iso(diagnostics_path) if diagnostics_path.exists() else None,
             **artifact_paths,
             **summary,
             **diagnostics,
@@ -605,6 +606,35 @@ def _latest_cooldown_metadata(source_runtime: dict[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in cooldown.items() if value not in (None, "", [])}
 
 
+def _source_health_state(source: dict[str, Any]) -> str:
+    metadata = source.get("metadata") if isinstance(source.get("metadata"), dict) else {}
+    cooldown = metadata.get("latest_cooldown") if isinstance(metadata.get("latest_cooldown"), dict) else {}
+    if cooldown.get("active"):
+        return "cooldown"
+
+    status = str(source.get("status") or "").strip().lower()
+    if status == "ok" and (source.get("analysis_ready") or source.get("parsed") or source.get("raw_ingested")):
+        return "healthy"
+    if status in {"partial", "stale", "warn", "rate_limited"}:
+        return "degraded"
+    if status in {"not_connected", "unavailable", "error", "failed"}:
+        return "unavailable"
+    if source.get("configured") or source.get("raw_ingested") or source.get("parsed"):
+        return "degraded"
+    return "unavailable"
+
+
+def _source_latest_health_at(source: dict[str, Any]) -> str | None:
+    metadata = source.get("metadata") if isinstance(source.get("metadata"), dict) else {}
+    cooldown = metadata.get("latest_cooldown") if isinstance(metadata.get("latest_cooldown"), dict) else {}
+    return _max_iso_datetime(
+        source.get("latest_update_time"),
+        metadata.get("latest_artifact_mtime"),
+        metadata.get("collection_diagnostics_artifact_mtime"),
+        cooldown.get("written_at"),
+    )
+
+
 def _load_json_artifact(path_rel: str) -> dict[str, Any]:
     path = _resolve_project_or_storage_path(path_rel)
     if path is None:
@@ -742,6 +772,13 @@ def _augment_source_observability(source: dict[str, Any]) -> dict[str, Any]:
     metadata.update(contract)
     result["metadata"] = metadata
     result["latest_update_time"] = _latest_update_time(result)
+    latest_health_at = _source_latest_health_at(result)
+    if latest_health_at:
+        metadata["latest_health_at"] = latest_health_at
+        result["latest_health_at"] = latest_health_at
+    health_state = _source_health_state(result)
+    metadata["health_state"] = health_state
+    result["health_state"] = health_state
     return result
 
 
@@ -818,22 +855,45 @@ def get_data_status_summary() -> dict[str, Any]:
     live_count = 0
     partial_count = 0
     unavailable_count = 0
-    source_list: list[dict[str, str]] = []
+    source_list: list[dict[str, Any]] = []
     missing_sources: list[str] = []
 
     for src in sources:
         status = src.get("status", "not_connected")
         source_key = src.get("source_key", "")
         label = src.get("metadata", {}).get("frontend_label") or src.get("source_name", source_key)
+        latest_health_at = src.get("latest_health_at") or src.get("metadata", {}).get("latest_health_at")
+        health_state = src.get("health_state") or src.get("metadata", {}).get("health_state") or "unavailable"
 
         if status == "ok":
-            source_list.append({"name": source_key, "status": "LIVE", "source": "api", "label": label})
+            source_list.append({
+                "name": source_key,
+                "status": "LIVE",
+                "source": "api",
+                "label": label,
+                "latest_health_at": latest_health_at,
+                "health_state": health_state,
+            })
             live_count += 1
         elif status in ("partial", "stale", "warn"):
-            source_list.append({"name": source_key, "status": "PARTIAL", "source": "api", "label": label})
+            source_list.append({
+                "name": source_key,
+                "status": "PARTIAL",
+                "source": "api",
+                "label": label,
+                "latest_health_at": latest_health_at,
+                "health_state": health_state,
+            })
             partial_count += 1
         else:
-            source_list.append({"name": source_key, "status": "UNAVAILABLE", "source": "unavailable", "label": label})
+            source_list.append({
+                "name": source_key,
+                "status": "UNAVAILABLE",
+                "source": "unavailable",
+                "label": label,
+                "latest_health_at": latest_health_at,
+                "health_state": health_state,
+            })
             unavailable_count += 1
             missing_sources.append(label)
 

--- a/apps/api/services/source_trace_service.py
+++ b/apps/api/services/source_trace_service.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 from apps.api.schemas.common import ArtifactType, DataStatus
 from apps.api.schemas.source_trace import ArtifactRef, SnapshotRef, SourceRef, SourceTraceResponse
 from apps.api.services._storage import _PROJECT_ROOT, _iso
+from apps.api.services.artifact_service import get_artifact_detail_response
 from database.models.analysis import AgentOutput, AnalysisSnapshot, FinalAnalysisResult
 
 
@@ -44,6 +45,31 @@ def get_source_trace_by_strategy_card_id(db: Session, strategy_card_id: str) -> 
         return None
     snapshot = _find_snapshot_for_final(db, final_result)
     return _build_source_trace_response(db, snapshot=snapshot, final_result=final_result)
+
+
+def get_source_trace_by_artifact_id(db: Session, artifact_id: str) -> SourceTraceResponse | None:
+    detail = get_artifact_detail_response(db, artifact_id)
+    if detail is None:
+        return None
+
+    trace = get_source_trace_by_snapshot_id(db, detail.snapshot_id) if detail.snapshot_id else None
+    if trace is None:
+        return SourceTraceResponse(
+            run_id=detail.run_id,
+            snapshot_id=detail.snapshot_id,
+            data_status=DataStatus.partial,
+            source_refs=detail.source_refs,
+            artifact_refs=detail.artifact_refs,
+            related_artifacts=detail.artifact_refs,
+        )
+
+    return trace.model_copy(
+        update={
+            "source_refs": _dedupe_sources([*trace.source_refs, *detail.source_refs]),
+            "artifact_refs": _dedupe_artifacts([*trace.artifact_refs, *detail.artifact_refs]),
+            "related_artifacts": _dedupe_artifacts([*trace.related_artifacts, *detail.artifact_refs]),
+        }
+    )
 
 
 def _find_final_for_snapshot(db: Session, snapshot: AnalysisSnapshot) -> FinalAnalysisResult | None:

--- a/apps/api/services/source_trace_service.py
+++ b/apps/api/services/source_trace_service.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 from apps.api.schemas.common import ArtifactType, DataStatus
 from apps.api.schemas.source_trace import ArtifactRef, SnapshotRef, SourceRef, SourceTraceResponse
 from apps.api.services._storage import _PROJECT_ROOT, _iso
+from apps.api.services._trace_refs import dedupe_artifact_refs, dedupe_source_refs, parse_source_refs
 from apps.api.services.artifact_service import get_artifact_detail_response
 from database.models.analysis import AgentOutput, AnalysisSnapshot, FinalAnalysisResult
 
@@ -65,9 +66,9 @@ def get_source_trace_by_artifact_id(db: Session, artifact_id: str) -> SourceTrac
 
     return trace.model_copy(
         update={
-            "source_refs": _dedupe_sources([*trace.source_refs, *detail.source_refs]),
-            "artifact_refs": _dedupe_artifacts([*trace.artifact_refs, *detail.artifact_refs]),
-            "related_artifacts": _dedupe_artifacts([*trace.related_artifacts, *detail.artifact_refs]),
+            "source_refs": dedupe_source_refs([*trace.source_refs, *detail.source_refs]),
+            "artifact_refs": dedupe_artifact_refs([*trace.artifact_refs, *detail.artifact_refs]),
+            "related_artifacts": dedupe_artifact_refs([*trace.related_artifacts, *detail.artifact_refs]),
         }
     )
 
@@ -198,21 +199,21 @@ def _build_source_trace_response(
 
     snapshot_ref = _build_snapshot_ref(snapshot, final_result=final_result, input_snapshot_ids=input_snapshot_ids)
     agent_outputs = _list_agent_outputs(db, snapshot_id)
-    source_refs = _dedupe_sources(
+    source_refs = dedupe_source_refs(
         [
-            *_parse_source_refs(snapshot.source_refs if snapshot is not None else []),
-            *_parse_source_refs(final_result.source_refs if final_result is not None else []),
+            *parse_source_refs(snapshot.source_refs if snapshot is not None else []),
+            *parse_source_refs(final_result.source_refs if final_result is not None else []),
             *[
                 source
                 for agent_output in agent_outputs
-                for source in _parse_source_refs(agent_output.source_refs)
+                for source in parse_source_refs(agent_output.source_refs)
             ],
         ]
     )
 
     snapshot_artifacts = _build_snapshot_artifacts(snapshot)
     related_artifacts = _build_final_result_artifacts(final_result)
-    artifact_refs = _dedupe_artifacts([*snapshot_artifacts, *related_artifacts])
+    artifact_refs = dedupe_artifact_refs([*snapshot_artifacts, *related_artifacts])
 
     data_status = _derive_data_status(
         snapshot=snapshot,
@@ -328,7 +329,7 @@ def _build_final_result_artifacts(final_result: FinalAnalysisResult | None) -> l
                 sha256=sha256,
             )
         )
-    return _dedupe_artifacts(refs)
+    return dedupe_artifact_refs(refs)
 
 
 def _structured_report_path(final_report_path: str | None) -> str | None:
@@ -400,33 +401,6 @@ def _list_agent_outputs(db: Session, snapshot_id: str | None) -> list[AgentOutpu
     )
 
 
-def _parse_source_refs(payload: Any) -> list[SourceRef]:
-    if not isinstance(payload, list):
-        return []
-    refs: list[SourceRef] = []
-    for index, item in enumerate(payload):
-        if not isinstance(item, dict):
-            continue
-        source_name = str(item.get("source_name") or item.get("source") or item.get("source_id") or f"source-{index}")
-        source_id = str(item.get("source_id") or f"{source_name}:{index}")
-        source_type = str(item.get("source_type") or item.get("type") or "unknown")
-        refs.append(
-            SourceRef(
-                source_id=source_id,
-                source_name=source_name,
-                source_type=source_type,
-                data_date=item.get("data_date"),
-                endpoint=item.get("endpoint"),
-                captured_at=item.get("captured_at"),
-                file_path=item.get("file_path"),
-                sha256=item.get("sha256"),
-                url=item.get("url"),
-                status=item.get("status"),
-            )
-        )
-    return refs
-
-
 def _normalize_snapshot_ids(payload: Any) -> list[str]:
     if isinstance(payload, dict):
         candidates = payload.values()
@@ -446,27 +420,3 @@ def _normalize_snapshot_ids(payload: Any) -> list[str]:
                     snapshot_ids.append(value)
                     break
     return list(dict.fromkeys(snapshot_ids))
-
-
-def _dedupe_sources(sources: list[SourceRef]) -> list[SourceRef]:
-    seen: set[tuple[str, str]] = set()
-    deduped: list[SourceRef] = []
-    for source in sources:
-        key = (source.source_id, source.source_type)
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(source)
-    return deduped
-
-
-def _dedupe_artifacts(artifacts: list[ArtifactRef]) -> list[ArtifactRef]:
-    seen: set[tuple[str, str]] = set()
-    deduped: list[ArtifactRef] = []
-    for artifact in artifacts:
-        key = (artifact.file_path, artifact.artifact_type.value)
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(artifact)
-    return deduped

--- a/apps/api/services/task_service.py
+++ b/apps/api/services/task_service.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session, selectinload
 from apps.api.schemas.common import ArtifactType, TaskStatus as ApiTaskStatus
 from apps.api.schemas.source_trace import ArtifactRef, SourceRef
 from apps.api.schemas.task_run import TaskRunResponse, TaskStepResponse
+from apps.runtime.artifact_registry import list_run_artifacts
 from database.models.engine import SessionLocal
 from database.models.task import StepStatus, TaskRun, TaskStatus, TaskStep
 
@@ -113,11 +114,13 @@ def get_task_run_artifacts(db: Session, run_id: str) -> dict[str, Any] | None:
     if run is None:
         return None
 
-    artifacts = _dedupe_artifacts(
-        artifact
-        for step in run.steps
-        for artifact in _step_artifact_refs(step)
-    )
+    artifacts = list_run_artifacts(db, run_id)
+    if not artifacts:
+        artifacts = _dedupe_artifacts(
+            artifact
+            for step in run.steps
+            for artifact in _step_artifact_refs(step)
+        )
     return {
         "run_id": str(run.id),
         "artifacts": [artifact.model_dump(mode="json") for artifact in artifacts],

--- a/apps/api/services/task_service.py
+++ b/apps/api/services/task_service.py
@@ -8,9 +8,16 @@ from typing import Any
 
 from sqlalchemy.orm import Session, selectinload
 
-from apps.api.schemas.common import ArtifactType, TaskStatus as ApiTaskStatus
-from apps.api.schemas.source_trace import ArtifactRef, SourceRef
+from apps.api.schemas.source_trace import ArtifactRef
+from apps.api.schemas.common import TaskStatus as ApiTaskStatus
 from apps.api.schemas.task_run import TaskRunResponse, TaskStepResponse
+from apps.api.services._trace_refs import (
+    artifact_ref_from_path,
+    dedupe_artifact_refs,
+    dedupe_source_refs,
+    parse_artifact_refs,
+    parse_source_refs,
+)
 from apps.runtime.artifact_registry import list_run_artifacts
 from database.models.engine import SessionLocal
 from database.models.task import StepStatus, TaskRun, TaskStatus, TaskStep
@@ -116,7 +123,7 @@ def get_task_run_artifacts(db: Session, run_id: str) -> dict[str, Any] | None:
 
     artifacts = list_run_artifacts(db, run_id)
     if not artifacts:
-        artifacts = _dedupe_artifacts(
+        artifacts = dedupe_artifact_refs(
             artifact
             for step in run.steps
             for artifact in _step_artifact_refs(step)
@@ -148,8 +155,8 @@ def build_task_run_response(run: TaskRun) -> TaskRunResponse:
         token_out=run.token_out,
         final_result_id=run.final_result_id,
         error_summary=run.error_summary or run.error,
-        source_refs=_dedupe_sources(source for step in run.steps for source in _parse_source_refs(step.source_refs)),
-        artifact_refs=_dedupe_artifacts(artifact for step in run.steps for artifact in _step_artifact_refs(step)),
+        source_refs=dedupe_source_refs(source for step in run.steps for source in parse_source_refs(step.source_refs)),
+        artifact_refs=dedupe_artifact_refs(artifact for step in run.steps for artifact in _step_artifact_refs(step)),
         steps=steps,
     )
 
@@ -164,11 +171,11 @@ def _try_parse_json(raw: str | None) -> dict | None:
 
 
 def build_task_step_response(step: TaskStep, *, run: TaskRun | None = None) -> TaskStepResponse:
-    input_refs = _parse_artifact_refs(step.input_refs)
-    output_refs = _parse_artifact_refs(step.output_refs)
-    extra_artifacts = _parse_artifact_refs(step.artifact_refs)
-    primary_output = _artifact_from_path(step.output_ref, artifact_id=f"{step.id}:output_ref") if step.output_ref else None
-    artifact_refs = _dedupe_artifacts(
+    input_refs = parse_artifact_refs(step.input_refs)
+    output_refs = parse_artifact_refs(step.output_refs)
+    extra_artifacts = parse_artifact_refs(step.artifact_refs)
+    primary_output = artifact_ref_from_path(step.output_ref, artifact_id=f"{step.id}:output_ref") if step.output_ref else None
+    artifact_refs = dedupe_artifact_refs(
         [*output_refs, *extra_artifacts, *([primary_output] if primary_output else [])]
     )
     return TaskStepResponse(
@@ -182,7 +189,7 @@ def build_task_step_response(step: TaskStep, *, run: TaskRun | None = None) -> T
         progress=_infer_step_progress(step.status),
         input_refs=input_refs,
         output_refs=output_refs,
-        source_refs=_parse_source_refs(step.source_refs),
+        source_refs=parse_source_refs(step.source_refs),
         artifact_refs=artifact_refs,
         started_at=step.started_at,
         ended_at=step.finished_at,
@@ -260,123 +267,8 @@ def _parse_json(raw: str | None) -> Any:
         return None
 
 
-def _parse_artifact_refs(raw: str | None) -> list[ArtifactRef]:
-    payload = _parse_json(raw)
-    if not isinstance(payload, list):
-        return []
-
-    artifacts: list[ArtifactRef] = []
-    for index, item in enumerate(payload):
-        if isinstance(item, dict):
-            file_path = item.get("file_path")
-            if not file_path:
-                continue
-            artifact_type = _coerce_artifact_type(item.get("artifact_type"), file_path)
-            artifacts.append(
-                ArtifactRef(
-                    artifact_id=str(item.get("artifact_id") or f"{file_path}:{index}"),
-                    artifact_type=artifact_type,
-                    file_path=file_path,
-                    version=item.get("version"),
-                    generated_at=item.get("generated_at"),
-                    sha256=item.get("sha256"),
-                )
-            )
-        elif isinstance(item, str):
-            artifacts.append(_artifact_from_path(item, artifact_id=f"{item}:{index}"))
-    return artifacts
-
-
-def _parse_source_refs(raw: str | None) -> list[SourceRef]:
-    payload = _parse_json(raw)
-    if not isinstance(payload, list):
-        return []
-
-    refs: list[SourceRef] = []
-    for index, item in enumerate(payload):
-        if not isinstance(item, dict):
-            continue
-        source_name = str(item.get("source_name") or item.get("source") or item.get("source_id") or f"source-{index}")
-        source_id = str(item.get("source_id") or f"{source_name}:{index}")
-        source_type = str(item.get("source_type") or item.get("type") or "unknown")
-        refs.append(
-            SourceRef(
-                source_id=source_id,
-                source_name=source_name,
-                source_type=source_type,
-                data_date=item.get("data_date"),
-                endpoint=item.get("endpoint"),
-                captured_at=item.get("captured_at"),
-                file_path=item.get("file_path"),
-                sha256=item.get("sha256"),
-                url=item.get("url"),
-                status=item.get("status"),
-            )
-        )
-    return refs
-
-
-def _artifact_from_path(path: str, *, artifact_id: str) -> ArtifactRef:
-    return ArtifactRef(
-        artifact_id=artifact_id,
-        artifact_type=_coerce_artifact_type(None, path),
-        file_path=path,
-    )
-
-
 def _step_artifact_refs(step: TaskStep) -> list[ArtifactRef]:
-    refs = [*_parse_artifact_refs(step.output_refs), *_parse_artifact_refs(step.artifact_refs)]
+    refs = [*parse_artifact_refs(step.output_refs), *parse_artifact_refs(step.artifact_refs)]
     if step.output_ref:
-        refs.append(_artifact_from_path(step.output_ref, artifact_id=f"{step.id}:output_ref"))
+        refs.append(artifact_ref_from_path(step.output_ref, artifact_id=f"{step.id}:output_ref"))
     return refs
-
-
-def _coerce_artifact_type(raw_type: str | None, file_path: str) -> ArtifactType:
-    if raw_type:
-        try:
-            return ArtifactType(raw_type)
-        except ValueError:
-            pass
-
-    normalized = file_path.lower()
-    if normalized.endswith("source.md"):
-        return ArtifactType.source_md
-    if normalized.endswith("analysis.md"):
-        return ArtifactType.analysis_md
-    if normalized.endswith("visual.html"):
-        return ArtifactType.visual_html
-    if normalized.endswith("report_structured.json"):
-        return ArtifactType.structured_json
-    if "/raw/" in normalized:
-        return ArtifactType.raw_file
-    if "/parsed/" in normalized:
-        return ArtifactType.parsed_file
-    if "/features/" in normalized:
-        return ArtifactType.feature_json
-    if normalized.endswith(".png") or normalized.endswith(".jpg") or normalized.endswith(".jpeg"):
-        return ArtifactType.chart_snapshot
-    return ArtifactType.structured_json
-
-
-def _dedupe_artifacts(artifacts: Iterable[ArtifactRef]) -> list[ArtifactRef]:
-    seen: set[tuple[str, str]] = set()
-    deduped: list[ArtifactRef] = []
-    for artifact in artifacts:
-        key = (artifact.file_path, artifact.artifact_type.value)
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(artifact)
-    return deduped
-
-
-def _dedupe_sources(sources: Iterable[SourceRef]) -> list[SourceRef]:
-    seen: set[tuple[str, str]] = set()
-    deduped: list[SourceRef] = []
-    for source in sources:
-        key = (source.source_id, source.source_type)
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(source)
-    return deduped

--- a/apps/api/services/task_service.py
+++ b/apps/api/services/task_service.py
@@ -6,13 +6,16 @@ from collections.abc import Iterable
 from datetime import datetime
 from typing import Any
 
+from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy.orm import Session, selectinload
 
 from apps.api.schemas.source_trace import ArtifactRef
+from apps.api.schemas.source_trace import SourceRef
 from apps.api.schemas.common import TaskStatus as ApiTaskStatus
 from apps.api.schemas.task_run import TaskRunResponse, TaskStepResponse
 from apps.api.services._trace_refs import (
     artifact_ref_from_path,
+    coerce_artifact_type,
     dedupe_artifact_refs,
     dedupe_source_refs,
     parse_artifact_refs,
@@ -20,6 +23,7 @@ from apps.api.services._trace_refs import (
 )
 from apps.runtime.artifact_registry import list_run_artifacts
 from database.models.engine import SessionLocal
+from database.models.execution import RunArtifact
 from database.models.task import StepStatus, TaskRun, TaskStatus, TaskStep
 
 
@@ -79,7 +83,7 @@ def list_task_runs(db: Session, limit: int = 20) -> list[TaskRunResponse]:
         .limit(limit)
         .all()
     )
-    return [build_task_run_response(run) for run in runs]
+    return [build_task_run_response(db, run) for run in runs]
 
 
 def get_task_run(db: Session, run_id: str) -> TaskRun | None:
@@ -99,7 +103,7 @@ def get_task_run_response(db: Session, run_id: str) -> TaskRunResponse | None:
     run = get_task_run(db, run_id)
     if run is None:
         return None
-    return build_task_run_response(run)
+    return build_task_run_response(db, run)
 
 
 def get_task_run_steps(db: Session, run_id: str) -> list[TaskStepResponse] | None:
@@ -134,8 +138,11 @@ def get_task_run_artifacts(db: Session, run_id: str) -> dict[str, Any] | None:
     }
 
 
-def build_task_run_response(run: TaskRun) -> TaskRunResponse:
+def build_task_run_response(db: Session, run: TaskRun) -> TaskRunResponse:
     steps = [build_task_step_response(step, run=run) for step in _sorted_steps(run.steps)]
+    run_artifacts = _list_run_artifact_rows(db, run.id)
+    run_artifact_refs = _run_artifact_refs(run_artifacts)
+    run_artifact_source_refs = _run_artifact_source_refs(run_artifacts)
     started_at = run.started_at or _first_non_null(step.started_at for step in run.steps)
     ended_at = run.ended_at or _last_non_null(step.finished_at for step in run.steps)
     return TaskRunResponse(
@@ -155,8 +162,18 @@ def build_task_run_response(run: TaskRun) -> TaskRunResponse:
         token_out=run.token_out,
         final_result_id=run.final_result_id,
         error_summary=run.error_summary or run.error,
-        source_refs=dedupe_source_refs(source for step in run.steps for source in parse_source_refs(step.source_refs)),
-        artifact_refs=dedupe_artifact_refs(artifact for step in run.steps for artifact in _step_artifact_refs(step)),
+        source_refs=dedupe_source_refs(
+            [
+                *run_artifact_source_refs,
+                *(source for step in run.steps for source in parse_source_refs(step.source_refs)),
+            ]
+        ),
+        artifact_refs=dedupe_artifact_refs(
+            [
+                *run_artifact_refs,
+                *(artifact for step in run.steps for artifact in _step_artifact_refs(step)),
+            ]
+        ),
         steps=steps,
     )
 
@@ -272,3 +289,32 @@ def _step_artifact_refs(step: TaskStep) -> list[ArtifactRef]:
     if step.output_ref:
         refs.append(artifact_ref_from_path(step.output_ref, artifact_id=f"{step.id}:output_ref"))
     return refs
+
+
+def _list_run_artifact_rows(db: Session, run_id: uuid.UUID) -> list[RunArtifact]:
+    try:
+        return (
+            db.query(RunArtifact)
+            .filter(RunArtifact.run_id == run_id)
+            .order_by(RunArtifact.created_at.asc(), RunArtifact.file_path.asc())
+            .all()
+        )
+    except (OperationalError, ProgrammingError, TypeError, ValueError):
+        return []
+
+
+def _run_artifact_refs(rows: list[RunArtifact]) -> list[ArtifactRef]:
+    return [
+        ArtifactRef(
+            artifact_id=str(row.artifact_id),
+            artifact_type=coerce_artifact_type(row.artifact_type, row.file_path),
+            file_path=row.file_path,
+            generated_at=row.created_at,
+            sha256=row.sha256,
+        )
+        for row in rows
+    ]
+
+
+def _run_artifact_source_refs(rows: list[RunArtifact]) -> list[SourceRef]:
+    return dedupe_source_refs(source for row in rows for source in parse_source_refs(row.source_refs))

--- a/apps/frontend-web/src/adapters/eventFlow.ts
+++ b/apps/frontend-web/src/adapters/eventFlow.ts
@@ -652,12 +652,14 @@ export async function ignoreEventFlowBrief(
 
 export async function reviewEventFlowEvent(
   eventId: string,
-  body: { review?: string },
+  body: { reason?: string; review?: string },
 ): Promise<EventFlowActionResponse> {
   return fetchJson<EventFlowActionResponse>(`/api/events/${eventId}/review`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
+    body: JSON.stringify({
+      reason: body.reason ?? body.review,
+    }),
   });
 }
 

--- a/apps/frontend-web/src/pages/EventFlowDetailPage.tsx
+++ b/apps/frontend-web/src/pages/EventFlowDetailPage.tsx
@@ -545,7 +545,7 @@ export function EventFlowDetailPage() {
     setReviewError(null);
     try {
       const response = await reviewEventFlowEvent(activeEvent.id, {
-        review: `event ${activeEvent.id} requested manual review`,
+        reason: `event ${activeEvent.id} requested manual review`,
       });
       setReviewReceipt({
         runId: response.run_id,

--- a/apps/premarket.py
+++ b/apps/premarket.py
@@ -1,9 +1,10 @@
-"""Shared premarket step ordering helpers."""
+"""Shared premarket step ordering and canonical contract helpers."""
 
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Protocol, TypeVar
+from dataclasses import dataclass
+from typing import Literal, Protocol, TypeVar
 
 PREMARKET_STEP_ORDER: tuple[str, ...] = (
     "macro_collect",
@@ -21,6 +22,143 @@ PREMARKET_STEP_ORDER: tuple[str, ...] = (
 
 _PREMARKET_STEP_INDEX = {name: idx for idx, name in enumerate(PREMARKET_STEP_ORDER)}
 
+PipelineGroup = Literal["macro", "cme", "news", "other"]
+StepStage = Literal["collect", "parse", "ingest", "feature", "output", "summary"]
+StepType = Literal["collector", "parser", "ingestor", "feature", "renderer", "summary"]
+BlockedScope = Literal["macro", "cme", "news", "none"]
+
+
+@dataclass(frozen=True, slots=True)
+class PremarketStepContract:
+    """Pure read model for one canonical premarket step."""
+
+    name: str
+    order: int
+    pipeline_group: PipelineGroup
+    stage: StepStage
+    type: StepType
+    upstream_dependencies: tuple[str, ...] = ()
+    blocked_scope: BlockedScope = "none"
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-friendly representation."""
+        return {
+            "name": self.name,
+            "order": self.order,
+            "pipeline_group": self.pipeline_group,
+            "stage": self.stage,
+            "type": self.type,
+            "upstream_dependencies": list(self.upstream_dependencies),
+            "blocked_scope": self.blocked_scope,
+        }
+
+
+_PREMARKET_STEP_CONTRACT_SPECS: dict[str, PremarketStepContract] = {
+    "macro_collect": PremarketStepContract(
+        name="macro_collect",
+        order=0,
+        pipeline_group="macro",
+        stage="collect",
+        type="collector",
+        blocked_scope="macro",
+    ),
+    "macro_feature": PremarketStepContract(
+        name="macro_feature",
+        order=1,
+        pipeline_group="macro",
+        stage="feature",
+        type="feature",
+        upstream_dependencies=("macro_collect",),
+        blocked_scope="macro",
+    ),
+    "cme_download": PremarketStepContract(
+        name="cme_download",
+        order=2,
+        pipeline_group="cme",
+        stage="collect",
+        type="collector",
+        blocked_scope="cme",
+    ),
+    "cme_parse": PremarketStepContract(
+        name="cme_parse",
+        order=3,
+        pipeline_group="cme",
+        stage="parse",
+        type="parser",
+        upstream_dependencies=("cme_download",),
+        blocked_scope="cme",
+    ),
+    "cme_ingest": PremarketStepContract(
+        name="cme_ingest",
+        order=4,
+        pipeline_group="cme",
+        stage="ingest",
+        type="ingestor",
+        upstream_dependencies=("cme_parse",),
+        blocked_scope="cme",
+    ),
+    "option_wall": PremarketStepContract(
+        name="option_wall",
+        order=5,
+        pipeline_group="cme",
+        stage="feature",
+        type="feature",
+        upstream_dependencies=("cme_ingest",),
+        blocked_scope="cme",
+    ),
+    "report_render": PremarketStepContract(
+        name="report_render",
+        order=6,
+        pipeline_group="macro",
+        stage="output",
+        type="renderer",
+        upstream_dependencies=("macro_feature",),
+        blocked_scope="macro",
+    ),
+    "news_collect": PremarketStepContract(
+        name="news_collect",
+        order=7,
+        pipeline_group="news",
+        stage="collect",
+        type="collector",
+        blocked_scope="news",
+    ),
+    "news_feature": PremarketStepContract(
+        name="news_feature",
+        order=8,
+        pipeline_group="news",
+        stage="feature",
+        type="feature",
+        upstream_dependencies=("news_collect",),
+        blocked_scope="news",
+    ),
+    "news_brief": PremarketStepContract(
+        name="news_brief",
+        order=9,
+        pipeline_group="news",
+        stage="output",
+        type="renderer",
+        upstream_dependencies=("news_feature",),
+        blocked_scope="news",
+    ),
+    "strategy_card": PremarketStepContract(
+        name="strategy_card",
+        order=10,
+        pipeline_group="other",
+        stage="summary",
+        type="summary",
+        upstream_dependencies=("report_render", "option_wall", "news_brief"),
+        blocked_scope="none",
+    ),
+}
+
+PREMARKET_STEP_CONTRACTS: tuple[PremarketStepContract, ...] = tuple(
+    _PREMARKET_STEP_CONTRACT_SPECS[name] for name in PREMARKET_STEP_ORDER
+)
+_PREMARKET_STEP_CONTRACT_BY_NAME = {
+    contract.name: contract for contract in PREMARKET_STEP_CONTRACTS
+}
+
 
 class _StepLike(Protocol):
     name: str
@@ -33,6 +171,30 @@ TStep = TypeVar("TStep", bound=_StepLike)
 def sort_premarket_steps(steps: Sequence[TStep]) -> list[TStep]:
     """Return task steps in canonical premarket execution order."""
     return sorted(steps, key=_premarket_step_sort_key)
+
+
+def get_premarket_step_contract(step_name: str) -> PremarketStepContract | None:
+    """Return the canonical read-only contract for one premarket step."""
+    return _PREMARKET_STEP_CONTRACT_BY_NAME.get(step_name)
+
+
+def get_premarket_step_contracts() -> tuple[PremarketStepContract, ...]:
+    """Return the canonical premarket step contracts in execution order."""
+    return PREMARKET_STEP_CONTRACTS
+
+
+def get_premarket_pipeline_contract() -> dict[str, object]:
+    """Return the canonical premarket DAG contract as a JSON-friendly payload."""
+    steps = [contract.to_dict() for contract in PREMARKET_STEP_CONTRACTS]
+    pipeline_groups: dict[str, list[str]] = {"macro": [], "cme": [], "news": [], "other": []}
+    for contract in PREMARKET_STEP_CONTRACTS:
+        pipeline_groups[contract.pipeline_group].append(contract.name)
+
+    return {
+        "step_order": list(PREMARKET_STEP_ORDER),
+        "steps": steps,
+        "pipeline_groups": pipeline_groups,
+    }
 
 
 def _premarket_step_sort_key(step: _StepLike) -> tuple[int, str, str]:

--- a/apps/runtime/artifact_registry.py
+++ b/apps/runtime/artifact_registry.py
@@ -8,6 +8,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from sqlalchemy import inspect
 from sqlalchemy.orm import Session
 
 from apps.api.schemas.common import ArtifactType
@@ -16,6 +17,22 @@ from database.models.execution import RunArtifact
 from database.models.task import TaskStep
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_artifacts_available(db: Session) -> bool:
+    cached = db.info.get("_run_artifacts_available")
+    if cached is not None:
+        return bool(cached)
+    try:
+        bind = db.connection()
+    except Exception:
+        return False
+    try:
+        available = inspect(bind).has_table("run_artifacts")
+    except Exception:
+        return False
+    db.info["_run_artifacts_available"] = available
+    return available
 
 
 def register_step_artifacts(
@@ -29,6 +46,8 @@ def register_step_artifacts(
     source_refs: list[dict[str, Any]] | None = None,
 ) -> list[RunArtifact]:
     """Persist additive registry rows for a step's artifacts."""
+    if not _run_artifacts_available(db):
+        return []
     persisted: list[RunArtifact] = []
     seen: set[tuple[str, str]] = set()
 
@@ -80,6 +99,8 @@ def register_step_artifacts(
 
 
 def list_run_artifacts(db: Session, run_id: str) -> list[ArtifactRef]:
+    if not _run_artifacts_available(db):
+        return []
     rows = (
         db.query(RunArtifact)
         .filter(RunArtifact.run_id == uuid.UUID(run_id))

--- a/apps/runtime/artifact_registry.py
+++ b/apps/runtime/artifact_registry.py
@@ -1,0 +1,175 @@
+"""RunArtifact registry helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from apps.api.schemas.common import ArtifactType
+from apps.api.schemas.source_trace import ArtifactRef
+from database.models.execution import RunArtifact
+from database.models.task import TaskStep
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def register_step_artifacts(
+    db: Session,
+    *,
+    run_id: str,
+    step: TaskStep,
+    output_refs: list[dict[str, Any]] | None = None,
+    artifact_refs: list[dict[str, Any]] | None = None,
+    output_ref: str | None = None,
+    source_refs: list[dict[str, Any]] | None = None,
+) -> list[RunArtifact]:
+    """Persist additive registry rows for a step's artifacts."""
+    persisted: list[RunArtifact] = []
+    seen: set[tuple[str, str]] = set()
+
+    for artifact in _collect_artifacts(
+        output_refs=output_refs,
+        artifact_refs=artifact_refs,
+        output_ref=output_ref,
+    ):
+        dedupe_key = (artifact.file_path, artifact.artifact_type)
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+
+        existing = (
+            db.query(RunArtifact)
+            .filter(
+                RunArtifact.run_id == uuid.UUID(run_id),
+                RunArtifact.task_id == step.id,
+                RunArtifact.file_path == artifact.file_path,
+                RunArtifact.artifact_type == artifact.artifact_type,
+            )
+            .first()
+        )
+        if existing is not None:
+            persisted.append(existing)
+            continue
+
+        row = RunArtifact(
+            run_id=uuid.UUID(run_id),
+            task_id=step.id,
+            artifact_type=artifact.artifact_type,
+            file_path=artifact.file_path,
+            sha256=artifact.sha256 or _maybe_sha256(artifact.file_path),
+            source_refs=json.dumps(source_refs, ensure_ascii=False) if source_refs else None,
+            metadata_json=json.dumps(
+                {
+                    "artifact_id": artifact.artifact_id,
+                    "generated_at": artifact.generated_at.isoformat() if artifact.generated_at else None,
+                },
+                ensure_ascii=False,
+            ),
+        )
+        db.add(row)
+        persisted.append(row)
+
+    if persisted:
+        db.flush()
+    return persisted
+
+
+def list_run_artifacts(db: Session, run_id: str) -> list[ArtifactRef]:
+    rows = (
+        db.query(RunArtifact)
+        .filter(RunArtifact.run_id == uuid.UUID(run_id))
+        .order_by(RunArtifact.created_at.asc(), RunArtifact.file_path.asc())
+        .all()
+    )
+    return [
+        ArtifactRef(
+            artifact_id=str(row.artifact_id),
+            artifact_type=_coerce_artifact_type(row.artifact_type, row.file_path),
+            file_path=row.file_path,
+            generated_at=row.created_at,
+            sha256=row.sha256,
+        )
+        for row in rows
+    ]
+
+
+def _collect_artifacts(
+    *,
+    output_refs: list[dict[str, Any]] | None,
+    artifact_refs: list[dict[str, Any]] | None,
+    output_ref: str | None,
+) -> list[ArtifactRef]:
+    artifacts: list[ArtifactRef] = []
+    for refs in (output_refs, artifact_refs):
+        for item in refs or []:
+            if not isinstance(item, dict):
+                continue
+            file_path = str(item.get("file_path") or "").strip()
+            if not file_path:
+                continue
+            artifacts.append(
+                ArtifactRef(
+                    artifact_id=str(item.get("artifact_id") or f"{file_path}:{len(artifacts)}"),
+                    artifact_type=_coerce_artifact_type(item.get("artifact_type"), file_path),
+                    file_path=file_path,
+                    version=item.get("version"),
+                    generated_at=item.get("generated_at"),
+                    sha256=item.get("sha256"),
+                )
+            )
+
+    if output_ref:
+        artifacts.append(
+            ArtifactRef(
+                artifact_id=f"{step_key(output_ref)}:output_ref",
+                artifact_type=_coerce_artifact_type("output_ref", output_ref),
+                file_path=output_ref,
+                sha256=_maybe_sha256(output_ref),
+            )
+        )
+    return artifacts
+
+
+def _maybe_sha256(file_path: str) -> str | None:
+    path = _PROJECT_ROOT / file_path
+    if not path.is_file():
+        return None
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _coerce_artifact_type(raw_type: str | ArtifactType | None, file_path: str) -> ArtifactType:
+    if raw_type:
+        try:
+            if str(raw_type) == "output_ref":
+                raise ValueError
+            return ArtifactType(str(raw_type))
+        except ValueError:
+            pass
+
+    normalized = file_path.lower()
+    if normalized.endswith("source.md"):
+        return ArtifactType.source_md
+    if normalized.endswith("analysis.md"):
+        return ArtifactType.analysis_md
+    if normalized.endswith("visual.html"):
+        return ArtifactType.visual_html
+    if normalized.endswith("report_structured.json"):
+        return ArtifactType.structured_json
+    if "/raw/" in normalized:
+        return ArtifactType.raw_file
+    if "/parsed/" in normalized:
+        return ArtifactType.parsed_file
+    if "/features/" in normalized:
+        return ArtifactType.feature_json
+    if normalized.endswith(".png") or normalized.endswith(".jpg") or normalized.endswith(".jpeg"):
+        return ArtifactType.chart_snapshot
+    return ArtifactType.structured_json
+
+
+def step_key(file_path: str) -> str:
+    return hashlib.sha1(file_path.encode("utf-8")).hexdigest()[:12]

--- a/apps/runtime/execution_event_bridge.py
+++ b/apps/runtime/execution_event_bridge.py
@@ -10,11 +10,28 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from sqlalchemy import inspect
 from sqlalchemy.orm import Session
 
 from apps.api.services.execution_event_service import emit_execution_event
 
 logger = logging.getLogger(__name__)
+
+
+def _execution_events_available(db: Session) -> bool:
+    cached = db.info.get("_execution_events_available")
+    if cached is not None:
+        return bool(cached)
+    try:
+        bind = db.connection()
+    except Exception:
+        return False
+    try:
+        available = inspect(bind).has_table("execution_events")
+    except Exception:
+        return False
+    db.info["_execution_events_available"] = available
+    return available
 
 
 def emit_run_event(
@@ -24,6 +41,8 @@ def emit_run_event(
     payload: dict[str, Any] | None = None,
 ) -> None:
     """Emit a run-scoped event (best-effort)."""
+    if not _execution_events_available(db):
+        return
     try:
         emit_execution_event(
             db,
@@ -44,6 +63,8 @@ def emit_task_event(
     payload: dict[str, Any] | None = None,
 ) -> None:
     """Emit a task/step-scoped event (best-effort)."""
+    if not _execution_events_available(db):
+        return
     try:
         emit_execution_event(
             db,

--- a/apps/runtime/state_machine.py
+++ b/apps/runtime/state_machine.py
@@ -165,6 +165,7 @@ def transition_task_run(
 
     if from_status != target or reason or error_message or progress is not None:
         emit_run_event(db, str(run.id), "RUN_STATUS_CHANGED", payload)
+        _emit_run_lifecycle_event(db, run, from_status=from_status, to_status=target, payload=payload)
         if target == TaskStatus.stale:
             emit_run_event(db, str(run.id), "RUN_MARKED_STALE", payload)
 
@@ -230,7 +231,100 @@ def transition_task_step(
 
     if from_status != target or reason or error_message or blocked_reason or error_type:
         emit_task_event(db, str(step.task_run_id), str(step.id), "TASK_STATUS_CHANGED", payload)
+        _emit_task_lifecycle_event(db, step, from_status=from_status, to_status=target, payload=payload)
         if target == StepStatus.blocked:
             emit_task_event(db, str(step.task_run_id), str(step.id), "TASK_BLOCKED", payload)
 
     return target
+
+
+def _emit_run_lifecycle_event(
+    db: Session,
+    run: TaskRun,
+    *,
+    from_status: TaskStatus,
+    to_status: TaskStatus,
+    payload: dict[str, object],
+) -> None:
+    lifecycle_payload = {
+        "task_name": run.name,
+        "task_type": run.task_type,
+        "trade_date": run.trade_date,
+        "workspace_id": run.workspace_id,
+        **payload,
+    }
+    if to_status == TaskStatus.running and from_status != TaskStatus.running:
+        emit_run_event(db, str(run.id), "RUN_STARTED", lifecycle_payload)
+        return
+    if to_status == TaskStatus.success and from_status != TaskStatus.success:
+        emit_run_event(
+            db,
+            str(run.id),
+            "RUN_FINISHED",
+            {"status": TaskStatus.success.value, "progress": 1.0, **lifecycle_payload},
+        )
+        return
+    if (
+        to_status in {TaskStatus.partial_success, TaskStatus.degraded, TaskStatus.blocked, TaskStatus.cancelled, TaskStatus.stale}
+        and from_status != to_status
+    ):
+        emit_run_event(
+            db,
+            str(run.id),
+            "RUN_FINISHED",
+            {"status": to_status.value, "progress": payload.get("progress"), **lifecycle_payload},
+        )
+        return
+    if to_status == TaskStatus.failed and from_status != TaskStatus.failed:
+        emit_run_event(
+            db,
+            str(run.id),
+            "RUN_FAILED",
+            {"status": TaskStatus.failed.value, "error_message": payload.get("error_message"), **lifecycle_payload},
+        )
+
+
+def _emit_task_lifecycle_event(
+    db: Session,
+    step: TaskStep,
+    *,
+    from_status: StepStatus,
+    to_status: StepStatus,
+    payload: dict[str, object],
+) -> None:
+    lifecycle_payload = {
+        "step_name": step.name,
+        "stage": step.stage,
+        "task_kind": step.task_kind,
+        "step_order": step.step_order,
+        **payload,
+    }
+    if to_status == StepStatus.running and from_status != StepStatus.running:
+        emit_task_event(db, str(step.task_run_id), str(step.id), "TASK_STARTED", lifecycle_payload)
+        return
+    if to_status == StepStatus.success and from_status != StepStatus.success:
+        emit_task_event(
+            db,
+            str(step.task_run_id),
+            str(step.id),
+            "TASK_FINISHED",
+            {"status": StepStatus.success.value, **lifecycle_payload},
+        )
+        return
+    if to_status == StepStatus.failed and from_status != StepStatus.failed:
+        emit_task_event(
+            db,
+            str(step.task_run_id),
+            str(step.id),
+            "TASK_FAILED",
+            {"error_message": payload.get("error_message"), **lifecycle_payload},
+        )
+        return
+    if to_status == StepStatus.skipped and from_status != StepStatus.skipped:
+        emit_task_event(
+            db,
+            str(step.task_run_id),
+            str(step.id),
+            "TASK_FINISHED",
+            {"status": StepStatus.skipped.value, **lifecycle_payload},
+        )

--- a/apps/runtime/state_machine.py
+++ b/apps/runtime/state_machine.py
@@ -1,0 +1,236 @@
+"""Unified execution state helpers for TaskRun / TaskStep."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable
+
+from apps.runtime.execution_event_bridge import emit_run_event, emit_task_event
+from database.models.task import StepStatus, TaskRun, TaskStatus, TaskStep
+from sqlalchemy.orm import Session
+
+ACTIVE_DAGSTER_RUN_STATUSES = frozenset({"QUEUED", "STARTING", "STARTED", "CANCELING"})
+_TERMINAL_RUN_STATUSES = {
+    TaskStatus.success,
+    TaskStatus.partial_success,
+    TaskStatus.failed,
+    TaskStatus.degraded,
+    TaskStatus.blocked,
+    TaskStatus.cancelled,
+    TaskStatus.stale,
+}
+_TERMINAL_STEP_STATUSES = {StepStatus.success, StepStatus.failed, StepStatus.skipped, StepStatus.blocked}
+
+_ALLOWED_RUN_TRANSITIONS = {
+    TaskStatus.pending: {
+        TaskStatus.running,
+        TaskStatus.success,
+        TaskStatus.failed,
+        TaskStatus.partial_success,
+        TaskStatus.degraded,
+        TaskStatus.blocked,
+        TaskStatus.cancelled,
+        TaskStatus.stale,
+    },
+    TaskStatus.running: {
+        TaskStatus.pending,
+        TaskStatus.success,
+        TaskStatus.failed,
+        TaskStatus.partial_success,
+        TaskStatus.degraded,
+        TaskStatus.blocked,
+        TaskStatus.cancelled,
+        TaskStatus.stale,
+    },
+    TaskStatus.blocked: {TaskStatus.running, TaskStatus.failed, TaskStatus.success},
+    TaskStatus.stale: {TaskStatus.running, TaskStatus.failed, TaskStatus.success},
+}
+_ALLOWED_STEP_TRANSITIONS = {
+    StepStatus.pending: {StepStatus.running, StepStatus.success, StepStatus.failed, StepStatus.skipped, StepStatus.blocked},
+    StepStatus.running: {StepStatus.success, StepStatus.failed, StepStatus.skipped, StepStatus.blocked},
+    StepStatus.blocked: {StepStatus.running, StepStatus.success, StepStatus.failed, StepStatus.skipped},
+    StepStatus.failed: {StepStatus.running},
+}
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def coerce_task_status(value: TaskStatus | str | None) -> TaskStatus:
+    if isinstance(value, TaskStatus):
+        return value
+    normalized = str(value or "").strip().lower()
+    try:
+        return TaskStatus(normalized)
+    except ValueError as exc:
+        raise ValueError(f"Unsupported task status: {value}") from exc
+
+
+def coerce_step_status(value: StepStatus | str | None) -> StepStatus:
+    if isinstance(value, StepStatus):
+        return value
+    normalized = str(value or "").strip().lower()
+    try:
+        return StepStatus(normalized)
+    except ValueError as exc:
+        raise ValueError(f"Unsupported step status: {value}") from exc
+
+
+def map_dagster_status_to_task_status(status: str | None) -> str:
+    value = str(status or "").upper()
+    if value in ACTIVE_DAGSTER_RUN_STATUSES:
+        return TaskStatus.running.value
+    if value == "SUCCESS":
+        return TaskStatus.success.value
+    if value in {"FAILURE", "CANCELED", "CANCELLED"}:
+        return TaskStatus.failed.value
+    return TaskStatus.pending.value
+
+
+def derive_task_run_status(
+    step_statuses: Iterable[StepStatus | str],
+    *,
+    has_partial_signal: bool = False,
+    has_degraded_signal: bool = False,
+) -> TaskStatus:
+    statuses = [coerce_step_status(status) for status in step_statuses]
+    if not statuses:
+        return TaskStatus.pending
+    if any(status == StepStatus.running for status in statuses):
+        return TaskStatus.running
+    if any(status == StepStatus.pending for status in statuses):
+        return TaskStatus.pending
+
+    success_like = sum(1 for status in statuses if status in {StepStatus.success, StepStatus.skipped})
+    failed = sum(1 for status in statuses if status == StepStatus.failed)
+    blocked = sum(1 for status in statuses if status == StepStatus.blocked)
+
+    if failed:
+        return TaskStatus.partial_success if success_like or blocked else TaskStatus.failed
+    if has_degraded_signal:
+        return TaskStatus.degraded
+    if has_partial_signal or (success_like and blocked):
+        return TaskStatus.partial_success
+    if blocked == len(statuses):
+        return TaskStatus.blocked
+    if success_like:
+        return TaskStatus.success
+    return TaskStatus.pending
+
+
+def transition_task_run(
+    db: Session,
+    run: TaskRun,
+    to_status: TaskStatus | str,
+    *,
+    source: str,
+    reason: str | None = None,
+    error_message: str | None = None,
+    progress: float | None = None,
+) -> TaskStatus:
+    from_status = coerce_task_status(run.status)
+    target = coerce_task_status(to_status)
+
+    if from_status != target:
+        allowed = _ALLOWED_RUN_TRANSITIONS.get(from_status)
+        if allowed is not None and target not in allowed:
+            raise ValueError(f"Invalid task run transition: {from_status.value} -> {target.value}")
+        run.status = target
+
+    if target == TaskStatus.running and run.started_at is None:
+        run.started_at = _utc_now()
+    if target in _TERMINAL_RUN_STATUSES:
+        run.ended_at = run.ended_at or _utc_now()
+    elif target == TaskStatus.running:
+        run.ended_at = None
+
+    if progress is not None:
+        run.progress = progress
+    if error_message is not None:
+        run.error = error_message
+        run.error_summary = error_message[:500]
+
+    payload = {
+        "from_status": from_status.value,
+        "to_status": target.value,
+        "source": source,
+    }
+    if reason:
+        payload["reason"] = reason
+    if error_message:
+        payload["error_message"] = error_message
+    if progress is not None:
+        payload["progress"] = progress
+
+    if from_status != target or reason or error_message or progress is not None:
+        emit_run_event(db, str(run.id), "RUN_STATUS_CHANGED", payload)
+        if target == TaskStatus.stale:
+            emit_run_event(db, str(run.id), "RUN_MARKED_STALE", payload)
+
+    return target
+
+
+def transition_task_step(
+    db: Session,
+    step: TaskStep,
+    to_status: StepStatus | str,
+    *,
+    source: str,
+    reason: str | None = None,
+    error_message: str | None = None,
+    error_type: str | None = None,
+    retryable: bool | None = None,
+    blocked_reason: str | None = None,
+) -> StepStatus:
+    from_status = coerce_step_status(step.status)
+    target = coerce_step_status(to_status)
+
+    if from_status != target:
+        allowed = _ALLOWED_STEP_TRANSITIONS.get(from_status)
+        if allowed is not None and target not in allowed:
+            raise ValueError(f"Invalid task step transition: {from_status.value} -> {target.value}")
+        step.status = target
+
+    if target == StepStatus.running and step.started_at is None:
+        step.started_at = _utc_now()
+    if target in _TERMINAL_STEP_STATUSES:
+        step.finished_at = step.finished_at or _utc_now()
+    elif target == StepStatus.running:
+        step.finished_at = None
+
+    if error_message is not None:
+        step.error = error_message
+    if error_type is not None:
+        step.error_type = error_type
+    if retryable is not None:
+        step.retryable = retryable
+    if blocked_reason is not None:
+        step.blocked_reason = blocked_reason
+
+    payload = {
+        "from_status": from_status.value,
+        "to_status": target.value,
+        "source": source,
+        "step_name": step.name,
+        "stage": step.stage,
+        "task_kind": step.task_kind,
+        "step_order": step.step_order,
+    }
+    if reason:
+        payload["reason"] = reason
+    if error_message:
+        payload["error_message"] = error_message
+    if error_type:
+        payload["error_type"] = error_type
+    if retryable is not None:
+        payload["retryable"] = retryable
+    if blocked_reason:
+        payload["blocked_reason"] = blocked_reason
+
+    if from_status != target or reason or error_message or blocked_reason or error_type:
+        emit_task_event(db, str(step.task_run_id), str(step.id), "TASK_STATUS_CHANGED", payload)
+        if target == StepStatus.blocked:
+            emit_task_event(db, str(step.task_run_id), str(step.id), "TASK_BLOCKED", payload)
+
+    return target

--- a/apps/runtime/task_recorder.py
+++ b/apps/runtime/task_recorder.py
@@ -17,7 +17,7 @@ import uuid
 from typing import Any
 
 from apps.runtime.artifact_registry import register_step_artifacts
-from apps.runtime.execution_event_bridge import emit_run_event, emit_task_event
+from apps.runtime.execution_event_bridge import emit_task_event
 from apps.runtime.state_machine import coerce_step_status, transition_task_run, transition_task_step
 from database.models.engine import SessionLocal
 from database.models.task import TaskRun, TaskStatus, TaskStep, StepStatus
@@ -80,17 +80,6 @@ class TaskRecorder:
             source="task_recorder",
             reason="run_started",
         )
-        emit_run_event(
-            self._session,
-            str(self._run_id),
-            "RUN_STARTED",
-            {
-                "task_name": self._task_name,
-                "task_type": self._task_type,
-                "trade_date": self._trade_date,
-                "workspace_id": self._workspace_id,
-            },
-        )
 
     def _succeed(self):
         if not self._run_id or not self._session:
@@ -105,15 +94,6 @@ class TaskRecorder:
                 reason="run_finished",
                 progress=1.0,
             )
-        emit_run_event(
-            self._session,
-            str(self._run_id),
-            "RUN_FINISHED",
-            {
-                "status": TaskStatus.success.value,
-                "progress": 1.0,
-            },
-        )
         self._session.commit()
 
     def _fail(self, error_message: str):
@@ -129,15 +109,6 @@ class TaskRecorder:
                 reason="run_failed",
                 error_message=error_message,
             )
-        emit_run_event(
-            self._session,
-            str(self._run_id),
-            "RUN_FAILED",
-            {
-                "status": TaskStatus.failed.value,
-                "error_message": error_message,
-            },
-        )
         self._session.commit()
 
     def step(
@@ -214,52 +185,14 @@ class TaskRecorder:
         task_id = str(step.id)
 
         if status == "running":
-            emit_task_event(
-                self._session,
-                run_id,
-                task_id,
-                "TASK_STARTED",
-                {
-                    "step_name": step.name,
-                    "stage": step.stage,
-                    "task_kind": step.task_kind,
-                    "step_order": step.step_order,
-                },
-            )
             return
 
         if status == "failed":
-            emit_task_event(
-                self._session,
-                run_id,
-                task_id,
-                "TASK_FAILED",
-                {
-                    "step_name": step.name,
-                    "stage": step.stage,
-                    "task_kind": step.task_kind,
-                    "step_order": step.step_order,
-                    "error_message": error,
-                },
-            )
             return
 
         if status != "success":
             return
 
-        emit_task_event(
-            self._session,
-            run_id,
-            task_id,
-            "TASK_FINISHED",
-            {
-                "step_name": step.name,
-                "stage": step.stage,
-                "task_kind": step.task_kind,
-                "step_order": step.step_order,
-                "status": status,
-            },
-        )
         register_step_artifacts(
             self._session,
             run_id=run_id,

--- a/apps/runtime/task_recorder.py
+++ b/apps/runtime/task_recorder.py
@@ -16,6 +16,7 @@ import json
 import uuid
 from typing import Any
 
+from apps.runtime.artifact_registry import register_step_artifacts
 from apps.runtime.execution_event_bridge import emit_run_event, emit_task_event
 from apps.runtime.state_machine import coerce_step_status, transition_task_run, transition_task_step
 from database.models.engine import SessionLocal
@@ -189,6 +190,7 @@ class TaskRecorder:
             status=status,
             error=error,
             output_refs=output_refs,
+            source_refs=source_refs,
             artifact_refs=artifact_refs,
             output_ref=output_ref,
         )
@@ -201,6 +203,7 @@ class TaskRecorder:
         status: str,
         error: str | None,
         output_refs: list[dict] | None,
+        source_refs: list[dict] | None,
         artifact_refs: list[dict] | None,
         output_ref: str | None,
     ) -> None:
@@ -256,6 +259,15 @@ class TaskRecorder:
                 "step_order": step.step_order,
                 "status": status,
             },
+        )
+        register_step_artifacts(
+            self._session,
+            run_id=run_id,
+            step=step,
+            output_refs=output_refs,
+            artifact_refs=artifact_refs,
+            output_ref=output_ref,
+            source_refs=source_refs,
         )
         for artifact_payload in self._artifact_event_payloads(
             output_refs=output_refs,

--- a/apps/runtime/task_recorder.py
+++ b/apps/runtime/task_recorder.py
@@ -14,16 +14,13 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import datetime, timezone
+from typing import Any
 
+from apps.runtime.execution_event_bridge import emit_run_event, emit_task_event
+from apps.runtime.state_machine import coerce_step_status, transition_task_run, transition_task_step
 from database.models.engine import SessionLocal
 from database.models.task import TaskRun, TaskStatus, TaskStep, StepStatus
 from sqlalchemy.orm import Session
-
-
-def utc_now() -> datetime:
-    return datetime.now(timezone.utc)
-
 
 class TaskRecorder:
     """记录一次任务运行的全生命周期到 task_runs / task_steps 表。"""
@@ -68,24 +65,54 @@ class TaskRecorder:
             name=self._task_name,
             task_type=self._task_type,
             workspace_id=self._workspace_id,
-            status=TaskStatus.running,
+            status=TaskStatus.pending,
             trade_date=self._trade_date,
-            started_at=utc_now(),
         )
         self._session.add(run)
         self._session.flush()
         self._run_id = run.id
         self._started = True
+        transition_task_run(
+            self._session,
+            run,
+            TaskStatus.running,
+            source="task_recorder",
+            reason="run_started",
+        )
+        emit_run_event(
+            self._session,
+            str(self._run_id),
+            "RUN_STARTED",
+            {
+                "task_name": self._task_name,
+                "task_type": self._task_type,
+                "trade_date": self._trade_date,
+                "workspace_id": self._workspace_id,
+            },
+        )
 
     def _succeed(self):
         if not self._run_id or not self._session:
             return
         run = self._session.get(TaskRun, self._run_id)
         if run:
-            run.status = TaskStatus.success
-            run.ended_at = utc_now()
-            if run.started_at:
-                run.progress = 1.0
+            transition_task_run(
+                self._session,
+                run,
+                TaskStatus.success,
+                source="task_recorder",
+                reason="run_finished",
+                progress=1.0,
+            )
+        emit_run_event(
+            self._session,
+            str(self._run_id),
+            "RUN_FINISHED",
+            {
+                "status": TaskStatus.success.value,
+                "progress": 1.0,
+            },
+        )
         self._session.commit()
 
     def _fail(self, error_message: str):
@@ -93,10 +120,23 @@ class TaskRecorder:
             return
         run = self._session.get(TaskRun, self._run_id)
         if run:
-            run.status = TaskStatus.failed
-            run.error = error_message
-            run.error_summary = error_message[:500]
-            run.ended_at = utc_now()
+            transition_task_run(
+                self._session,
+                run,
+                TaskStatus.failed,
+                source="task_recorder",
+                reason="run_failed",
+                error_message=error_message,
+            )
+        emit_run_event(
+            self._session,
+            str(self._run_id),
+            "RUN_FAILED",
+            {
+                "status": TaskStatus.failed.value,
+                "error_message": error_message,
+            },
+        )
         self._session.commit()
 
     def step(
@@ -116,15 +156,7 @@ class TaskRecorder:
         if not self._session or not self._run_id:
             return None
 
-        step_status = StepStatus.running
-        if status == "success":
-            step_status = StepStatus.success
-        elif status == "failed":
-            step_status = StepStatus.failed
-        elif status == "skipped":
-            step_status = StepStatus.skipped
-        elif status == "blocked":
-            step_status = StepStatus.blocked
+        step_status = coerce_step_status(status)
 
         self._step_order_counter += 1
 
@@ -133,20 +165,149 @@ class TaskRecorder:
             name=step_name,
             stage=stage,
             task_kind=task_kind,
-            status=step_status,
-            error=error,
+            status=StepStatus.pending,
             step_order=self._step_order_counter,
             input_refs=json.dumps(input_refs) if input_refs else None,
             output_refs=json.dumps(output_refs) if output_refs else None,
             source_refs=json.dumps(source_refs) if source_refs else None,
             artifact_refs=json.dumps(artifact_refs) if artifact_refs else None,
             output_ref=output_ref,
-            started_at=utc_now() if status == "running" else None,
-            finished_at=utc_now() if status in ("success", "failed", "skipped", "blocked") else None,
         )
         self._session.add(step)
         self._session.flush()
+        transition_task_step(
+            self._session,
+            step,
+            step_status,
+            source="task_recorder",
+            reason="step_recorded",
+            error_message=error if step_status == StepStatus.failed else None,
+            blocked_reason=error if step_status == StepStatus.blocked else None,
+        )
+        self._emit_step_events(
+            step=step,
+            status=status,
+            error=error,
+            output_refs=output_refs,
+            artifact_refs=artifact_refs,
+            output_ref=output_ref,
+        )
         return str(step.id)
+
+    def _emit_step_events(
+        self,
+        *,
+        step: TaskStep,
+        status: str,
+        error: str | None,
+        output_refs: list[dict] | None,
+        artifact_refs: list[dict] | None,
+        output_ref: str | None,
+    ) -> None:
+        if not self._session or not self._run_id:
+            return
+
+        run_id = str(self._run_id)
+        task_id = str(step.id)
+
+        if status == "running":
+            emit_task_event(
+                self._session,
+                run_id,
+                task_id,
+                "TASK_STARTED",
+                {
+                    "step_name": step.name,
+                    "stage": step.stage,
+                    "task_kind": step.task_kind,
+                    "step_order": step.step_order,
+                },
+            )
+            return
+
+        if status == "failed":
+            emit_task_event(
+                self._session,
+                run_id,
+                task_id,
+                "TASK_FAILED",
+                {
+                    "step_name": step.name,
+                    "stage": step.stage,
+                    "task_kind": step.task_kind,
+                    "step_order": step.step_order,
+                    "error_message": error,
+                },
+            )
+            return
+
+        if status != "success":
+            return
+
+        emit_task_event(
+            self._session,
+            run_id,
+            task_id,
+            "TASK_FINISHED",
+            {
+                "step_name": step.name,
+                "stage": step.stage,
+                "task_kind": step.task_kind,
+                "step_order": step.step_order,
+                "status": status,
+            },
+        )
+        for artifact_payload in self._artifact_event_payloads(
+            output_refs=output_refs,
+            artifact_refs=artifact_refs,
+            output_ref=output_ref,
+        ):
+            emit_task_event(
+                self._session,
+                run_id,
+                task_id,
+                "ARTIFACT_WRITTEN",
+                {
+                    "step_name": step.name,
+                    "stage": step.stage,
+                    "step_order": step.step_order,
+                    **artifact_payload,
+                },
+            )
+
+    @staticmethod
+    def _artifact_event_payloads(
+        *,
+        output_refs: list[dict[str, Any]] | None,
+        artifact_refs: list[dict[str, Any]] | None,
+        output_ref: str | None,
+    ) -> list[dict[str, Any]]:
+        payloads: list[dict[str, Any]] = []
+
+        for role, refs in (("output_refs", output_refs), ("artifact_refs", artifact_refs)):
+            for ref in refs or []:
+                if not isinstance(ref, dict):
+                    continue
+                payloads.append({"artifact_role": role, **ref})
+
+        if output_ref:
+            payloads.append(
+                {
+                    "artifact_role": "output_ref",
+                    "artifact_type": "output_ref",
+                    "file_path": output_ref,
+                }
+            )
+
+        deduped: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for payload in payloads:
+            key = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(payload)
+        return deduped
 
 
 def record_task(task_type: str, task_name: str, trade_date: str | None = None) -> TaskRecorder:

--- a/apps/worker/pipelines/daily_analysis_followup.py
+++ b/apps/worker/pipelines/daily_analysis_followup.py
@@ -11,6 +11,7 @@ from typing import Any, Callable
 
 from sqlalchemy.orm import Session, selectinload
 
+from apps.runtime.artifact_registry import register_step_artifacts
 from database.models.task import StepStatus, TaskRun, TaskStatus, TaskStep
 
 TASK_TYPE = "daily_analysis_followup"
@@ -258,6 +259,7 @@ def _run_detail_fetch_stage(
     detail_step.output_refs = _dump_json(_detail_artifact_refs(result_payload))
     detail_step.artifact_refs = detail_step.output_refs
     detail_step.source_refs = _dump_json(_merge_source_refs(detail_step.source_refs, _detail_source_ref(source_url, result_payload)))
+    _register_step_artifacts(db, run=run, step=detail_step)
     detail_step.finished_at = _now()
     detail_step.retryable = False
 
@@ -425,6 +427,7 @@ def _run_vip_browser_fallback_stage(
     fallback_step.source_refs = _dump_json(
         _merge_source_refs(fallback_step.source_refs, _vip_browser_source_ref(source_url, result_payload))
     )
+    _register_step_artifacts(db, run=run, step=fallback_step)
     fallback_step.finished_at = _now()
     fallback_step.retryable = False
 
@@ -559,6 +562,7 @@ def _run_daily_analysis_stage(
     analysis_step.artifact_refs = analysis_step.output_refs
     analysis_step.source_refs = _dump_json(snapshot["source_refs"])
     analysis_step.input_refs = _dump_json(snapshot["input_refs"])
+    _register_step_artifacts(db, run=run, step=analysis_step)
     analysis_step.finished_at = _now()
     analysis_step.retryable = False
     analysis_step.error = None
@@ -916,6 +920,18 @@ def _ensure_step(
     db.flush()
     run.steps.append(step)
     return step
+
+
+def _register_step_artifacts(db: Session, *, run: TaskRun, step: TaskStep) -> None:
+    register_step_artifacts(
+        db,
+        run_id=str(run.id),
+        step=step,
+        output_refs=_parse_json(step.output_refs) if isinstance(_parse_json(step.output_refs), list) else None,
+        artifact_refs=_parse_json(step.artifact_refs) if isinstance(_parse_json(step.artifact_refs), list) else None,
+        output_ref=step.output_ref,
+        source_refs=_parse_json(step.source_refs) if isinstance(_parse_json(step.source_refs), list) else None,
+    )
 
 
 def _build_execution_plan(*, payload: dict[str, Any], source_url: str, storage_root: Path) -> dict[str, Any]:

--- a/apps/worker/runner.py
+++ b/apps/worker/runner.py
@@ -26,6 +26,7 @@ from sqlalchemy.orm import Session as DBSession
 from apps.analysis.snapshots.builder import build_analysis_snapshot, write_analysis_snapshot
 from apps.output.artifacts import artifact_run_dir
 from apps.premarket import sort_premarket_steps
+from apps.runtime.state_machine import derive_task_run_status, transition_task_run
 from database.models.task import StepStatus, TaskRun, TaskStatus
 
 # ── C4 agent pipeline imports (deterministic, no LLM / network / file reads) ──
@@ -89,7 +90,7 @@ def run_premarket(
     if not task:
         return TaskStatus.failed
 
-    task.status = TaskStatus.running
+    transition_task_run(db, task, TaskStatus.running, source="worker", reason="worker_started")
     db.commit()
 
     # Ensure analysis DB tables exist (idempotent, additive sink)
@@ -347,14 +348,15 @@ def run_premarket(
     except Exception:
         logger.exception("Failed to write run provenance artifact")
 
-    if had_failure:
-        task.status = TaskStatus.partial_success if had_non_failed_step else TaskStatus.failed
-    elif had_partial_summary:
-        task.status = TaskStatus.partial_success
-    else:
-        task.status = TaskStatus.success
+    final_status = derive_task_run_status(
+        (step.status for step in ordered_steps),
+        has_partial_signal=had_partial_summary,
+    )
+    if had_failure and not had_non_failed_step:
+        final_status = TaskStatus.failed
+    transition_task_run(db, task, final_status, source="worker", reason="step_rollup")
     db.commit()
-    return task.status
+    return final_status
 
 
 def _classify_error_type(exc: Exception) -> str:

--- a/apps/worker/runner.py
+++ b/apps/worker/runner.py
@@ -26,6 +26,7 @@ from sqlalchemy.orm import Session as DBSession
 from apps.analysis.snapshots.builder import build_analysis_snapshot, write_analysis_snapshot
 from apps.output.artifacts import artifact_run_dir
 from apps.premarket import sort_premarket_steps
+from apps.runtime.artifact_registry import register_step_artifacts
 from apps.runtime.state_machine import derive_task_run_status, transition_task_run
 from database.models.task import StepStatus, TaskRun, TaskStatus
 
@@ -222,6 +223,8 @@ def run_premarket(
                         break
 
             summary_status = _apply_step_summary_status(step, summary)
+            if step.status in {StepStatus.success, StepStatus.skipped}:
+                _register_runner_step_artifacts(db, run_id=run_id, step=step, summary=summary)
             # ── T1.3: successful steps are not retryable ───────────
             step.retryable = False
             if summary_status == _STEP_STATUS_FAILED:
@@ -417,6 +420,28 @@ def _apply_step_summary_status(step, summary: dict[str, object] | None) -> str:
         logger.warning("Step %s returned %s", getattr(step, "name", "<unknown>"), unknown_status)
         return _STEP_STATUS_FAILED
     return status
+
+
+def _register_runner_step_artifacts(
+    db: DBSession,
+    *,
+    run_id: str,
+    step,
+    summary: dict[str, object] | None,
+) -> None:
+    if not isinstance(summary, dict) and not step.output_ref:
+        return
+    output_refs = summary.get("output_refs") if isinstance(summary, dict) else None
+    artifact_refs = summary.get("artifact_refs") if isinstance(summary, dict) else None
+    register_step_artifacts(
+        db,
+        run_id=run_id,
+        step=step,
+        output_refs=output_refs if isinstance(output_refs, list) else None,
+        artifact_refs=artifact_refs if isinstance(artifact_refs, list) else None,
+        output_ref=step.output_ref,
+        source_refs=None,
+    )
 
 
 def _persist_analysis_snapshot(

--- a/apps/worker/runner.py
+++ b/apps/worker/runner.py
@@ -316,6 +316,12 @@ def run_premarket(
                     "status": "failed",
                     "error": str(db_exc),
                 }
+            _register_c4_output_artifacts(
+                db,
+                run_id=run_id,
+                steps=ordered_steps,
+                c4_outputs=c4_outputs,
+            )
         except Exception as exc:
             logger.exception("C4 agent pipeline failed")
             had_failure = True
@@ -357,6 +363,8 @@ def run_premarket(
     )
     if had_failure and not had_non_failed_step:
         final_status = TaskStatus.failed
+    elif had_failure and final_status == TaskStatus.success:
+        final_status = TaskStatus.partial_success
     transition_task_run(db, task, final_status, source="worker", reason="step_rollup")
     db.commit()
     return final_status
@@ -440,6 +448,61 @@ def _register_runner_step_artifacts(
         output_refs=output_refs if isinstance(output_refs, list) else None,
         artifact_refs=artifact_refs if isinstance(artifact_refs, list) else None,
         output_ref=step.output_ref,
+        source_refs=None,
+    )
+
+
+def _register_c4_output_artifacts(
+    db: DBSession,
+    *,
+    run_id: str,
+    steps: list[Any],
+    c4_outputs: dict[str, Any],
+) -> None:
+    report_step = next((step for step in steps if step.name == "report_render"), None)
+    if report_step is None:
+        return
+
+    report_result = c4_outputs.get("report_result") if isinstance(c4_outputs, dict) else None
+    card_result = c4_outputs.get("card_result") if isinstance(c4_outputs, dict) else None
+
+    artifacts: list[dict[str, Any]] = []
+    if isinstance(report_result, dict):
+        report_paths = report_result.get("paths")
+        if isinstance(report_paths, list):
+            for index, path in enumerate(report_paths):
+                if not isinstance(path, str):
+                    continue
+                artifacts.append(
+                    {
+                        "artifact_id": f"{run_id}:final_report:{index}",
+                        "artifact_type": "analysis_md" if path.endswith(".md") else "structured_json",
+                        "file_path": path,
+                    }
+                )
+    if isinstance(card_result, dict):
+        card_paths = card_result.get("paths")
+        if isinstance(card_paths, list):
+            for index, path in enumerate(card_paths):
+                if not isinstance(path, str):
+                    continue
+                artifacts.append(
+                    {
+                        "artifact_id": f"{run_id}:strategy_card:{index}",
+                        "artifact_type": "analysis_md" if path.endswith(".md") else "structured_json",
+                        "file_path": path,
+                    }
+                )
+    if not artifacts:
+        return
+
+    register_step_artifacts(
+        db,
+        run_id=run_id,
+        step=report_step,
+        output_refs=artifacts,
+        artifact_refs=None,
+        output_ref=None,
         source_refs=None,
     )
 

--- a/tests/api/test_agent_analysis_api.py
+++ b/tests/api/test_agent_analysis_api.py
@@ -94,7 +94,11 @@ def test_agent_analysis_response_exposes_unified_agent_output_summary() -> None:
     assert cme_summary["role"] == "domain_agent"
     assert cme_summary["summary"] == "CME options read-only view is bullish; confidence 0.73."
     assert cme_summary["summary_zh"] == "期权结构只读视图为偏多；确信度 0.73。"
-    assert cme_summary["artifact_refs"] == ["storage/outputs/options/2026-05-31/options_report.md"]
+    assert cme_summary["artifact_refs"][0]["artifact_type"] == "analysis_md"
+    assert cme_summary["artifact_refs"][0]["file_path"] == "storage/outputs/options/2026-05-31/options_report.md"
+    assert cme_summary["artifact_refs"][0]["artifact_id"].startswith(
+        "storage/outputs/options/2026-05-31/options_report.md"
+    )
     assert cme_summary["source_refs"][0]["data_date"] == "2026-05-31"
     assert cme_summary["source_refs"][0]["url"] == "https://example.test/cme/options/2026-05-31"
     assert cme_summary["claim_count"] == 1

--- a/tests/api/test_agent_analysis_api.py
+++ b/tests/api/test_agent_analysis_api.py
@@ -133,7 +133,16 @@ def test_agent_analysis_response_includes_fact_review_agent_output() -> None:
                     "claim_id": "claim-jin10-1",
                     "text": "地缘风险抬升支撑金价风险溢价。",
                     "claim_type": "market_view",
-                    "source_refs": [{"source_id": "src-jin10", "source_name": "Jin10", "source_type": "article", "status": "available"}],
+                    "source_refs": [
+                        {
+                            "source_id": "src-jin10",
+                            "source_name": "Jin10",
+                            "source_type": "article",
+                            "status": "available",
+                            "report_date": "2026-05-31",
+                            "source_url": "https://example.test/jin10/218330",
+                        }
+                    ],
                     "evidence_refs": [{"artifact_path": "storage/outputs/jin10/2026-05-31/analysis.md"}],
                     "confidence": 0.74,
                 }
@@ -155,6 +164,9 @@ def test_agent_analysis_response_includes_fact_review_agent_output() -> None:
     assert fact_summary["fact_review_status"] == "passed"
     assert fact_summary["claim_count"] == 0
     assert fact_summary["claim_reviews"][0]["claim_id"] == "claim-jin10-1"
+    claim_source_ref = next(item for item in payload["agent_outputs"] if item["agent_name"] == "jin10_report_analysis_agent")["claims"][0]["source_refs"][0]
+    assert claim_source_ref["data_date"] == "2026-05-31"
+    assert claim_source_ref["url"] == "https://example.test/jin10/218330"
 
 
 def test_agent_analysis_synthesis_latest_returns_latest_synthesis_output() -> None:

--- a/tests/api/test_agent_analysis_api.py
+++ b/tests/api/test_agent_analysis_api.py
@@ -38,7 +38,13 @@ def test_agent_analysis_response_exposes_unified_agent_output_summary() -> None:
         bias="bullish",
         confidence=0.73,
         input_snapshot_ids={"options": "snap-options-001"},
-        source_refs=[{"source": "cme"}],
+        source_refs=[
+            {
+                "source": "cme",
+                "report_date": "2026-05-31",
+                "source_url": "https://example.test/cme/options/2026-05-31",
+            }
+        ],
         key_findings=["Gamma Zero 上移"],
         risk_points=["PRELIM 数据待终稿确认"],
         watchlist=["4500"],
@@ -89,6 +95,8 @@ def test_agent_analysis_response_exposes_unified_agent_output_summary() -> None:
     assert cme_summary["summary"] == "CME options read-only view is bullish; confidence 0.73."
     assert cme_summary["summary_zh"] == "期权结构只读视图为偏多；确信度 0.73。"
     assert cme_summary["artifact_refs"] == ["storage/outputs/options/2026-05-31/options_report.md"]
+    assert cme_summary["source_refs"][0]["data_date"] == "2026-05-31"
+    assert cme_summary["source_refs"][0]["url"] == "https://example.test/cme/options/2026-05-31"
     assert cme_summary["claim_count"] == 1
     assert cme_summary["claims"][0]["claim_id"] == "claim-cme-1"
     assert cme_summary["claims"][0]["claim_type"] == "market_view"

--- a/tests/api/test_agent_analysis_inspect_api.py
+++ b/tests/api/test_agent_analysis_inspect_api.py
@@ -207,7 +207,13 @@ def test_agent_analysis_inspection_exposes_cme_options_prompt_and_artifacts() ->
         bias="neutral",
         confidence=0.58,
         input_snapshot_ids={"options_analysis_snapshot": "options:2026-05-06:options-sample"},
-        source_refs=[{"source": "cme_daily_bulletin", "report_date": "2026-05-06"}],
+        source_refs=[
+            {
+                "source": "cme_daily_bulletin",
+                "report_date": "2026-05-06",
+                "source_url": "https://example.test/cme/2026-05-06.pdf",
+            }
+        ],
         key_findings=["Aggregate gamma zero is 4195."],
         risk_points=["PRELIM 数据可能修订。"],
         watchlist=["gamma zero", "wall scores"],
@@ -238,6 +244,8 @@ def test_agent_analysis_inspection_exposes_cme_options_prompt_and_artifacts() ->
     assert agent["registry_id"] == "cme_options_agent"
     assert agent["role"] == "domain_agent"
     assert agent["prompt"]["available"] is True
+    assert agent["input"]["source_refs"][0]["data_date"] == "2026-05-06"
+    assert agent["input"]["source_refs"][0]["url"] == "https://example.test/cme/2026-05-06.pdf"
     assert agent["input"]["payload"]["options_snapshot"]["product"] == "OG"
     assert agent["output"]["summary"] == "Gamma Zero 附近仍是短线主战区。"
     assert agent["output"]["payload"]["prompt_version"] == "cme_options_agent_v1"

--- a/tests/api/test_data_source_status_api.py
+++ b/tests/api/test_data_source_status_api.py
@@ -277,6 +277,60 @@ def test_data_service_each_source_has_four_booleans() -> None:
         assert isinstance(src[key], bool), f"{key} must be bool, got {type(src[key])}"
 
 
+def test_data_service_exposes_readiness_and_gate_states() -> None:
+    """Readiness/gating semantics are derived in the output layer only."""
+    from apps.api.data_service import get_data_source_statuses
+
+    session = _db_session()
+    _seed_source(
+        session,
+        source_key="ready_source",
+        source_name="Ready Source",
+        configured=True,
+        raw_ingested=True,
+        parsed=True,
+        analysis_ready=True,
+        status="ok",
+    )
+    _seed_source(
+        session,
+        source_key="degraded_source",
+        source_name="Degraded Source",
+        configured=True,
+        raw_ingested=True,
+        parsed=False,
+        analysis_ready=False,
+        status="partial",
+    )
+    _seed_source(
+        session,
+        source_key="blocked_source",
+        source_name="Blocked Source",
+        configured=True,
+        raw_ingested=False,
+        parsed=False,
+        analysis_ready=False,
+        status="not_connected",
+        error_message="missing api key",
+    )
+
+    with patch("apps.api.data_service._try_db_session", return_value=session):
+        result = get_data_source_statuses()
+
+    sources = _sources_by_key(result)
+    assert sources["ready_source"]["readiness_state"] == "ready"
+    assert sources["ready_source"]["gate_state"] == "open"
+    assert sources["ready_source"]["gating_reason"] == "analysis_ready"
+
+    assert sources["degraded_source"]["readiness_state"] == "degraded"
+    assert sources["degraded_source"]["gate_state"] == "degraded"
+    assert sources["degraded_source"]["gating_reason"] == "status_partial"
+
+    assert sources["blocked_source"]["readiness_state"] == "blocked"
+    assert sources["blocked_source"]["gate_state"] == "closed"
+    assert sources["blocked_source"]["gating_reason"] == "error_message"
+
+
 def test_data_service_handles_empty_db() -> None:
     """When DB is available but has no records, return compatible sources list."""
     from apps.api.data_service import get_data_source_statuses
@@ -401,6 +455,9 @@ def test_data_service_filesystem_fallback_exposes_p0_news_sources(tmp_path: Path
         if source_key == "reuters_public_news":
             assert src["metadata"]["priority_level"] == "P0.5"
             assert src["metadata"]["authorized_wire"] is False
+        assert src["readiness_state"] == "not_configured"
+        assert src["gate_state"] == "closed"
+        assert src["gating_reason"] == "not_configured"
 
 
 def test_data_service_filesystem_fallback_attaches_news_feature_artifacts(tmp_path: Path) -> None:
@@ -611,6 +668,7 @@ def test_api_route_each_source_has_required_fields() -> None:
             "analysis_ready", "latest_raw_time", "latest_parsed_time",
             "latest_snapshot_id", "row_count", "status", "error_message",
             "last_run_id", "next_run_time", "metadata",
+            "readiness_state", "gate_state", "gating_reason",
         ]
         for field in required_fields:
             assert field in src, f"Missing field: {field}"
@@ -634,6 +692,19 @@ def test_api_route_four_booleans_are_present() -> None:
         for key in ["configured", "raw_ingested", "parsed", "analysis_ready"]:
             assert key in src
             assert isinstance(src[key], bool)
+        assert src["readiness_state"] in {"ready", "degraded", "blocked", "not_configured"}
+        assert src["gate_state"] in {"open", "degraded", "closed"}
+        assert isinstance(src["gating_reason"], str)
+
+
+def test_api_route_exposes_readiness_contract_on_known_fallback_sources() -> None:
+    """Clean fallback rows expose the gating contract for frontend consumption."""
+    data = _api_status_payload()
+    sources = _sources_by_key(data)
+
+    assert sources["fred"]["readiness_state"] == "not_configured"
+    assert sources["fred"]["gate_state"] == "closed"
+    assert sources["fred"]["gating_reason"] == "not_configured"
 
 
 def test_api_route_exposes_dual_source_metadata_contract() -> None:

--- a/tests/api/test_data_source_status_api.py
+++ b/tests/api/test_data_source_status_api.py
@@ -50,6 +50,11 @@ _JIN10_MULTI_ENTRY_EXPECTATIONS = {
 def _relative_to(root: Path, path: Path) -> str:
     return path.relative_to(root).as_posix()
 
+
+def _mtime_iso(path: Path) -> str:
+    return datetime.fromtimestamp(path.stat().st_mtime).astimezone().isoformat()
+
+
 def _latest_materialized_file(base: Path) -> Path:
     files = sorted(base.glob("*/*.json"))
     assert files, f"No fixture files materialized under {base}"
@@ -489,6 +494,10 @@ def test_data_service_filesystem_fallback_attaches_news_collection_diagnostics(t
         "written_at": "2026-06-11T12:00:00+00:00",
         "reason": "HTTP 429 from https://api.gdeltproject.org/api/v2/doc/doc",
     }
+    assert fed_rss["metadata"]["latest_health_at"] == _mtime_iso(replay["feature_dir"] / "collection_diagnostics.json")
+    assert fed_rss["metadata"]["health_state"] == "healthy"
+    assert gdelt["metadata"]["latest_health_at"] == _mtime_iso(replay["feature_dir"] / "collection_diagnostics.json")
+    assert gdelt["metadata"]["health_state"] == "cooldown"
 
 
 def test_data_service_db_rows_are_augmented_with_news_feature_artifacts(tmp_path: Path) -> None:
@@ -715,6 +724,44 @@ def test_data_status_summary_marks_partial_and_lists_missing_sources() -> None:
     assert result["sources"][0]["status"] == "LIVE"
     assert result["sources"][1]["status"] == "UNAVAILABLE"
     assert result["sources"][2]["status"] == "PARTIAL"
+
+
+def test_data_status_summary_exposes_latest_health_signal() -> None:
+    """Summary read model should surface the latest health timestamp and state."""
+    payload = {
+        "sources": [
+            {
+                "source_key": "fred",
+                "source_name": "FRED",
+                "status": "ok",
+                "metadata": {
+                    "frontend_label": "FRED 官方宏观主源",
+                    "latest_health_at": "2026-06-11T12:05:00+00:00",
+                    "health_state": "healthy",
+                },
+            },
+            {
+                "source_key": "gdelt_news",
+                "source_name": "GDELT DOC News Radar",
+                "status": "not_connected",
+                "metadata": {
+                    "frontend_label": "GDELT 全球新闻雷达",
+                    "latest_health_at": "2026-06-11T12:15:00+00:00",
+                    "health_state": "cooldown",
+                },
+            },
+        ]
+    }
+
+    with patch("apps.api.services.source_service.get_data_source_statuses", return_value=payload), patch(
+        "apps.api.services.source_service._try_db_session", return_value=None
+    ):
+        result = get_data_status_summary()
+
+    assert result["sources"][0]["latest_health_at"] == "2026-06-11T12:05:00+00:00"
+    assert result["sources"][0]["health_state"] == "healthy"
+    assert result["sources"][1]["latest_health_at"] == "2026-06-11T12:15:00+00:00"
+    assert result["sources"][1]["health_state"] == "cooldown"
 
 
 def test_api_data_sources_status_http_smoke() -> None:

--- a/tests/api/test_premarket_contract.py
+++ b/tests/api/test_premarket_contract.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+from apps.api.services.pipeline_contract_service import build_premarket_pipeline_contract
+from apps.premarket import PREMARKET_STEP_ORDER, get_premarket_step_contracts
+
+client = TestClient(app)
+
+
+def test_premarket_contract_keeps_canonical_order() -> None:
+    contract = build_premarket_pipeline_contract()
+    assert contract["step_order"] == list(PREMARKET_STEP_ORDER)
+    assert [step["name"] for step in contract["steps"]] == list(PREMARKET_STEP_ORDER)
+    assert [step["order"] for step in contract["steps"]] == list(range(len(PREMARKET_STEP_ORDER)))
+
+
+def test_premarket_contract_classifies_pipeline_groups() -> None:
+    contract = build_premarket_pipeline_contract()
+    assert contract["pipeline_groups"] == {
+        "macro": ["macro_collect", "macro_feature", "report_render"],
+        "cme": ["cme_download", "cme_parse", "cme_ingest", "option_wall"],
+        "news": ["news_collect", "news_feature", "news_brief"],
+        "other": ["strategy_card"],
+    }
+
+
+def test_premarket_contract_keeps_same_pipeline_dependencies_isolated() -> None:
+    contracts = {step.name: step for step in get_premarket_step_contracts()}
+
+    same_pipeline_steps = {
+        "macro": {"macro_collect", "macro_feature", "report_render"},
+        "cme": {"cme_download", "cme_parse", "cme_ingest", "option_wall"},
+        "news": {"news_collect", "news_feature", "news_brief"},
+    }
+
+    for pipeline, step_names in same_pipeline_steps.items():
+        for step_name in step_names:
+            step = contracts[step_name]
+            assert step.pipeline_group == pipeline
+            assert step.blocked_scope == pipeline
+            assert set(step.upstream_dependencies).issubset(step_names)
+
+    strategy_card = contracts["strategy_card"]
+    assert strategy_card.pipeline_group == "other"
+    assert strategy_card.stage == "summary"
+    assert strategy_card.type == "summary"
+    assert strategy_card.blocked_scope == "none"
+    assert strategy_card.upstream_dependencies == ("report_render", "option_wall", "news_brief")
+
+
+def test_premarket_contract_api_exposes_canonical_contract() -> None:
+    resp = client.get("/api/pipelines/premarket/contract")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["step_order"] == list(PREMARKET_STEP_ORDER)
+    assert [step["name"] for step in body["steps"]] == list(PREMARKET_STEP_ORDER)
+    assert body["pipeline_groups"]["cme"] == ["cme_download", "cme_parse", "cme_ingest", "option_wall"]

--- a/tests/api/test_report_analysis_inputs_api.py
+++ b/tests/api/test_report_analysis_inputs_api.py
@@ -203,6 +203,7 @@ def test_report_analysis_inputs_returns_snapshot_and_agent_outputs(tmp_path: Pat
     assert jin10_output["llm_model"] == "qwen3-vl-plus"
     assert jin10_output["claims"][0]["claim_type"] == "market_view"
     assert jin10_output["claim_reviews"] == []
+    assert jin10_output["artifact_refs"][0]["artifact_type"] == "analysis_md"
     snapshot_input = next(item for item in payload["deterministic_inputs"] if item["input_type"] == "analysis_snapshot")
     assert snapshot_input["sections"] == ["macro", "options"]
     assert snapshot_input["snapshot"]["snapshot_id"] == "snap-std-001"

--- a/tests/api/test_run_api.py
+++ b/tests/api/test_run_api.py
@@ -217,10 +217,14 @@ def test_get_artifact_detail_returns_registry_context() -> None:
     assert payload["task_id"] == str(step.id)
     assert payload["task_name"] == "macro_collect"
     assert payload["stage"] == "collector"
+    assert payload["input_refs"][0]["artifact_id"] == "art-in-001"
+    assert payload["input_refs"][0]["artifact_type"] == "raw_file"
     assert payload["artifact"]["artifact_id"] == str(row.artifact_id)
     assert payload["artifact"]["artifact_type"] == "feature_json"
     assert payload["artifact"]["file_path"] == "storage/features/macro/rollup.json"
     assert payload["artifact_refs"][0]["artifact_id"] == str(row.artifact_id)
+    assert any(item["artifact_id"] == "art-out-001" for item in payload["artifact_refs"])
+    assert any(item["artifact_id"] == "art-visual-001" for item in payload["artifact_refs"])
     assert payload["source_refs"][0]["source_id"] == "src-registry-001"
     assert payload["metadata"]["label"] == "macro rollup"
 

--- a/tests/api/test_run_api.py
+++ b/tests/api/test_run_api.py
@@ -5,11 +5,20 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 
+import pytest
+from fastapi import HTTPException
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from apps.api.main import api_run_artifacts, api_run_detail, api_run_events, api_run_steps, api_runs
+from apps.api.main import (
+    api_artifact_detail,
+    api_run_artifacts,
+    api_run_detail,
+    api_run_events,
+    api_run_steps,
+    api_runs,
+)
 from apps.api.schemas.common import TaskStatus as ApiTaskStatus
 from apps.api.services.task_service import map_task_status_to_api
 from database.models.execution import ExecutionEvent, RunArtifact, ensure_execution_tables
@@ -168,6 +177,62 @@ def test_get_run_artifacts_prefers_registry_rows_when_present() -> None:
     assert [item["file_path"] for item in payload["artifacts"]] == ["storage/features/macro/rollup.json"]
     assert payload["artifacts"][0]["artifact_type"] == "feature_json"
     assert payload["artifacts"][0]["sha256"] == "sha-rollup-001"
+
+
+def test_get_artifact_detail_returns_registry_context() -> None:
+    session, _ = _make_session()
+    run = _seed_run(session)
+    step = session.query(TaskStep).filter(TaskStep.task_run_id == run.id).one()
+    row = RunArtifact(
+        run_id=run.id,
+        task_id=step.id,
+        artifact_type="feature_json",
+        file_path="storage/features/macro/rollup.json",
+        sha256="sha-rollup-001",
+        source_refs=json.dumps(
+            [
+                {
+                    "source_id": "src-registry-001",
+                    "source_name": "FRED",
+                    "source_type": "api",
+                    "data_date": "2026-05-26",
+                }
+            ]
+        ),
+        metadata_json=json.dumps(
+            {
+                "artifact_id": "legacy-art-001",
+                "generated_at": "2026-05-26T08:00:05+00:00",
+                "label": "macro rollup",
+            }
+        ),
+    )
+    session.add(row)
+    session.commit()
+
+    payload = api_artifact_detail(str(row.artifact_id), db=session).model_dump(mode="json")
+
+    assert payload["run_id"] == str(run.id)
+    assert payload["snapshot_id"] == "snap-001"
+    assert payload["task_id"] == str(step.id)
+    assert payload["task_name"] == "macro_collect"
+    assert payload["stage"] == "collector"
+    assert payload["artifact"]["artifact_id"] == str(row.artifact_id)
+    assert payload["artifact"]["artifact_type"] == "feature_json"
+    assert payload["artifact"]["file_path"] == "storage/features/macro/rollup.json"
+    assert payload["artifact_refs"][0]["artifact_id"] == str(row.artifact_id)
+    assert payload["source_refs"][0]["source_id"] == "src-registry-001"
+    assert payload["metadata"]["label"] == "macro rollup"
+
+
+def test_get_artifact_detail_raises_404_for_missing_registry_row() -> None:
+    session, _ = _make_session()
+
+    with pytest.raises(HTTPException) as exc_info:
+        api_artifact_detail("11111111-1111-1111-1111-111111111111", db=session)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Artifact not found"
 
 
 def test_get_run_detail_maps_public_status() -> None:

--- a/tests/api/test_run_api.py
+++ b/tests/api/test_run_api.py
@@ -250,6 +250,40 @@ def test_get_run_detail_maps_public_status() -> None:
     assert payload["current_stage"] == "analysis"
 
 
+def test_run_list_and_detail_include_registry_artifact_and_source_refs() -> None:
+    session, _ = _make_session()
+    run = _seed_run(session, status=TaskStatus.success)
+    step = session.query(TaskStep).filter(TaskStep.task_run_id == run.id).one()
+    registry_row = RunArtifact(
+        run_id=run.id,
+        task_id=step.id,
+        artifact_type="feature_json",
+        file_path="storage/features/macro/rollup.json",
+        sha256="sha-rollup-001",
+        source_refs=json.dumps(
+            [
+                {
+                    "source_id": "src-registry-001",
+                    "source_name": "FRED",
+                    "source_type": "api",
+                    "data_date": "2026-05-26",
+                }
+            ]
+        ),
+    )
+    session.add(registry_row)
+    session.commit()
+
+    detail_payload = api_run_detail(str(run.id), db=session).model_dump(mode="json")
+    list_payload = api_runs(db=session)
+
+    for payload in (detail_payload, list_payload["runs"][0]):
+        assert any(item["artifact_id"] == str(registry_row.artifact_id) for item in payload["artifact_refs"])
+        assert any(item["file_path"] == "storage/features/macro/rollup.json" for item in payload["artifact_refs"])
+        assert any(item["source_id"] == "src-registry-001" for item in payload["source_refs"])
+        assert any(item["artifact_id"] == "art-out-001" for item in payload["artifact_refs"])
+
+
 def test_get_run_events_returns_sorted_timeline() -> None:
     session, _ = _make_session()
     run = _seed_run(session, status=TaskStatus.success)

--- a/tests/api/test_run_api.py
+++ b/tests/api/test_run_api.py
@@ -225,7 +225,7 @@ def test_get_artifact_detail_returns_registry_context() -> None:
     assert payload["artifact_refs"][0]["artifact_id"] == str(row.artifact_id)
     assert any(item["artifact_id"] == "art-out-001" for item in payload["artifact_refs"])
     assert any(item["artifact_id"] == "art-visual-001" for item in payload["artifact_refs"])
-    assert payload["source_refs"][0]["source_id"] == "src-registry-001"
+    assert {item["source_id"] for item in payload["source_refs"]} == {"src-registry-001", "src-001"}
     assert payload["metadata"]["label"] == "macro rollup"
 
 

--- a/tests/api/test_run_api.py
+++ b/tests/api/test_run_api.py
@@ -12,7 +12,7 @@ from sqlalchemy.pool import StaticPool
 from apps.api.main import api_run_artifacts, api_run_detail, api_run_events, api_run_steps, api_runs
 from apps.api.schemas.common import TaskStatus as ApiTaskStatus
 from apps.api.services.task_service import map_task_status_to_api
-from database.models.execution import ExecutionEvent, ensure_execution_tables
+from database.models.execution import ExecutionEvent, RunArtifact, ensure_execution_tables
 from database.models.task import StepStatus, TaskRun, TaskStatus, TaskStep, ensure_task_tables
 
 
@@ -146,6 +146,28 @@ def test_get_run_artifacts_aggregates_output_refs_and_output_ref() -> None:
     artifact_ids = {item["artifact_id"] for item in payload["artifacts"]}
     assert {"art-out-001", "art-visual-001"} <= artifact_ids
     assert any(item["file_path"] == "storage/parsed/macro/output.json" for item in payload["artifacts"])
+
+
+def test_get_run_artifacts_prefers_registry_rows_when_present() -> None:
+    session, _ = _make_session()
+    run = _seed_run(session)
+    step = session.query(TaskStep).filter(TaskStep.task_run_id == run.id).one()
+    session.add(
+        RunArtifact(
+            run_id=run.id,
+            task_id=step.id,
+            artifact_type="feature_json",
+            file_path="storage/features/macro/rollup.json",
+            sha256="sha-rollup-001",
+        )
+    )
+    session.commit()
+
+    payload = api_run_artifacts(str(run.id), db=session)
+
+    assert [item["file_path"] for item in payload["artifacts"]] == ["storage/features/macro/rollup.json"]
+    assert payload["artifacts"][0]["artifact_type"] == "feature_json"
+    assert payload["artifacts"][0]["sha256"] == "sha-rollup-001"
 
 
 def test_get_run_detail_maps_public_status() -> None:

--- a/tests/api/test_run_api.py
+++ b/tests/api/test_run_api.py
@@ -9,9 +9,10 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from apps.api.main import api_run_artifacts, api_run_detail, api_run_steps, api_runs
+from apps.api.main import api_run_artifacts, api_run_detail, api_run_events, api_run_steps, api_runs
 from apps.api.schemas.common import TaskStatus as ApiTaskStatus
 from apps.api.services.task_service import map_task_status_to_api
+from database.models.execution import ExecutionEvent, ensure_execution_tables
 from database.models.task import StepStatus, TaskRun, TaskStatus, TaskStep, ensure_task_tables
 
 
@@ -22,6 +23,7 @@ def _make_session() -> tuple[Session, sessionmaker]:
         poolclass=StaticPool,
     )
     ensure_task_tables(engine)
+    ensure_execution_tables(engine)
     factory = sessionmaker(bind=engine, expire_on_commit=False)
     return factory(), factory
 
@@ -155,3 +157,35 @@ def test_get_run_detail_maps_public_status() -> None:
     assert payload["task_id"] == str(run.id)
     assert payload["status"] == "degraded"
     assert payload["current_stage"] == "analysis"
+
+
+def test_get_run_events_returns_sorted_timeline() -> None:
+    session, _ = _make_session()
+    run = _seed_run(session, status=TaskStatus.success)
+    step = session.query(TaskStep).filter(TaskStep.task_run_id == run.id).one()
+    session.add_all(
+        [
+            ExecutionEvent(
+                run_id=run.id,
+                task_id=None,
+                event_type="RUN_STARTED",
+                payload=json.dumps({"task_name": "agent_task"}),
+                created_at=datetime(2026, 5, 26, 8, 0, tzinfo=UTC),
+            ),
+            ExecutionEvent(
+                run_id=run.id,
+                task_id=step.id,
+                event_type="TASK_FAILED",
+                payload=json.dumps({"step_name": step.name, "error_message": "upstream blocked"}),
+                created_at=datetime(2026, 5, 26, 8, 0, 3, tzinfo=UTC),
+            ),
+        ]
+    )
+    session.commit()
+
+    payload = api_run_events(str(run.id), db=session)
+
+    assert payload["run_id"] == str(run.id)
+    assert [event["event_type"] for event in payload["events"]] == ["RUN_STARTED", "TASK_FAILED"]
+    assert payload["events"][1]["task_id"] == str(step.id)
+    assert payload["events"][1]["payload"]["error_message"] == "upstream blocked"

--- a/tests/api/test_source_trace_api.py
+++ b/tests/api/test_source_trace_api.py
@@ -8,8 +8,9 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
+from database.models.execution import RunArtifact, ensure_execution_tables
+from database.models.task import TaskRun, TaskStatus, ensure_task_tables
 from database.models.analysis import ensure_analysis_tables
-from database.models.task import ensure_task_tables
 
 
 def _make_session_factory() -> sessionmaker:
@@ -20,6 +21,7 @@ def _make_session_factory() -> sessionmaker:
     )
     ensure_analysis_tables(engine)
     ensure_task_tables(engine)
+    ensure_execution_tables(engine)
     return sessionmaker(bind=engine, expire_on_commit=False)
 
 
@@ -100,6 +102,25 @@ def _seed_final_result(session: Session, **overrides):
     return upsert_final_analysis_result(session, payload=payload, paths=paths)
 
 
+def _seed_task_run(session: Session, **overrides) -> TaskRun:
+    run = TaskRun(
+        name="premarket",
+        task_type="premarket",
+        workspace_id="workspace-001",
+        status=TaskStatus.success,
+        current_stage="analysis",
+        progress=1.0,
+        snapshot_id="snap-001",
+        final_result_id="run-001",
+        trade_date="2026-05-26",
+    )
+    for key, value in overrides.items():
+        setattr(run, key, value)
+    session.add(run)
+    session.flush()
+    return run
+
+
 def test_get_source_trace_by_snapshot_returns_snapshot_and_refs() -> None:
     from apps.api.main import api_source_trace_detail
 
@@ -159,8 +180,38 @@ def test_get_source_trace_by_strategy_resolves_run_trace() -> None:
     assert payload["snapshot"]["snapshot_id"] == "snap-001"
 
 
+def test_get_source_trace_by_artifact_bridges_registry_artifact_to_snapshot_trace() -> None:
+    from apps.api.main import api_source_trace_by_artifact
+
+    factory = _make_session_factory()
+    with factory() as session:
+        _seed_snapshot(session)
+        _seed_final_result(session)
+        run = _seed_task_run(session)
+        session.add(
+            RunArtifact(
+                run_id=run.id,
+                task_id=None,
+                artifact_type="feature_json",
+                file_path="storage/features/macro/2026-05-26/run-001/rollup.json",
+                sha256="sha-rollup-001",
+            )
+        )
+        session.commit()
+        artifact_id = str(session.query(RunArtifact).one().artifact_id)
+
+    with factory() as db:
+        payload = api_source_trace_by_artifact(artifact_id, db=db).model_dump(mode="json")
+
+    assert payload["run_id"] == "run-001"
+    assert payload["snapshot_id"] == "snap-001"
+    artifact_paths = {item["file_path"] for item in payload["artifact_refs"]}
+    assert "storage/features/macro/2026-05-26/run-001/rollup.json" in artifact_paths
+    assert payload["source_refs"][0]["source_id"] == "src-cme-001"
+
+
 def test_source_trace_missing_snapshot_and_report_return_404() -> None:
-    from apps.api.main import api_source_trace_by_report, api_source_trace_detail
+    from apps.api.main import api_source_trace_by_artifact, api_source_trace_by_report, api_source_trace_detail
 
     factory = _make_session_factory()
     with factory() as db:
@@ -169,8 +220,13 @@ def test_source_trace_missing_snapshot_and_report_return_404() -> None:
     with factory() as db:
         with pytest.raises(HTTPException) as report_exc:
             api_source_trace_by_report("missing-report", db=db)
+    with factory() as db:
+        with pytest.raises(HTTPException) as artifact_exc:
+            api_source_trace_by_artifact("11111111-1111-1111-1111-111111111111", db=db)
 
     assert snapshot_exc.value.status_code == 404
     assert snapshot_exc.value.detail == "Source trace not found"
     assert report_exc.value.status_code == 404
     assert report_exc.value.detail == "Source trace not found"
+    assert artifact_exc.value.status_code == 404
+    assert artifact_exc.value.detail == "Source trace not found"

--- a/tests/api/test_source_trace_api.py
+++ b/tests/api/test_source_trace_api.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 from fastapi import HTTPException
 from sqlalchemy import create_engine
@@ -9,7 +11,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from database.models.execution import RunArtifact, ensure_execution_tables
-from database.models.task import TaskRun, TaskStatus, ensure_task_tables
+from database.models.task import StepStatus, TaskRun, TaskStatus, TaskStep, ensure_task_tables
 from database.models.analysis import ensure_analysis_tables
 
 
@@ -188,13 +190,40 @@ def test_get_source_trace_by_artifact_bridges_registry_artifact_to_snapshot_trac
         _seed_snapshot(session)
         _seed_final_result(session)
         run = _seed_task_run(session)
+        step = TaskStep(
+            task_run_id=run.id,
+            name="macro_collect",
+            stage="collector",
+            task_kind="collector",
+            status=StepStatus.success,
+            source_refs=json.dumps(
+                [
+                    {
+                        "source_id": "src-001",
+                        "source_name": "FRED",
+                        "source_type": "api",
+                    }
+                ]
+            ),
+        )
+        session.add(step)
+        session.flush()
         session.add(
             RunArtifact(
                 run_id=run.id,
-                task_id=None,
+                task_id=step.id,
                 artifact_type="feature_json",
                 file_path="storage/features/macro/2026-05-26/run-001/rollup.json",
                 sha256="sha-rollup-001",
+                source_refs=json.dumps(
+                    [
+                        {
+                            "source_id": "src-registry-001",
+                            "source_name": "FRED",
+                            "source_type": "api",
+                        }
+                    ]
+                ),
             )
         )
         session.commit()
@@ -207,7 +236,12 @@ def test_get_source_trace_by_artifact_bridges_registry_artifact_to_snapshot_trac
     assert payload["snapshot_id"] == "snap-001"
     artifact_paths = {item["file_path"] for item in payload["artifact_refs"]}
     assert "storage/features/macro/2026-05-26/run-001/rollup.json" in artifact_paths
-    assert payload["source_refs"][0]["source_id"] == "src-cme-001"
+    assert {item["source_id"] for item in payload["source_refs"]} == {
+        "src-cme-001",
+        "src-final-001",
+        "src-registry-001",
+        "src-001",
+    }
 
 
 def test_source_trace_missing_snapshot_and_report_return_404() -> None:

--- a/tests/api/test_trace_ref_helpers.py
+++ b/tests/api/test_trace_ref_helpers.py
@@ -67,3 +67,21 @@ def test_parse_source_refs_and_dedupe_support_json_and_python_lists() -> None:
 
     assert [item.source_id for item in deduped] == ["src-001", "src-002"]
 
+
+def test_artifact_ref_from_path_supports_report_alias_filenames() -> None:
+    source_ref = artifact_ref_from_path(
+        "storage/outputs/jin10/2026-05-31/220787/raw_article_report.md",
+        artifact_id="report:source",
+    )
+    analysis_ref = artifact_ref_from_path(
+        "storage/outputs/final_report/XAUUSD/2026-05-26/run-001/final_report.md",
+        artifact_id="report:analysis",
+    )
+    visual_ref = artifact_ref_from_path(
+        "storage/outputs/jin10/2026-05-31/220787/daily_analysis.html",
+        artifact_id="report:visual",
+    )
+
+    assert source_ref.artifact_type == ArtifactType.source_md
+    assert analysis_ref.artifact_type == ArtifactType.analysis_md
+    assert visual_ref.artifact_type == ArtifactType.visual_html

--- a/tests/api/test_trace_ref_helpers.py
+++ b/tests/api/test_trace_ref_helpers.py
@@ -94,6 +94,10 @@ def test_artifact_ref_from_path_supports_report_alias_filenames() -> None:
         "storage/outputs/final_report/XAUUSD/2026-05-26/run-001/final_report.md",
         artifact_id="report:analysis",
     )
+    options_ref = artifact_ref_from_path(
+        "storage/outputs/cme/2026-05-26/run-001/options_analysis_agent_report.md",
+        artifact_id="report:options",
+    )
     visual_ref = artifact_ref_from_path(
         "storage/outputs/jin10/2026-05-31/220787/daily_analysis.html",
         artifact_id="report:visual",
@@ -101,4 +105,5 @@ def test_artifact_ref_from_path_supports_report_alias_filenames() -> None:
 
     assert source_ref.artifact_type == ArtifactType.source_md
     assert analysis_ref.artifact_type == ArtifactType.analysis_md
+    assert options_ref.artifact_type == ArtifactType.analysis_md
     assert visual_ref.artifact_type == ArtifactType.visual_html

--- a/tests/api/test_trace_ref_helpers.py
+++ b/tests/api/test_trace_ref_helpers.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+
+from apps.api.schemas.common import ArtifactType
+from apps.api.services._trace_refs import (
+    artifact_ref_from_path,
+    dedupe_artifact_refs,
+    dedupe_source_refs,
+    parse_artifact_refs,
+    parse_source_refs,
+)
+
+
+def test_parse_artifact_refs_and_dedupe_support_json_strings_and_path_refs() -> None:
+    parsed = parse_artifact_refs(
+        json.dumps(
+            [
+                {
+                    "artifact_id": "art-001",
+                    "artifact_type": "parsed_file",
+                    "file_path": "storage/parsed/macro/output.json",
+                },
+                "storage/parsed/macro/output.json",
+                {
+                    "artifact_id": "art-visual-001",
+                    "artifact_type": "visual_html",
+                    "file_path": "storage/outputs/reports/2026-05-26/run-001/visual.html",
+                },
+            ]
+        )
+    )
+
+    deduped = dedupe_artifact_refs(
+        [
+            *parsed,
+            artifact_ref_from_path(
+                "storage/parsed/macro/output.json",
+                artifact_id="step-001:output_ref",
+            ),
+        ]
+    )
+
+    assert [item.artifact_type for item in deduped] == [
+        ArtifactType.parsed_file,
+        ArtifactType.visual_html,
+    ]
+    assert deduped[0].artifact_id == "art-001"
+
+
+def test_parse_source_refs_and_dedupe_support_json_and_python_lists() -> None:
+    from_json = parse_source_refs(
+        json.dumps(
+            [
+                {"source_id": "src-001", "source_name": "FRED", "source_type": "api"},
+                {"source_id": "src-001", "source_name": "FRED", "source_type": "api"},
+            ]
+        )
+    )
+    from_list = parse_source_refs(
+        [
+            {"source_id": "src-002", "source_name": "CME", "source_type": "pdf"},
+        ]
+    )
+
+    deduped = dedupe_source_refs([*from_json, *from_list])
+
+    assert [item.source_id for item in deduped] == ["src-001", "src-002"]
+

--- a/tests/api/test_trace_ref_helpers.py
+++ b/tests/api/test_trace_ref_helpers.py
@@ -68,6 +68,23 @@ def test_parse_source_refs_and_dedupe_support_json_and_python_lists() -> None:
     assert [item.source_id for item in deduped] == ["src-001", "src-002"]
 
 
+def test_parse_source_refs_supports_report_date_and_source_url_aliases() -> None:
+    parsed = parse_source_refs(
+        [
+            {
+                "source_id": "src-review-001",
+                "source_name": "CME",
+                "source_type": "pdf",
+                "report_date": "2026-05-06",
+                "source_url": "https://example.test/cme.pdf",
+            }
+        ]
+    )
+
+    assert parsed[0].data_date == "2026-05-06"
+    assert parsed[0].url == "https://example.test/cme.pdf"
+
+
 def test_artifact_ref_from_path_supports_report_alias_filenames() -> None:
     source_ref = artifact_ref_from_path(
         "storage/outputs/jin10/2026-05-31/220787/raw_article_report.md",

--- a/tests/runtime/test_state_machine.py
+++ b/tests/runtime/test_state_machine.py
@@ -75,7 +75,51 @@ def test_transition_helpers_emit_execution_events() -> None:
     events = session.query(ExecutionEvent).order_by(ExecutionEvent.created_at.asc()).all()
     event_types = [event.event_type for event in events]
 
+    assert "RUN_STARTED" in event_types
     assert "RUN_STATUS_CHANGED" in event_types
     assert "TASK_STATUS_CHANGED" in event_types
     assert "TASK_BLOCKED" in event_types
+    assert "RUN_FINISHED" in event_types
     assert "RUN_MARKED_STALE" in event_types
+
+
+def test_transition_helpers_emit_run_and_step_lifecycle_events() -> None:
+    session = _make_session()
+    run = TaskRun(name="premarket", status=TaskStatus.pending)
+    session.add(run)
+    session.flush()
+    step = TaskStep(task_run_id=run.id, name="collect_macro", status=StepStatus.pending, step_order=0)
+    session.add(step)
+    session.flush()
+
+    transition_task_run(session, run, TaskStatus.running, source="worker", reason="worker_started")
+    transition_task_step(session, step, StepStatus.running, source="worker", reason="step_started")
+    transition_task_step(session, step, StepStatus.success, source="worker", reason="step_finished")
+    transition_task_run(session, run, TaskStatus.success, source="worker", reason="worker_finished")
+    session.commit()
+
+    events = session.query(ExecutionEvent).order_by(ExecutionEvent.created_at.asc()).all()
+    event_types = [event.event_type for event in events]
+
+    assert "RUN_STARTED" in event_types
+    assert "TASK_STARTED" in event_types
+    assert "TASK_FINISHED" in event_types
+    assert "RUN_FINISHED" in event_types
+
+
+def test_transition_helpers_do_not_repeat_terminal_lifecycle_events_for_reason_only_update() -> None:
+    session = _make_session()
+    run = TaskRun(name="premarket", status=TaskStatus.pending)
+    session.add(run)
+    session.flush()
+
+    transition_task_run(session, run, TaskStatus.stale, source="scheduler", reason="timeout")
+    transition_task_run(session, run, TaskStatus.stale, source="api", reason="operator_ack")
+    session.commit()
+
+    events = session.query(ExecutionEvent).order_by(ExecutionEvent.created_at.asc()).all()
+    event_types = [event.event_type for event in events]
+
+    assert event_types.count("RUN_STATUS_CHANGED") == 2
+    assert event_types.count("RUN_FINISHED") == 1
+    assert event_types.count("RUN_MARKED_STALE") == 2

--- a/tests/runtime/test_state_machine.py
+++ b/tests/runtime/test_state_machine.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from apps.runtime.state_machine import (
+    ACTIVE_DAGSTER_RUN_STATUSES,
+    derive_task_run_status,
+    map_dagster_status_to_task_status,
+    transition_task_run,
+    transition_task_step,
+)
+from database.models.execution import ExecutionEvent, ensure_execution_tables
+from database.models.task import StepStatus, TaskRun, TaskStatus, TaskStep, ensure_task_tables
+
+
+def _make_session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    ensure_task_tables(engine)
+    ensure_execution_tables(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+    return factory()
+
+
+def test_map_dagster_status_to_task_status_uses_shared_active_set() -> None:
+    for status in ACTIVE_DAGSTER_RUN_STATUSES:
+        assert map_dagster_status_to_task_status(status) == TaskStatus.running.value
+    assert map_dagster_status_to_task_status("SUCCESS") == TaskStatus.success.value
+    assert map_dagster_status_to_task_status("FAILURE") == TaskStatus.failed.value
+    assert map_dagster_status_to_task_status("OTHER") == TaskStatus.pending.value
+
+
+def test_derive_task_run_status_handles_partial_and_blocked_rollups() -> None:
+    assert derive_task_run_status([StepStatus.success, StepStatus.failed]) == TaskStatus.partial_success
+    assert derive_task_run_status([StepStatus.blocked, StepStatus.blocked]) == TaskStatus.blocked
+    assert derive_task_run_status([StepStatus.success, StepStatus.success], has_partial_signal=True) == (
+        TaskStatus.partial_success
+    )
+
+
+def test_transition_helpers_emit_execution_events() -> None:
+    session = _make_session()
+    run = TaskRun(name="premarket", status=TaskStatus.pending)
+    session.add(run)
+    session.flush()
+    step = TaskStep(task_run_id=run.id, name="collect_macro", status=StepStatus.pending, step_order=0)
+    session.add(step)
+    session.flush()
+
+    transition_task_run(session, run, TaskStatus.running, source="worker", reason="worker_started")
+    transition_task_step(
+        session,
+        step,
+        StepStatus.blocked,
+        source="worker",
+        reason="upstream_failed",
+        blocked_reason="macro source unavailable",
+        retryable=False,
+    )
+    transition_task_run(
+        session,
+        run,
+        TaskStatus.stale,
+        source="api",
+        reason="active_timeout_exceeded",
+        error_message="run timed out",
+    )
+    session.commit()
+
+    events = session.query(ExecutionEvent).order_by(ExecutionEvent.created_at.asc()).all()
+    event_types = [event.event_type for event in events]
+
+    assert "RUN_STATUS_CHANGED" in event_types
+    assert "TASK_STATUS_CHANGED" in event_types
+    assert "TASK_BLOCKED" in event_types
+    assert "RUN_MARKED_STALE" in event_types

--- a/tests/runtime/test_task_recorder_execution_events.py
+++ b/tests/runtime/test_task_recorder_execution_events.py
@@ -6,7 +6,7 @@ from sqlalchemy.pool import StaticPool
 
 from apps.runtime import task_recorder as task_recorder_module
 from apps.runtime.task_recorder import TaskRecorder
-from database.models.execution import ExecutionEvent, ensure_execution_tables
+from database.models.execution import ExecutionEvent, RunArtifact, ensure_execution_tables
 from database.models.task import ensure_task_tables
 
 
@@ -44,6 +44,7 @@ def test_task_recorder_emits_run_and_artifact_events(monkeypatch) -> None:
 
     with factory() as session:
         events = session.query(ExecutionEvent).order_by(ExecutionEvent.created_at.asc()).all()
+        artifacts = session.query(RunArtifact).order_by(RunArtifact.created_at.asc()).all()
 
     event_types = [event.event_type for event in events]
     assert "RUN_STARTED" in event_types
@@ -53,6 +54,8 @@ def test_task_recorder_emits_run_and_artifact_events(monkeypatch) -> None:
     assert "TASK_FINISHED" in event_types
     assert "ARTIFACT_WRITTEN" in event_types
     assert event_types[-1] == "RUN_FINISHED"
+    assert [artifact.file_path for artifact in artifacts] == ["storage/raw/macro/fred.json"]
+    assert artifacts[0].artifact_type == "raw_file"
 
 
 def test_task_recorder_emits_failed_event(monkeypatch) -> None:

--- a/tests/runtime/test_task_recorder_execution_events.py
+++ b/tests/runtime/test_task_recorder_execution_events.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from apps.runtime import task_recorder as task_recorder_module
+from apps.runtime.task_recorder import TaskRecorder
+from database.models.execution import ExecutionEvent, ensure_execution_tables
+from database.models.task import ensure_task_tables
+
+
+def _make_factory():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    ensure_task_tables(engine)
+    ensure_execution_tables(engine)
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def test_task_recorder_emits_run_and_artifact_events(monkeypatch) -> None:
+    factory = _make_factory()
+    monkeypatch.setattr(task_recorder_module, "SessionLocal", factory)
+
+    with TaskRecorder(task_type="macro_collect", task_name="FRED 采集", trade_date="2026-06-18") as rec:
+        rec.step("collect_fred", status="running", stage="collector", task_kind="collector")
+        rec.step(
+            "collect_fred",
+            status="success",
+            stage="collector",
+            task_kind="collector",
+            output_refs=[
+                {
+                    "artifact_id": "art-001",
+                    "artifact_type": "raw_file",
+                    "file_path": "storage/raw/macro/fred.json",
+                }
+            ],
+            output_ref="storage/raw/macro/fred.json",
+        )
+
+    with factory() as session:
+        events = session.query(ExecutionEvent).order_by(ExecutionEvent.created_at.asc()).all()
+
+    event_types = [event.event_type for event in events]
+    assert "RUN_STARTED" in event_types
+    assert "RUN_STATUS_CHANGED" in event_types
+    assert "TASK_STARTED" in event_types
+    assert "TASK_STATUS_CHANGED" in event_types
+    assert "TASK_FINISHED" in event_types
+    assert "ARTIFACT_WRITTEN" in event_types
+    assert event_types[-1] == "RUN_FINISHED"
+
+
+def test_task_recorder_emits_failed_event(monkeypatch) -> None:
+    factory = _make_factory()
+    monkeypatch.setattr(task_recorder_module, "SessionLocal", factory)
+
+    try:
+        with TaskRecorder(task_type="macro_collect", task_name="FRED 采集") as rec:
+            rec.step("collect_fred", status="running", stage="collector")
+            raise RuntimeError("collector exploded")
+    except RuntimeError:
+        pass
+
+    with factory() as session:
+        events = session.query(ExecutionEvent).order_by(ExecutionEvent.created_at.asc()).all()
+
+    event_types = [event.event_type for event in events]
+    assert "TASK_STARTED" in event_types
+    assert "TASK_STATUS_CHANGED" in event_types
+    assert "RUN_FAILED" in event_types

--- a/tests/worker/test_cme_pipeline.py
+++ b/tests/worker/test_cme_pipeline.py
@@ -31,6 +31,7 @@ from apps.worker.pipelines.cme import (
     CmePipelineState,
     run_cme_step,
 )
+from database.models.execution import RunArtifact, ensure_execution_tables
 from database.models.task import Base, StepStatus, TaskRun, TaskStatus, TaskStep
 from database.queries.cme import ensure_cme_tables
 
@@ -869,6 +870,28 @@ class TestRunPremarket:
         assert task.status == TaskStatus.failed
         assert task.steps[0].status == StepStatus.failed
         assert task.steps[0].error == "Unknown pipeline summary status: mystery"
+
+    def test_runner_persists_output_ref_into_run_artifact_registry_when_table_exists(self, tmp_path):
+        db = _make_db_session(tmp_path)
+        ensure_execution_tables(db)
+        task = self._make_task_with_steps(db, ["cme_download"])
+
+        def mock_run_cme_step(step_name, state, **kwargs):
+            return {
+                "step": step_name,
+                "status": "success",
+                "raw_path": "storage/raw/cme/daily_bulletin.pdf",
+            }
+
+        with patch("apps.worker.pipelines.cme.run_cme_step", side_effect=mock_run_cme_step):
+            from apps.worker.runner import run_premarket
+
+            result = run_premarket(db, task.id, storage_root=tmp_path)
+
+        assert result == TaskStatus.success
+        artifacts = db.query(RunArtifact).filter(RunArtifact.run_id == task.id).all()
+        assert [artifact.file_path for artifact in artifacts] == ["storage/raw/cme/daily_bulletin.pdf"]
+        assert artifacts[0].artifact_type == "raw_file"
 
     def test_task_not_found_returns_failed(self, tmp_path):
         """Test that a non-existent task_id returns TaskStatus.failed."""

--- a/tests/worker/test_daily_analysis_followup_pipeline.py
+++ b/tests/worker/test_daily_analysis_followup_pipeline.py
@@ -14,6 +14,7 @@ from apps.worker.pipelines.daily_analysis_followup import (
     run_pending_daily_analysis_followup_tasks,
 )
 from apps.collectors.news.jin10_detail_fetcher import Jin10DetailFetchResult
+from database.models.execution import RunArtifact, ensure_execution_tables
 from database.models.task import Base, StepStatus, TaskRun, TaskStatus, TaskStep
 
 
@@ -120,6 +121,7 @@ def test_run_daily_analysis_followup_task_expands_auditable_steps(tmp_path: Path
 
 def test_run_daily_analysis_followup_task_fetches_readable_detail_page(tmp_path: Path) -> None:
     session = _make_db_session(tmp_path)
+    ensure_execution_tables(session)
     run = _seed_followup_run(session)
     run_daily_analysis_followup_task(session, run.id, storage_root=tmp_path)
 
@@ -156,6 +158,8 @@ def test_run_daily_analysis_followup_task_fetches_readable_detail_page(tmp_path:
     assert {item["artifact_type"] for item in refs} >= {"raw_file", "parsed_file", "chart_snapshot"}
     source_refs = json.loads(detail_step.source_refs or "[]")
     assert any(item.get("source_name") == "jin10_detail_pages" for item in source_refs)
+    run_artifacts = session.query(RunArtifact).filter(RunArtifact.run_id == run.id).all()
+    assert {artifact.artifact_type for artifact in run_artifacts} >= {"raw_file", "parsed_file", "chart_snapshot"}
     assert steps[VIP_BROWSER_FALLBACK_STEP].status == StepStatus.skipped
     assert steps[DAILY_ANALYSIS_STEP].status == StepStatus.pending
 
@@ -354,6 +358,7 @@ def test_run_daily_analysis_followup_task_vip_browser_fallback_routes_to_daily_a
     monkeypatch,
 ) -> None:
     session = _make_db_session(tmp_path)
+    ensure_execution_tables(session)
     profile_dir = tmp_path / "jin10-browser-profile"
     profile_dir.mkdir()
     monkeypatch.setenv("JIN10_BROWSER_PROFILE", str(profile_dir))
@@ -404,9 +409,45 @@ def test_run_daily_analysis_followup_task_vip_browser_fallback_routes_to_daily_a
     refs = json.loads(fallback_step.output_refs or "[]")
     assert {item["artifact_type"] for item in refs} >= {"raw_file", "parsed_file", "chart_snapshot"}
     assert fallback_step.artifact_refs == fallback_step.output_refs
+    run_artifacts = session.query(RunArtifact).filter(RunArtifact.run_id == run.id).all()
+    assert {artifact.file_path for artifact in run_artifacts} >= {
+        output["vip_browser_fallback"]["raw_html_path"],
+        output["vip_browser_fallback"]["parsed_path"],
+    }
     source_refs = json.loads(fallback_step.source_refs or "[]")
     assert any(item.get("source_name") == "jin10_vip_browser_fallback" for item in source_refs)
     assert steps[DAILY_ANALYSIS_STEP].status == StepStatus.pending
+
+
+def test_run_daily_analysis_followup_task_daily_analysis_registers_snapshot_artifact(tmp_path: Path) -> None:
+    session = _make_db_session(tmp_path)
+    ensure_execution_tables(session)
+    run = _seed_followup_run(session)
+    run_daily_analysis_followup_task(session, run.id, storage_root=tmp_path)
+
+    def fake_fetcher(**kwargs):
+        return Jin10DetailFetchResult(
+            detail_url=kwargs["url"],
+            final_url=kwargs["url"],
+            status="fetched",
+            access_status="readable",
+            title="黄金日报",
+            raw_text="黄金和美联储主线仍需重点跟进，美元和收益率反应是关键。",
+            raw_html_path="raw/news/jin10_detail_pages/2026-06-12/detail.html",
+            parsed_path="parsed/news/jin10_detail_pages/2026-06-12/detail.json",
+            fetched_at="2026-06-12T00:00:00+00:00",
+        )
+
+    run_daily_analysis_followup_task(session, run.id, storage_root=tmp_path, detail_fetcher=fake_fetcher)
+    status = run_daily_analysis_followup_task(session, run.id, storage_root=tmp_path)
+
+    assert status == TaskStatus.success
+    run_artifacts = session.query(RunArtifact).filter(RunArtifact.run_id == run.id).all()
+    assert any(
+        artifact.artifact_type == "feature_json"
+        and artifact.file_path == "features/news/2026-06-12/run-news/daily_brief_input_snapshot.json"
+        for artifact in run_artifacts
+    )
 
 
 def test_run_daily_analysis_followup_task_vip_browser_fallback_keeps_logged_in_vip_text_readable(

--- a/tests/worker/test_premarket_c4_output_integration.py
+++ b/tests/worker/test_premarket_c4_output_integration.py
@@ -9,6 +9,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from database.models.execution import RunArtifact, ensure_execution_tables
 from database.models.task import Base, StepStatus, TaskRun, TaskStatus, TaskStep
 
 _CREATED_AT = datetime(2026, 5, 14, 12, 0, tzinfo=timezone.utc)
@@ -343,6 +344,7 @@ def test_c4_pipeline_source_refs_flow_through(tmp_path: Path) -> None:
 def test_run_premarket_with_c4_writes_all_artifacts(tmp_path: Path) -> None:
     """Full premarket run with mocked steps should produce C4 outputs."""
     db = _make_db_session(tmp_path)
+    ensure_execution_tables(db)
     task = _make_task_with_steps(
         db,
         [
@@ -427,6 +429,13 @@ def test_run_premarket_with_c4_writes_all_artifacts(tmp_path: Path) -> None:
     assert "c3_agents" in summaries["steps"]
     assert "final_report" in summaries["steps"]
     assert "strategy_card" in summaries["steps"]
+
+    run_artifacts = db.query(RunArtifact).filter(RunArtifact.run_id == task.id).all()
+    artifact_paths = {artifact.file_path for artifact in run_artifacts}
+    assert str(report_path) in artifact_paths
+    assert str(sc_json_candidates[0]) in artifact_paths
+    assert str(sc_md_candidates[0]) in artifact_paths
+    assert any(artifact.artifact_type == "analysis_md" for artifact in run_artifacts)
 
 
 def test_run_premarket_c4_not_triggered_when_snapshot_fails(tmp_path: Path) -> None:


### PR DESCRIPTION
## What
- Adds execution timeline and RunArtifact registry integration across TaskRecorder, worker outputs, follow-up artifacts, and final outputs.
- Normalizes run/source/artifact read models and exposes registry-backed lineage details.
- Adds premarket pipeline contract API and source readiness/gating read-model fields.

## Validation
- Targeted regression: `45 passed, 3 skipped`
- Targeted ruff: passed
- Live API health: `GET /health -> 200`
- DAG contract: `GET /api/pipelines/premarket/contract -> 200`
- Source readiness: `GET /api/data-sources/status -> 200`
- Real replay acceptance run: `c1ccff65-4cd4-44b8-982c-ce5828a97f2a`
- Replay evidence: `/api/runs/{run_id}/events` returned 8 events; `/api/runs/{run_id}/artifacts` returned 1 registry artifact.

## Notes
- Issues #1/#5/#7 are not auto-closed yet; comments document remaining replay/coverage acceptance scope.
- Issues #2/#3/#6/#8/#9 remain open with narrowed remaining work.
- No storage outputs or temporary acceptance artifacts are committed.