### PR TITLE
ci: gate Analysis Memory migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,102 @@ jobs:
           tests/scripts/test_run_automation_orchestrator.py
           tests/worker/test_premarket_composite_output_integration.py
           tests/architecture/test_contract_review_guards.py
+      - name: Lint Analysis Memory boundaries
+        run: >-
+          uv run ruff check
+          apps/analysis/state
+          apps/analysis/context_bundle
+          apps/analysis/figure_facts.py
+          apps/output/context_bundle.py
+          apps/output/figure_facts.py
+          apps/worker/composite_state_shadow.py
+          database/migrations
+          database/models/analysis_state.py
+          scripts/bootstrap_analysis_state.py
+          tests/analysis/test_context_bundle.py
+          tests/analysis/test_figure_facts.py
+          tests/analysis/test_state_bootstrap.py
+          tests/analysis/test_state_materializer.py
+          tests/api/test_analysis_memory_api.py
+          tests/architecture/test_analysis_memory_ci_guards.py
+          tests/architecture/test_analysis_memory_observability_guards.py
+          tests/database/test_alembic_runtime_unification.py
+          tests/database/test_analysis_memory_postgres.py
+          tests/database/test_analysis_state_core.py
+          tests/output/test_context_bundle_artifacts.py
+          tests/output/test_figure_fact_artifacts.py
+          tests/scripts/test_bootstrap_analysis_state.py
+          tests/worker/test_composite_state_shadow.py
+      - name: Run Analysis Memory regression tests
+        shell: bash
+        run: >-
+          mkdir -p test-results &&
+          uv run pytest -q --tb=short
+          --junitxml=test-results/analysis-memory.xml
+          tests/database/test_alembic_runtime_unification.py
+          tests/database/test_analysis_state_core.py
+          tests/analysis/test_context_bundle.py
+          tests/analysis/test_state_materializer.py
+          tests/analysis/test_figure_facts.py
+          tests/output/test_context_bundle_artifacts.py
+          tests/output/test_figure_fact_artifacts.py
+          tests/worker/test_composite_state_shadow.py
+          tests/analysis/test_state_bootstrap.py
+          tests/scripts/test_bootstrap_analysis_state.py
+          tests/api/test_analysis_memory_api.py
+          tests/architecture/test_analysis_memory_ci_guards.py
+          tests/architecture/test_analysis_memory_observability_guards.py
+      - name: Upload Analysis Memory test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: analysis-memory-test-results
+          path: test-results/analysis-memory.xml
+          if-no-files-found: warn
+
+  analysis-memory-postgres:
+    name: Analysis Memory PostgreSQL
+    runs-on: ubuntu-latest
+    env:
+      ANALYSIS_MEMORY_POSTGRES_URL: postgresql+psycopg2://postgres:postgres@127.0.0.1:5432/finance_agent_test
+      UV_CACHE_DIR: /tmp/uv-cache
+      no_proxy: 127.0.0.1,localhost,::1
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: finance_agent_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d finance_agent_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.11"
+      - name: Install Python dependencies
+        run: uv sync --locked --extra dev
+      - name: Run PostgreSQL migration and CAS checks
+        shell: bash
+        run: >-
+          mkdir -p test-results &&
+          uv run pytest -q --tb=short
+          --junitxml=test-results/analysis-memory-postgres.xml
+          tests/database/test_analysis_memory_postgres.py
+      - name: Upload PostgreSQL test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: analysis-memory-postgres-test-results
+          path: test-results/analysis-memory-postgres.xml
+          if-no-files-found: warn
 
   frontend:
     name: Frontend contracts

--- a/database/migrations/versions/20260704_0001_unify_runtime_schema.py
+++ b/database/migrations/versions/20260704_0001_unify_runtime_schema.py
@@ -24,14 +24,29 @@ down_revision = None
 branch_labels = None
 depends_on = None
 
+# Tables introduced by later revisions must never leak backwards through the
+# legacy metadata-backed baseline.  The baseline predates Analysis Memory; the
+# explicit 0002 revision below owns these tables.
+_POST_BASELINE_TABLES = frozenset(
+    {
+        "analysis_states",
+        "analysis_state_heads",
+        "analysis_transitions",
+    }
+)
+
+
+def _baseline_tables(metadata):
+    return [table for table in metadata.sorted_tables if table.name not in _POST_BASELINE_TABLES]
+
 
 def upgrade() -> None:
     bind = op.get_bind()
     for metadata in (AnalysisBase.metadata, Base.metadata, ExecutionBase.metadata, ReportBase.metadata):
-        metadata.create_all(bind=bind, checkfirst=True)
+        metadata.create_all(bind=bind, tables=_baseline_tables(metadata), checkfirst=True)
 
 
 def downgrade() -> None:
     bind = op.get_bind()
     for metadata in (ReportBase.metadata, ExecutionBase.metadata, Base.metadata, AnalysisBase.metadata):
-        metadata.drop_all(bind=bind, checkfirst=True)
+        metadata.drop_all(bind=bind, tables=_baseline_tables(metadata), checkfirst=True)

--- a/database/migrations/versions/20260722_0002_add_analysis_state_core.py
+++ b/database/migrations/versions/20260722_0002_add_analysis_state_core.py
@@ -7,9 +7,9 @@ Create Date: 2026-07-22
 
 from __future__ import annotations
 
+import sqlalchemy as sa
 from alembic import op
-
-from database.models.analysis_state import AnalysisState, AnalysisStateHead, AnalysisTransition
+from sqlalchemy.dialects import postgresql
 
 
 revision = "20260722_0002"
@@ -18,13 +18,138 @@ branch_labels = None
 depends_on = None
 
 
+JSONB_COMPAT = sa.JSON().with_variant(postgresql.JSONB(), "postgresql")
+
+
+def _table_exists(table_name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(table_name)
+
+
+def _create_table_if_missing(table_name: str, *elements) -> None:
+    if not _table_exists(table_name):
+        op.create_table(table_name, *elements)
+
+
+def _create_index_if_missing(index_name: str, table_name: str, columns: list[str], **kwargs) -> None:
+    if not _table_exists(table_name):
+        return
+    existing_indexes = {index["name"] for index in sa.inspect(op.get_bind()).get_indexes(table_name)}
+    if index_name not in existing_indexes:
+        op.create_index(index_name, table_name, columns, **kwargs)
+
+
+def _drop_table_if_exists(table_name: str) -> None:
+    if _table_exists(table_name):
+        op.drop_table(table_name)
+
+
 def upgrade() -> None:
-    bind = op.get_bind()
-    for table in (AnalysisState.__table__, AnalysisStateHead.__table__, AnalysisTransition.__table__):
-        table.create(bind=bind, checkfirst=True)
+    """Create the frozen Analysis Memory v1 persistence schema.
+
+    Keep this revision independent from live ORM metadata.  Model evolution
+    belongs in a later revision so a fresh install and an incremental upgrade
+    always execute the same historical DDL.
+    """
+
+    _create_table_if_missing(
+        "analysis_states",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("schema_version", sa.String(length=16), nullable=False),
+        sa.Column("asset", sa.String(length=32), nullable=False),
+        sa.Column("as_of", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("previous_state_id", sa.String(length=36), nullable=True),
+        sa.Column("task_run_id", sa.String(length=255), nullable=False),
+        sa.Column("analysis_snapshot_db_id", sa.String(length=36), nullable=True),
+        sa.Column("final_analysis_result_id", sa.String(length=36), nullable=True),
+        sa.Column("quality_gate_action", sa.String(length=32), nullable=False),
+        sa.Column("publish_allowed", sa.Boolean(), nullable=False),
+        sa.Column("accepted_output_source", sa.String(length=32), nullable=False),
+        sa.Column("accepted_output_agent_name", sa.String(length=64), nullable=True),
+        sa.Column("accepted_output_snapshot_id", sa.String(length=255), nullable=True),
+        sa.Column("input_snapshot_ids", JSONB_COMPAT, nullable=False),
+        sa.Column("source_refs", JSONB_COMPAT, nullable=False),
+        sa.Column("evidence_cursors", JSONB_COMPAT, nullable=False),
+        sa.Column("payload", JSONB_COMPAT, nullable=False),
+        sa.Column("content_hash", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
+        sa.ForeignKeyConstraint(["analysis_snapshot_db_id"], ["analysis_snapshots.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["final_analysis_result_id"], ["final_analysis_results.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["previous_state_id"], ["analysis_states.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    _create_index_if_missing("ix_analysis_states_asset_as_of", "analysis_states", ["asset", "as_of"])
+    _create_index_if_missing("ix_analysis_states_content_hash", "analysis_states", ["content_hash"])
+    _create_index_if_missing(
+        "ix_analysis_states_payload_gin", "analysis_states", ["payload"], postgresql_using="gin"
+    )
+    _create_index_if_missing("ix_analysis_states_previous_state_id", "analysis_states", ["previous_state_id"])
+    _create_index_if_missing(
+        "ix_analysis_states_quality",
+        "analysis_states",
+        ["quality_gate_action", "publish_allowed"],
+    )
+    _create_index_if_missing(
+        "ix_analysis_states_source_refs_gin",
+        "analysis_states",
+        ["source_refs"],
+        postgresql_using="gin",
+    )
+    _create_index_if_missing("ix_analysis_states_task_run_id", "analysis_states", ["task_run_id"])
+
+    _create_table_if_missing(
+        "analysis_state_heads",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("asset", sa.String(length=32), nullable=False),
+        sa.Column("canonical_state_id", sa.String(length=36), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
+        sa.ForeignKeyConstraint(["canonical_state_id"], ["analysis_states.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("asset", name="uq_analysis_state_heads_asset"),
+        sa.UniqueConstraint("canonical_state_id", name="uq_analysis_state_heads_state"),
+    )
+    _create_index_if_missing(
+        "ix_analysis_state_heads_asset_version",
+        "analysis_state_heads",
+        ["asset", "version"],
+    )
+
+    _create_table_if_missing(
+        "analysis_transitions",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("schema_version", sa.String(length=16), nullable=False),
+        sa.Column("asset", sa.String(length=32), nullable=False),
+        sa.Column("from_state_id", sa.String(length=36), nullable=True),
+        sa.Column("to_state_id", sa.String(length=36), nullable=False),
+        sa.Column("task_run_id", sa.String(length=255), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("actions", JSONB_COMPAT, nullable=False),
+        sa.Column("evidence_refs", JSONB_COMPAT, nullable=False),
+        sa.Column("content_hash", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("CURRENT_TIMESTAMP"), nullable=False),
+        sa.ForeignKeyConstraint(["from_state_id"], ["analysis_states.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["to_state_id"], ["analysis_states.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("to_state_id", name="uq_analysis_transitions_to_state"),
+    )
+    _create_index_if_missing(
+        "ix_analysis_transitions_actions_gin",
+        "analysis_transitions",
+        ["actions"],
+        postgresql_using="gin",
+    )
+    _create_index_if_missing(
+        "ix_analysis_transitions_asset_created",
+        "analysis_transitions",
+        ["asset", "created_at"],
+    )
+    _create_index_if_missing("ix_analysis_transitions_content_hash", "analysis_transitions", ["content_hash"])
+    _create_index_if_missing("ix_analysis_transitions_from_state_id", "analysis_transitions", ["from_state_id"])
+    _create_index_if_missing("ix_analysis_transitions_task_run_id", "analysis_transitions", ["task_run_id"])
 
 
 def downgrade() -> None:
-    bind = op.get_bind()
-    for table in (AnalysisTransition.__table__, AnalysisStateHead.__table__, AnalysisState.__table__):
-        table.drop(bind=bind, checkfirst=True)
+    _drop_table_if_exists("analysis_transitions")
+    _drop_table_if_exists("analysis_state_heads")
+    _drop_table_if_exists("analysis_states")

--- a/tests/architecture/test_analysis_memory_ci_guards.py
+++ b/tests/architecture/test_analysis_memory_ci_guards.py
@@ -1,0 +1,33 @@
+"""CI guards for the Analysis Memory production baseline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_ci_runs_analysis_memory_focused_and_postgres_suites() -> None:
+    workflow = (Path(__file__).resolve().parents[2] / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    focused_suites = {
+        "tests/database/test_analysis_state_core.py",
+        "tests/analysis/test_context_bundle.py",
+        "tests/analysis/test_state_materializer.py",
+        "tests/analysis/test_figure_facts.py",
+        "tests/output/test_context_bundle_artifacts.py",
+        "tests/output/test_figure_fact_artifacts.py",
+        "tests/worker/test_composite_state_shadow.py",
+        "tests/analysis/test_state_bootstrap.py",
+        "tests/scripts/test_bootstrap_analysis_state.py",
+        "tests/api/test_analysis_memory_api.py",
+    }
+    for suite in focused_suites:
+        assert suite in workflow
+
+    assert "analysis-memory-postgres:" in workflow
+    assert "services:" in workflow
+    assert "postgres:" in workflow
+    assert "tests/database/test_analysis_memory_postgres.py" in workflow
+    assert "ANALYSIS_MEMORY_POSTGRES_URL" in workflow
+    assert "postgresql+psycopg2://" in workflow
+    assert workflow.count("mkdir -p test-results &&") == 2
+    assert "actions/upload-artifact@v4" in workflow

--- a/tests/database/test_alembic_runtime_unification.py
+++ b/tests/database/test_alembic_runtime_unification.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from pathlib import Path
+
 import pytest
-from sqlalchemy import UniqueConstraint, create_engine, inspect
+from alembic import command
+from sqlalchemy import UniqueConstraint, create_engine, inspect, select
 
 
 def _metadata_table_names(target_metadata) -> set[str]:
@@ -78,6 +82,127 @@ def test_runtime_alembic_upgrade_creates_current_schema(tmp_path, monkeypatch: p
     assert "execution_events" in table_names
     assert "report_items" in table_names
     assert "cme_option_rows" in table_names
+
+
+def test_analysis_memory_revision_boundary_is_explicit_and_replay_safe(tmp_path: Path) -> None:
+    from database.migrations.runtime import build_alembic_config
+    from database.models.analysis_state import AnalysisState, AnalysisStateHead, AnalysisTransition
+
+    database_url = f"sqlite:///{tmp_path / 'revision-boundary.sqlite'}"
+    config = build_alembic_config(database_url)
+    engine = create_engine(database_url)
+    state_tables = {"analysis_states", "analysis_state_heads", "analysis_transitions"}
+
+    command.upgrade(config, "20260704_0001")
+    assert state_tables.isdisjoint(inspect(engine).get_table_names())
+
+    command.upgrade(config, "20260722_0002")
+    inspector = inspect(engine)
+    assert state_tables <= set(inspector.get_table_names())
+    expected_indexes = {
+        table.name: {index.name for index in table.indexes}
+        for table in (
+            AnalysisState.__table__,
+            AnalysisStateHead.__table__,
+            AnalysisTransition.__table__,
+        )
+    }
+    for table_name, index_names in expected_indexes.items():
+        assert {index["name"] for index in inspector.get_indexes(table_name)} == index_names
+    assert {"uq_analysis_state_heads_asset", "uq_analysis_state_heads_state"} == {
+        constraint["name"] for constraint in inspector.get_unique_constraints("analysis_state_heads")
+    }
+    assert {"uq_analysis_transitions_to_state"} == {
+        constraint["name"] for constraint in inspector.get_unique_constraints("analysis_transitions")
+    }
+    assert {
+        (tuple(foreign_key["constrained_columns"]), foreign_key["referred_table"])
+        for foreign_key in inspector.get_foreign_keys("analysis_states")
+    } == {
+        (("previous_state_id",), "analysis_states"),
+        (("analysis_snapshot_db_id",), "analysis_snapshots"),
+        (("final_analysis_result_id",), "final_analysis_results"),
+    }
+
+    state_id = "00000000-0000-0000-0000-000000000074"
+    with engine.begin() as connection:
+        connection.execute(
+            AnalysisState.__table__.insert().values(
+                id=state_id,
+                schema_version="1.0",
+                asset="XAUUSD",
+                as_of=datetime(2026, 7, 22, 8, tzinfo=UTC),
+                task_run_id="issue-74-replay",
+                quality_gate_action="manual_review",
+                publish_allowed=False,
+                accepted_output_source="none",
+                input_snapshot_ids={},
+                source_refs=[],
+                evidence_cursors={},
+                payload={"asset": "XAUUSD"},
+                content_hash="0" * 64,
+            )
+        )
+
+    command.upgrade(config, "head")
+    with engine.connect() as connection:
+        assert connection.scalar(select(AnalysisState.id).where(AnalysisState.id == state_id)) == state_id
+
+    command.downgrade(config, "20260704_0001")
+    assert state_tables.isdisjoint(inspect(engine).get_table_names())
+    command.upgrade(config, "head")
+    assert state_tables <= set(inspect(engine).get_table_names())
+
+
+def test_analysis_memory_revision_does_not_import_live_orm() -> None:
+    revision_path = (
+        Path(__file__).resolve().parents[2]
+        / "database/migrations/versions/20260722_0002_add_analysis_state_core.py"
+    )
+    source = revision_path.read_text(encoding="utf-8")
+
+    assert "database.models.analysis_state" not in source
+    assert source.count("\n    _create_table_if_missing(") == 3
+    assert source.count("\n        op.create_table(") == 1
+    assert '"analysis_states"' in source
+    assert '"analysis_state_heads"' in source
+    assert '"analysis_transitions"' in source
+
+
+def test_analysis_memory_upgrade_preserves_precreated_tables_and_data(tmp_path: Path) -> None:
+    from database.migrations.runtime import build_alembic_config
+    from database.models.analysis_state import AnalysisState, AnalysisStateHead, AnalysisTransition
+
+    database_url = f"sqlite:///{tmp_path / 'precreated-state.sqlite'}"
+    config = build_alembic_config(database_url)
+    engine = create_engine(database_url)
+    command.upgrade(config, "20260704_0001")
+    for table in (AnalysisState.__table__, AnalysisStateHead.__table__, AnalysisTransition.__table__):
+        table.create(bind=engine, checkfirst=True)
+
+    state_id = "00000000-0000-0000-0000-000000000080"
+    with engine.begin() as connection:
+        connection.execute(
+            AnalysisState.__table__.insert().values(
+                id=state_id,
+                schema_version="1.0",
+                asset="XAUUSD",
+                as_of=datetime(2026, 7, 22, 8, tzinfo=UTC),
+                task_run_id="issue-74-precreated",
+                quality_gate_action="manual_review",
+                publish_allowed=False,
+                accepted_output_source="none",
+                input_snapshot_ids={},
+                source_refs=[],
+                evidence_cursors={},
+                payload={"asset": "XAUUSD"},
+                content_hash="2" * 64,
+            )
+        )
+
+    command.upgrade(config, "head")
+    with engine.connect() as connection:
+        assert connection.scalar(select(AnalysisState.id).where(AnalysisState.id == state_id)) == state_id
 
 
 @pytest.mark.anyio

--- a/tests/database/test_analysis_memory_postgres.py
+++ b/tests/database/test_analysis_memory_postgres.py
@@ -1,0 +1,239 @@
+"""PostgreSQL-only migration lifecycle and canonical-head CAS checks."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from contextlib import contextmanager
+from datetime import UTC, date, datetime
+from typing import Iterator
+
+import pytest
+from alembic import command
+from sqlalchemy import create_engine, inspect, select, text
+from sqlalchemy.engine import URL, make_url
+from sqlalchemy.orm import Session
+
+from apps.analysis.state import (
+    CanonicalHeadConflictError,
+    StateMaterializationAuthority,
+    advance_canonical_head,
+)
+from database.migrations.runtime import build_alembic_config
+from database.models.analysis import AnalysisSnapshot
+from database.models.analysis_state import AnalysisState, AnalysisStateHead
+
+
+POSTGRES_URL_ENV = "ANALYSIS_MEMORY_POSTGRES_URL"
+STATE_TABLES = {"analysis_states", "analysis_state_heads", "analysis_transitions"}
+
+
+def _postgres_url() -> str:
+    database_url = os.getenv(POSTGRES_URL_ENV)
+    if not database_url:
+        pytest.skip(f"{POSTGRES_URL_ENV} is required for PostgreSQL migration checks")
+    if make_url(database_url).get_backend_name() != "postgresql":
+        pytest.fail(f"{POSTGRES_URL_ENV} must use PostgreSQL")
+    return database_url
+
+
+def _render_url(url: URL) -> str:
+    return url.render_as_string(hide_password=False)
+
+
+@contextmanager
+def _isolated_schema(database_url: str) -> Iterator[str]:
+    schema_name = f"analysis_memory_ci_{uuid.uuid4().hex}"
+    admin_engine = create_engine(database_url)
+    with admin_engine.begin() as connection:
+        connection.execute(text(f'CREATE SCHEMA "{schema_name}"'))
+    schema_url = make_url(database_url).update_query_dict(
+        {"options": f"-csearch_path={schema_name}"},
+        append=False,
+    )
+    try:
+        yield _render_url(schema_url)
+    finally:
+        with admin_engine.begin() as connection:
+            connection.execute(text(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE'))
+        admin_engine.dispose()
+
+
+def _table_names(database_url: str) -> set[str]:
+    engine = create_engine(database_url)
+    try:
+        return set(inspect(engine).get_table_names())
+    finally:
+        engine.dispose()
+
+
+def test_postgres_fresh_and_incremental_migration_lifecycle() -> None:
+    database_url = _postgres_url()
+
+    with _isolated_schema(database_url) as fresh_url:
+        config = build_alembic_config(fresh_url)
+        command.upgrade(config, "head")
+        assert STATE_TABLES <= _table_names(fresh_url)
+
+        engine = create_engine(fresh_url)
+        state_id = "00000000-0000-0000-0000-000000000074"
+        try:
+            with engine.begin() as connection:
+                connection.execute(
+                    AnalysisState.__table__.insert().values(
+                        id=state_id,
+                        schema_version="1.0",
+                        asset="XAUUSD",
+                        as_of=datetime(2026, 7, 22, 8, tzinfo=UTC),
+                        task_run_id="issue-74-repeat",
+                        quality_gate_action="manual_review",
+                        publish_allowed=False,
+                        accepted_output_source="none",
+                        input_snapshot_ids={},
+                        source_refs=[],
+                        evidence_cursors={},
+                        payload={"asset": "XAUUSD"},
+                        content_hash="0" * 64,
+                    )
+                )
+            command.upgrade(config, "head")
+            with engine.connect() as connection:
+                assert connection.scalar(select(AnalysisState.id).where(AnalysisState.id == state_id)) == state_id
+            command.check(config)
+        finally:
+            engine.dispose()
+
+        command.downgrade(config, "20260704_0001")
+        assert STATE_TABLES.isdisjoint(_table_names(fresh_url))
+        command.upgrade(config, "head")
+        assert STATE_TABLES <= _table_names(fresh_url)
+
+    with _isolated_schema(database_url) as incremental_url:
+        config = build_alembic_config(incremental_url)
+        command.upgrade(config, "20260704_0001")
+        assert STATE_TABLES.isdisjoint(_table_names(incremental_url))
+
+        engine = create_engine(incremental_url)
+        snapshot_id = "snapshot-issue-74-existing"
+        try:
+            with engine.begin() as connection:
+                connection.execute(
+                    AnalysisSnapshot.__table__.insert().values(
+                        id="00000000-0000-0000-0000-000000000075",
+                        snapshot_id=snapshot_id,
+                        asset="XAUUSD",
+                        trade_date=date(2026, 7, 22),
+                        run_id="issue-74-incremental",
+                        status="success",
+                        input_snapshot_ids={},
+                        source_refs=[],
+                        payload={"asset": "XAUUSD"},
+                        payload_sha256="1" * 64,
+                        artifact_path="outputs/issue-74.json",
+                    )
+                )
+            command.upgrade(config, "head")
+            assert STATE_TABLES <= _table_names(incremental_url)
+            with engine.connect() as connection:
+                assert (
+                    connection.scalar(
+                        select(AnalysisSnapshot.snapshot_id).where(AnalysisSnapshot.snapshot_id == snapshot_id)
+                    )
+                    == snapshot_id
+                )
+            command.upgrade(config, "head")
+            command.check(config)
+        finally:
+            engine.dispose()
+
+
+def test_canonical_head_cas_uses_real_postgresql() -> None:
+    database_url = _postgres_url()
+    with _isolated_schema(database_url) as schema_url:
+        command.upgrade(build_alembic_config(schema_url), "head")
+        engine = create_engine(schema_url)
+        authority = StateMaterializationAuthority(
+            quality_gate_action="pass",
+            publish_allowed=True,
+            accepted_output_source="primary",
+            accepted_output_agent_name="coordinator_agent",
+            accepted_output_snapshot_id="snapshot-issue-74",
+        )
+        root_id = "00000000-0000-0000-0000-000000000076"
+        winner_id = "00000000-0000-0000-0000-000000000077"
+        stale_id = "00000000-0000-0000-0000-000000000078"
+
+        def state_values(state_id: str, previous_state_id: str | None) -> dict:
+            return {
+                "id": state_id,
+                "schema_version": "1.0",
+                "asset": "XAUUSD",
+                "as_of": datetime(2026, 7, 22, 8, tzinfo=UTC),
+                "previous_state_id": previous_state_id,
+                "task_run_id": f"issue-74-{state_id[-2:]}",
+                "quality_gate_action": "pass",
+                "publish_allowed": True,
+                "accepted_output_source": "primary",
+                "accepted_output_agent_name": "coordinator_agent",
+                "accepted_output_snapshot_id": "snapshot-issue-74",
+                "input_snapshot_ids": {"market": "snapshot-issue-74"},
+                "source_refs": [{"snapshot_id": "snapshot-issue-74"}],
+                "evidence_cursors": {},
+                "payload": {"asset": "XAUUSD", "state_id": state_id},
+                "content_hash": state_id.replace("-", "").ljust(64, "0"),
+            }
+
+        try:
+            with engine.begin() as connection:
+                connection.execute(
+                    AnalysisState.__table__.insert(),
+                    [
+                        state_values(root_id, None),
+                        state_values(winner_id, root_id),
+                        state_values(stale_id, root_id),
+                    ],
+                )
+                connection.execute(
+                    AnalysisStateHead.__table__.insert().values(
+                        id="00000000-0000-0000-0000-000000000079",
+                        asset="XAUUSD",
+                        canonical_state_id=root_id,
+                        version=1,
+                    )
+                )
+
+            with Session(engine) as winner, Session(engine) as stale:
+                winner_head = winner.scalar(
+                    select(AnalysisStateHead).where(AnalysisStateHead.asset == "XAUUSD")
+                )
+                stale_head = stale.scalar(select(AnalysisStateHead).where(AnalysisStateHead.asset == "XAUUSD"))
+                assert winner_head is not None and stale_head is not None
+                assert (winner_head.canonical_state_id, winner_head.version) == (root_id, 1)
+                assert (stale_head.canonical_state_id, stale_head.version) == (root_id, 1)
+
+                advance_canonical_head(
+                    winner,
+                    asset="XAUUSD",
+                    new_state_id=winner_id,
+                    expected_state_id=root_id,
+                    expected_version=1,
+                    authority=authority,
+                )
+                winner.commit()
+
+                with pytest.raises(CanonicalHeadConflictError, match="compare-and-swap conflict"):
+                    advance_canonical_head(
+                        stale,
+                        asset="XAUUSD",
+                        new_state_id=stale_id,
+                        expected_state_id=root_id,
+                        expected_version=1,
+                        authority=authority,
+                    )
+
+            with Session(engine) as verify:
+                head = verify.scalar(select(AnalysisStateHead).where(AnalysisStateHead.asset == "XAUUSD"))
+                assert head is not None
+                assert (head.canonical_state_id, head.version) == (winner_id, 2)
+        finally:
+            engine.dispose()


### PR DESCRIPTION
## 目标

为当前远端 Analysis Memory v1 基础设施补齐可重复的 CI、Alembic 迁移和 PostgreSQL CAS 门禁。本 PR 不包含 state_scope/v1.1、Materializer/Bootstrap、API、前端或生产模式变更。

## 范围

- 将已发布 Analysis Memory focused suites显式纳入 CI
- 增加 PostgreSQL 16 service job
- 覆盖 fresh upgrade、existing-schema incremental upgrade、repeat upgrade、downgrade boundary 与 alembic check
- 使用真实 PostgreSQL 验证 canonical-head CAS 冲突
- 冻结 20260722_0002 的历史 DDL，避免继续依赖 live ORM metadata
- 明确 20260704_0001 与 Analysis Memory 三张表的 revision 边界

## 本地验证

- Analysis Memory focused suites: 90 passed
- PostgreSQL migration/CAS: 2 passed
- Ruff: passed
- CI YAML parse: passed
- git diff --check: passed

## 交付约束

- Issue 在 PR 合并且 required CI green 前保持 open
- 不允许 amend/force-push main
- 后续 #75 state_scope 工作必须使用新的 forward migration

Closes #74