### PR TITLE
feat: propagate analysis state scope

### DIFF
--- a/apps/analysis/context_bundle/__init__.py
+++ b/apps/analysis/context_bundle/__init__.py
@@ -7,6 +7,7 @@ from .assembler import (
 )
 from .schemas import (
     CONTEXT_BUNDLE_SCHEMA_VERSION,
+    LEGACY_CONTEXT_BUNDLE_SCHEMA_VERSION,
     AnalysisContextBundle,
     ContextBlock,
     EvidenceCursor,
@@ -15,6 +16,7 @@ from .schemas import (
 
 __all__ = [
     "CONTEXT_BUNDLE_SCHEMA_VERSION",
+    "LEGACY_CONTEXT_BUNDLE_SCHEMA_VERSION",
     "AnalysisContextBundle",
     "ContextBlock",
     "ContextBundleBudgetExceeded",

--- a/apps/analysis/context_bundle/assembler.py
+++ b/apps/analysis/context_bundle/assembler.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from apps.analysis.context_bundle.schemas import (
+    CONTEXT_BUNDLE_SCHEMA_VERSION,
     AnalysisContextBundle,
     ContextBlock,
     ContextBudgetTrace,
@@ -16,6 +17,7 @@ from apps.analysis.context_bundle.schemas import (
     EvidenceItem,
     compute_bundle_content_hash,
 )
+from apps.analysis.state.schemas import StateScope
 
 
 DEFAULT_CONTEXT_TOKEN_BUDGET = 15_000
@@ -91,6 +93,7 @@ def assemble_context_bundle(
     *,
     run_id: str,
     asset: str,
+    state_scope: StateScope,
     canonical_state_id: str,
     canonical_state: dict[str, Any],
     evidence: list[EvidenceItem | dict[str, Any]],
@@ -110,6 +113,14 @@ def assemble_context_bundle(
         raise ValueError("max_alignment_seconds must be non-negative")
     _require_aware_datetime(cutoff_at, field="cutoff_at")
     _require_aware_datetime(assembled_at, field="assembled_at")
+    normalized_asset = str(asset).strip()
+    if not normalized_asset:
+        raise ValueError("asset must not be blank")
+    _validate_canonical_state_identity(
+        canonical_state,
+        asset=normalized_asset,
+        state_scope=state_scope,
+    )
 
     trim_reasons: dict[str, list[str]] = defaultdict(list)
     state_payload = _compact_value(
@@ -184,9 +195,10 @@ def assemble_context_bundle(
     alignment = _alignment_status(retained, max_alignment_seconds=max_alignment_seconds)
     source_refs = [dict(item.source_ref) for item in retained if item.source_ref]
     base_payload = {
-        "schema_version": "analysis_context_bundle.v1",
+        "schema_version": CONTEXT_BUNDLE_SCHEMA_VERSION,
         "run_id": str(run_id).strip(),
-        "asset": str(asset).strip(),
+        "asset": normalized_asset,
+        "state_scope": state_scope,
         "canonical_state_id": str(canonical_state_id).strip(),
         "cutoff_at": _json_datetime(cutoff_at),
         "evidence_cursors": {
@@ -420,3 +432,21 @@ def _json_datetime(value: datetime) -> str:
 def _require_aware_datetime(value: datetime, *, field: str) -> None:
     if value.tzinfo is None or value.utcoffset() is None:
         raise ValueError(f"{field} must be timezone-aware")
+
+
+def _validate_canonical_state_identity(
+    canonical_state: dict[str, Any],
+    *,
+    asset: str,
+    state_scope: StateScope,
+) -> None:
+    state_asset = str(canonical_state.get("asset") or "").strip()
+    if state_asset != asset:
+        raise ValueError("canonical state asset does not match bundle asset")
+    declared_scope = canonical_state.get("state_scope")
+    if declared_scope is None:
+        if canonical_state.get("schema_version") != "1.0" or state_scope != "daily_close":
+            raise ValueError("canonical state must explicitly match bundle state_scope")
+        return
+    if declared_scope != state_scope:
+        raise ValueError("canonical state belongs to a different state_scope")

--- a/apps/analysis/context_bundle/schemas.py
+++ b/apps/analysis/context_bundle/schemas.py
@@ -8,9 +8,11 @@ from typing import Any, Literal
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from apps.analysis.state.hashing import content_hash
+from apps.analysis.state.schemas import StateScope
 
 
-CONTEXT_BUNDLE_SCHEMA_VERSION = "analysis_context_bundle.v1"
+LEGACY_CONTEXT_BUNDLE_SCHEMA_VERSION = "analysis_context_bundle.v1"
+CONTEXT_BUNDLE_SCHEMA_VERSION = "analysis_context_bundle.v2"
 _TRANSPORT_KEYS = frozenset(
     {
         "provider",
@@ -101,7 +103,11 @@ class ContextBudgetTrace(_StrictFrozenModel):
 
 
 class AnalysisContextBundle(_StrictFrozenModel):
-    schema_version: Literal["analysis_context_bundle.v1"] = CONTEXT_BUNDLE_SCHEMA_VERSION
+    schema_version: Literal[
+        "analysis_context_bundle.v1",
+        "analysis_context_bundle.v2",
+    ] = CONTEXT_BUNDLE_SCHEMA_VERSION
+    state_scope: StateScope | None = None
     bundle_id: str
     content_hash: str
     run_id: str
@@ -135,6 +141,11 @@ class AnalysisContextBundle(_StrictFrozenModel):
     def _validate_bundle(self) -> "AnalysisContextBundle":
         payload = self.model_dump(mode="json")
         _reject_transport_keys(payload)
+        if self.schema_version == LEGACY_CONTEXT_BUNDLE_SCHEMA_VERSION:
+            if self.state_scope is not None:
+                raise ValueError("legacy context bundle must not declare state_scope")
+        elif self.state_scope is None:
+            raise ValueError("context bundle v2 requires state_scope")
         if any(not source.strip() for source in self.evidence_cursors):
             raise ValueError("evidence cursor source must not be blank")
         if any(not source.strip() for source in self.next_evidence_cursors):
@@ -176,6 +187,8 @@ def compute_bundle_content_hash(value: AnalysisContextBundle | dict[str, Any]) -
     payload.pop("bundle_id", None)
     payload.pop("content_hash", None)
     payload.pop("assembled_at", None)
+    if payload.get("schema_version") == LEGACY_CONTEXT_BUNDLE_SCHEMA_VERSION:
+        payload.pop("state_scope", None)
     return content_hash(payload, exclude_keys=frozenset())
 
 

--- a/apps/api/routes/analysis_memory_routes.py
+++ b/apps/api/routes/analysis_memory_routes.py
@@ -8,6 +8,7 @@ import secrets
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from sqlalchemy.orm import Session
 
+from apps.analysis.state.schemas import StateScope
 from apps.api.schemas.analysis_memory import (
     AnalysisStateView,
     AnalysisTransitionView,
@@ -53,16 +54,24 @@ def require_analysis_memory_writer(
 @router.get("/assets/{asset}/canonical", response_model=CanonicalStateResponse)
 def api_analysis_memory_canonical(
     asset: str,
+    state_scope: StateScope = Query(alias="stateScope"),
     max_depth: int = Query(default=20, alias="maxDepth", ge=1, le=100),
     db: Session = Depends(get_db),
 ) -> CanonicalStateResponse:
     """Read accepted canonical state only; this route never invokes a model."""
-    return _call_read(analysis_memory_service.get_latest_canonical, db, asset=asset, max_depth=max_depth)
+    return _call_read(
+        analysis_memory_service.get_latest_canonical,
+        db,
+        asset=asset,
+        state_scope=state_scope,
+        max_depth=max_depth,
+    )
 
 
 @router.get("/assets/{asset}/candidates", response_model=CandidateStatePage)
 def api_analysis_memory_candidates(
     asset: str,
+    state_scope: StateScope = Query(alias="stateScope"),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, alias="pageSize", ge=1, le=100),
     db: Session = Depends(get_db),
@@ -71,6 +80,7 @@ def api_analysis_memory_candidates(
         analysis_memory_service.list_candidates,
         db,
         asset=asset,
+        state_scope=state_scope,
         page=page,
         page_size=page_size,
     )
@@ -79,12 +89,14 @@ def api_analysis_memory_candidates(
 @router.get("/assets/{asset}/context-bundles", response_model=ContextBundleMetadataPage)
 def api_analysis_memory_context_bundles(
     asset: str,
+    state_scope: StateScope = Query(alias="stateScope"),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, alias="pageSize", ge=1, le=100),
 ) -> ContextBundleMetadataPage:
     return _call_read(
         analysis_memory_service.list_context_bundle_metadata,
         asset=asset,
+        state_scope=state_scope,
         page=page,
         page_size=page_size,
     )
@@ -93,22 +105,41 @@ def api_analysis_memory_context_bundles(
 @router.get("/states/{state_id}", response_model=AnalysisStateView)
 def api_analysis_memory_state(
     state_id: str,
+    state_scope: StateScope = Query(alias="stateScope"),
     db: Session = Depends(get_db),
 ) -> AnalysisStateView:
-    return _call_read(analysis_memory_service.get_state_response, db, state_id=state_id)
+    return _call_read(
+        analysis_memory_service.get_state_response,
+        db,
+        state_id=state_id,
+        state_scope=state_scope,
+    )
 
 
 @router.get("/transitions/{transition_id}", response_model=AnalysisTransitionView)
 def api_analysis_memory_transition(
     transition_id: str,
+    state_scope: StateScope = Query(alias="stateScope"),
     db: Session = Depends(get_db),
 ) -> AnalysisTransitionView:
-    return _call_read(analysis_memory_service.get_transition_response, db, transition_id=transition_id)
+    return _call_read(
+        analysis_memory_service.get_transition_response,
+        db,
+        transition_id=transition_id,
+        state_scope=state_scope,
+    )
 
 
 @router.get("/context-bundles/{bundle_id}", response_model=ContextBundleMetadata)
-def api_analysis_memory_context_bundle(bundle_id: str) -> ContextBundleMetadata:
-    return _call_read(analysis_memory_service.get_context_bundle_metadata, bundle_id=bundle_id)
+def api_analysis_memory_context_bundle(
+    bundle_id: str,
+    state_scope: StateScope = Query(alias="stateScope"),
+) -> ContextBundleMetadata:
+    return _call_read(
+        analysis_memory_service.get_context_bundle_metadata,
+        bundle_id=bundle_id,
+        state_scope=state_scope,
+    )
 
 
 @router.post("/candidates/{candidate_id}/reviews", response_model=CandidateReviewResponse)

--- a/apps/api/routes/analysis_memory_routes.py
+++ b/apps/api/routes/analysis_memory_routes.py
@@ -54,7 +54,7 @@ def require_analysis_memory_writer(
 @router.get("/assets/{asset}/canonical", response_model=CanonicalStateResponse)
 def api_analysis_memory_canonical(
     asset: str,
-    state_scope: StateScope = Query(alias="stateScope"),
+    state_scope: StateScope = Query(default="daily_close", alias="stateScope"),
     max_depth: int = Query(default=20, alias="maxDepth", ge=1, le=100),
     db: Session = Depends(get_db),
 ) -> CanonicalStateResponse:
@@ -71,7 +71,7 @@ def api_analysis_memory_canonical(
 @router.get("/assets/{asset}/candidates", response_model=CandidateStatePage)
 def api_analysis_memory_candidates(
     asset: str,
-    state_scope: StateScope = Query(alias="stateScope"),
+    state_scope: StateScope = Query(default="daily_close", alias="stateScope"),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, alias="pageSize", ge=1, le=100),
     db: Session = Depends(get_db),
@@ -89,7 +89,7 @@ def api_analysis_memory_candidates(
 @router.get("/assets/{asset}/context-bundles", response_model=ContextBundleMetadataPage)
 def api_analysis_memory_context_bundles(
     asset: str,
-    state_scope: StateScope = Query(alias="stateScope"),
+    state_scope: StateScope = Query(default="daily_close", alias="stateScope"),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, alias="pageSize", ge=1, le=100),
 ) -> ContextBundleMetadataPage:
@@ -105,7 +105,7 @@ def api_analysis_memory_context_bundles(
 @router.get("/states/{state_id}", response_model=AnalysisStateView)
 def api_analysis_memory_state(
     state_id: str,
-    state_scope: StateScope = Query(alias="stateScope"),
+    state_scope: StateScope = Query(default="daily_close", alias="stateScope"),
     db: Session = Depends(get_db),
 ) -> AnalysisStateView:
     return _call_read(
@@ -119,7 +119,7 @@ def api_analysis_memory_state(
 @router.get("/transitions/{transition_id}", response_model=AnalysisTransitionView)
 def api_analysis_memory_transition(
     transition_id: str,
-    state_scope: StateScope = Query(alias="stateScope"),
+    state_scope: StateScope = Query(default="daily_close", alias="stateScope"),
     db: Session = Depends(get_db),
 ) -> AnalysisTransitionView:
     return _call_read(
@@ -133,7 +133,7 @@ def api_analysis_memory_transition(
 @router.get("/context-bundles/{bundle_id}", response_model=ContextBundleMetadata)
 def api_analysis_memory_context_bundle(
     bundle_id: str,
-    state_scope: StateScope = Query(alias="stateScope"),
+    state_scope: StateScope = Query(default="daily_close", alias="stateScope"),
 ) -> ContextBundleMetadata:
     return _call_read(
         analysis_memory_service.get_context_bundle_metadata,

--- a/apps/api/schemas/analysis_memory.py
+++ b/apps/api/schemas/analysis_memory.py
@@ -8,6 +8,7 @@ from typing import Any, Literal
 from pydantic import Field, field_validator, model_validator
 
 from apps.api.schemas.common import SchemaModel
+from apps.analysis.state.schemas import StateScope
 
 
 class PaginationMeta(SchemaModel):
@@ -21,6 +22,7 @@ class AnalysisTransitionView(SchemaModel):
     transition_id: str
     schema_version: str
     asset: str
+    state_scope: StateScope
     from_state_id: str | None
     to_state_id: str
     run_id: str
@@ -46,6 +48,7 @@ class AnalysisStateView(SchemaModel):
     state_kind: Literal["accepted_canonical", "candidate", "blocked"]
     schema_version: str
     asset: str
+    state_scope: StateScope
     as_of: datetime
     previous_state_id: str | None
     quality_gate_action: str
@@ -60,16 +63,18 @@ class AnalysisStateView(SchemaModel):
 
 
 class CanonicalStateResponse(SchemaModel):
-    schema_version: Literal["analysis_memory_read.v1"] = "analysis_memory_read.v1"
+    schema_version: Literal["analysis_memory_read.v2"] = "analysis_memory_read.v2"
     asset: str
+    state_scope: StateScope
     head_version: int = Field(ge=1)
     state: AnalysisStateView
     canonical_chain: list[AnalysisStateView] = Field(default_factory=list)
 
 
 class CandidateStatePage(SchemaModel):
-    schema_version: Literal["analysis_memory_read.v1"] = "analysis_memory_read.v1"
+    schema_version: Literal["analysis_memory_read.v2"] = "analysis_memory_read.v2"
     asset: str
+    state_scope: StateScope
     data: list[AnalysisStateView]
     pagination: PaginationMeta
 
@@ -87,6 +92,7 @@ class ContextBundleMetadata(SchemaModel):
     bundle_id: str
     content_hash: str
     asset: str
+    state_scope: StateScope
     run_id: str
     canonical_state_id: str
     cutoff_at: datetime
@@ -106,14 +112,16 @@ class ContextBundleMetadata(SchemaModel):
 
 
 class ContextBundleMetadataPage(SchemaModel):
-    schema_version: Literal["analysis_memory_read.v1"] = "analysis_memory_read.v1"
+    schema_version: Literal["analysis_memory_read.v2"] = "analysis_memory_read.v2"
     asset: str
+    state_scope: StateScope
     data: list[ContextBundleMetadata]
     pagination: PaginationMeta
 
 
 class CandidateReviewRequest(SchemaModel):
     action: Literal["accept"]
+    state_scope: StateScope
     actor: str = Field(min_length=1, max_length=128)
     reason: str = Field(min_length=1, max_length=2000)
     request_id: str = Field(min_length=1, max_length=255)
@@ -140,6 +148,7 @@ class ReviewArtifactView(SchemaModel):
     candidate_state_id: str
     accepted_state_id: str
     transition_id: str
+    state_scope: StateScope
     actor: str
     reason: str
     request_id: str
@@ -150,8 +159,9 @@ class ReviewArtifactView(SchemaModel):
 
 
 class CandidateReviewResponse(SchemaModel):
-    schema_version: Literal["analysis_memory_review.v1"] = "analysis_memory_review.v1"
+    schema_version: Literal["analysis_memory_review.v2"] = "analysis_memory_review.v2"
     disposition: Literal["canonical_accepted"]
+    state_scope: StateScope
     canonical_state: AnalysisStateView
     head_version: int = Field(ge=1)
     review_artifact: ReviewArtifactView
@@ -162,4 +172,10 @@ class CandidateReviewResponse(SchemaModel):
             raise ValueError("review response must contain accepted canonical state")
         if self.review_artifact.accepted_state_id != self.canonical_state.state_id:
             raise ValueError("review artifact must bind the accepted canonical state")
+        if not (
+            self.state_scope
+            == self.canonical_state.state_scope
+            == self.review_artifact.state_scope
+        ):
+            raise ValueError("review response scope binding is inconsistent")
         return self

--- a/apps/api/services/analysis_memory_service.py
+++ b/apps/api/services/analysis_memory_service.py
@@ -15,14 +15,22 @@ from apps.analysis.agents.quality_gate_evaluator import (
     QualityGateDecision,
     QualityGateFinding,
 )
-from apps.analysis.state import AnalysisStateDocument, TransitionReviewResult, materialize_reviewed_transition
+from apps.analysis.state import (
+    AnalysisStateDocumentV11,
+    AnalysisTransitionDocument,
+    AnalysisTransitionDocumentV11,
+    StateScope,
+    TransitionReviewResult,
+    materialize_reviewed_transition,
+    materialize_reviewed_transition_scoped,
+    parse_analysis_state_document,
+)
 from apps.analysis.state.hashing import content_hash
 from apps.analysis.state.repository import (
     CanonicalHeadConflictError,
     StateLineageError,
     get_state_history,
 )
-from apps.analysis.state.schemas import AnalysisTransitionDocument
 from apps.api.schemas.analysis_memory import (
     AnalysisStateLineage,
     AnalysisStateView,
@@ -42,12 +50,12 @@ from apps.output.context_bundle import ContextBundleLoadError, load_context_bund
 from apps.output.analysis_state_review import review_artifact_id, write_analysis_state_review
 from database.models.analysis_state import AnalysisState, AnalysisTransition
 from database.queries.analysis_state_observability import (
-    get_head,
+    get_head_scoped,
     get_candidate_acceptance_lineage,
     get_state,
     get_transition,
     get_transition_to_state,
-    list_candidate_states_page,
+    list_candidate_states_page_scoped,
 )
 
 
@@ -70,21 +78,25 @@ def get_latest_canonical(
     db: Session,
     *,
     asset: str,
+    state_scope: StateScope,
     max_depth: int = 20,
 ) -> CanonicalStateResponse:
     normalized_asset = _asset(asset)
-    head = get_head(db, normalized_asset)
+    head = get_head_scoped(db, asset=normalized_asset, state_scope=state_scope)
     if head is None:
         raise AnalysisMemoryNotFoundError("canonical state not found")
     canonical = get_state(db, head.canonical_state_id)
     if canonical is None or not _is_accepted(canonical):
         raise AnalysisMemoryConflictError("canonical head does not reference an accepted state")
+    if canonical.state_scope != state_scope:
+        raise AnalysisMemoryConflictError("canonical head references a different state scope")
     try:
         history = get_state_history(db, canonical.id, max_depth=max_depth)
     except StateLineageError as exc:
         raise AnalysisMemoryConflictError("canonical state lineage is invalid") from exc
     return CanonicalStateResponse(
         asset=normalized_asset,
+        state_scope=state_scope,
         head_version=head.version,
         state=_state_view(db, canonical, state_kind="accepted_canonical"),
         canonical_chain=[
@@ -95,11 +107,18 @@ def get_latest_canonical(
     )
 
 
-def get_state_response(db: Session, *, state_id: str) -> AnalysisStateView:
+def get_state_response(
+    db: Session,
+    *,
+    state_id: str,
+    state_scope: StateScope,
+) -> AnalysisStateView:
     state = get_state(db, _required(state_id, "state_id"))
     if state is None:
         raise AnalysisMemoryNotFoundError("analysis state not found")
-    head = get_head(db, state.asset)
+    if state.state_scope != state_scope:
+        raise AnalysisMemoryNotFoundError("analysis state not found in requested scope")
+    head = get_head_scoped(db, asset=state.asset, state_scope=state_scope)
     is_canonical = head is not None and head.canonical_state_id == state.id
     if is_canonical and not _is_accepted(state):
         raise AnalysisMemoryConflictError("canonical head does not reference an accepted state")
@@ -114,26 +133,34 @@ def list_candidates(
     db: Session,
     *,
     asset: str,
+    state_scope: StateScope,
     page: int,
     page_size: int,
 ) -> CandidateStatePage:
     normalized_asset = _asset(asset)
-    rows, total = list_candidate_states_page(
+    rows, total = list_candidate_states_page_scoped(
         db,
         asset=normalized_asset,
+        state_scope=state_scope,
         page=page,
         page_size=page_size,
     )
     return CandidateStatePage(
         asset=normalized_asset,
+        state_scope=state_scope,
         data=[_state_view(db, row, state_kind=_candidate_kind(row)) for row in rows],
         pagination=_pagination(page=page, page_size=page_size, total=total),
     )
 
 
-def get_transition_response(db: Session, *, transition_id: str) -> AnalysisTransitionView:
+def get_transition_response(
+    db: Session,
+    *,
+    transition_id: str,
+    state_scope: StateScope,
+) -> AnalysisTransitionView:
     row = get_transition(db, _required(transition_id, "transition_id"))
-    if row is None:
+    if row is None or row.state_scope != state_scope:
         raise AnalysisMemoryNotFoundError("analysis transition not found")
     return _transition_view(row)
 
@@ -141,15 +168,21 @@ def get_transition_response(db: Session, *, transition_id: str) -> AnalysisTrans
 def list_context_bundle_metadata(
     *,
     asset: str,
+    state_scope: StateScope,
     page: int,
     page_size: int,
     storage_root: Path | None = None,
 ) -> ContextBundleMetadataPage:
     normalized_asset = _asset(asset)
-    rows = _context_bundle_rows(asset=normalized_asset, storage_root=storage_root)
+    rows = _context_bundle_rows(
+        asset=normalized_asset,
+        state_scope=state_scope,
+        storage_root=storage_root,
+    )
     start = (page - 1) * page_size
     return ContextBundleMetadataPage(
         asset=normalized_asset,
+        state_scope=state_scope,
         data=rows[start : start + page_size],
         pagination=_pagination(page=page, page_size=page_size, total=len(rows)),
     )
@@ -158,6 +191,7 @@ def list_context_bundle_metadata(
 def get_context_bundle_metadata(
     *,
     bundle_id: str,
+    state_scope: StateScope,
     storage_root: Path | None = None,
 ) -> ContextBundleMetadata:
     normalized_id = _required(bundle_id, "bundle_id")
@@ -169,10 +203,18 @@ def get_context_bundle_metadata(
     base = root / "outputs" / "context_bundles"
     if not base.is_dir():
         raise AnalysisMemoryNotFoundError("context bundle not found")
-    for path in base.glob(f"*/*/{normalized_id}.json"):
-        metadata = _load_bundle_metadata(root=root, path=path)
-        if metadata is not None and metadata.bundle_id == normalized_id:
-            return metadata
+    patterns = [f"*/{state_scope}/*/{normalized_id}.json"]
+    if state_scope == "daily_close":
+        patterns.append(f"*/*/{normalized_id}.json")
+    for pattern in patterns:
+        for path in base.glob(pattern):
+            metadata = _load_bundle_metadata(
+                root=root,
+                path=path,
+                requested_scope=state_scope,
+            )
+            if metadata is not None and metadata.bundle_id == normalized_id:
+                return metadata
     raise AnalysisMemoryNotFoundError("context bundle not found")
 
 
@@ -187,7 +229,13 @@ def accept_candidate(
         raise AnalysisMemoryNotFoundError("analysis candidate not found")
     if candidate.publish_allowed or candidate.quality_gate_action != "manual_review":
         raise AnalysisMemoryReviewError("candidate is not eligible for manual acceptance")
-    head = get_head(db, candidate.asset)
+    if candidate.state_scope != request.state_scope:
+        raise AnalysisMemoryReviewError("candidate belongs to a different state scope")
+    head = get_head_scoped(
+        db,
+        asset=candidate.asset,
+        state_scope=request.state_scope,
+    )
     if head is None:
         raise AnalysisMemoryConflictError("canonical head not found")
     if (
@@ -199,9 +247,13 @@ def accept_candidate(
     previous = get_state(db, head.canonical_state_id)
     if previous is None or not _is_accepted(previous):
         raise AnalysisMemoryConflictError("canonical head does not reference an accepted state")
+    if previous.state_scope != request.state_scope:
+        raise AnalysisMemoryConflictError("canonical head belongs to a different state scope")
     candidate_transition = get_transition_to_state(db, candidate.id)
     if candidate_transition is None:
         raise AnalysisMemoryConflictError("candidate transition is missing")
+    if candidate_transition.state_scope != request.state_scope:
+        raise AnalysisMemoryConflictError("candidate transition belongs to a different state scope")
 
     acceptance_lineage = get_candidate_acceptance_lineage(db, state=candidate)
     if acceptance_lineage is None:
@@ -221,13 +273,22 @@ def accept_candidate(
         "actor": request.actor,
         "reason": request.reason,
         "request_id": request.request_id,
+        "state_scope": request.state_scope,
     }
-    transition = AnalysisTransitionDocument(
-        summary=f"Manual review accepted candidate: {candidate_transition.summary}",
-        changes=candidate_transition.actions,
-        evidence_refs=[*candidate_transition.evidence_refs, review_ref],
+    document = parse_analysis_state_document(candidate.payload)
+    transition_payload = {
+        "summary": f"Manual review accepted candidate: {candidate_transition.summary}",
+        "changes": candidate_transition.actions,
+        "evidence_refs": [*candidate_transition.evidence_refs, review_ref],
+    }
+    transition = (
+        AnalysisTransitionDocumentV11(
+            state_scope=request.state_scope,
+            **transition_payload,
+        )
+        if isinstance(document, AnalysisStateDocumentV11)
+        else AnalysisTransitionDocument(**transition_payload)
     )
-    document = AnalysisStateDocument.model_validate(candidate.payload)
     review = TransitionReviewResult(
         previous_state_id=head.canonical_state_id,
         previous_state_content_hash=previous.content_hash,
@@ -251,6 +312,7 @@ def accept_candidate(
                     "candidate_state_id": candidate.id,
                     "review_artifact_id": artifact_id,
                     "request_id": request.request_id,
+                    "state_scope": request.state_scope,
                 },
             )
         ],
@@ -268,8 +330,7 @@ def accept_candidate(
         ),
     )
     try:
-        materialization = materialize_reviewed_transition(
-            db,
+        materializer_kwargs = dict(
             review=review,
             quality_gate=quality_gate,
             agent_loop=agent_loop,
@@ -278,6 +339,16 @@ def accept_candidate(
             analysis_snapshot_db_id=candidate.analysis_snapshot_db_id,
             final_analysis_result_id=candidate.final_analysis_result_id,
         )
+        if isinstance(document, AnalysisStateDocumentV11):
+            materialization = materialize_reviewed_transition_scoped(
+                db,
+                state_scope=request.state_scope,
+                **materializer_kwargs,
+            )
+        else:
+            if request.state_scope != "daily_close":  # pragma: no cover - row contract
+                raise AnalysisMemoryReviewError("legacy candidate is only valid for daily_close")
+            materialization = materialize_reviewed_transition(db, **materializer_kwargs)
         if (
             materialization.disposition != "canonical_accepted"
             or not materialization.state_id
@@ -291,16 +362,22 @@ def accept_candidate(
         accepted_transition = get_transition_to_state(db, accepted.id)
         if accepted_transition is None:  # pragma: no cover - append contract
             raise AnalysisMemoryConflictError("accepted transition was not persisted")
+        if (
+            accepted.state_scope != request.state_scope
+            or accepted_transition.state_scope != request.state_scope
+        ):
+            raise AnalysisMemoryConflictError("accepted review scope binding is invalid")
         reviewed_at = accepted_transition.created_at or candidate.created_at or candidate.as_of
         artifact = write_analysis_state_review(
             storage_root=_PROJECT_ROOT / "storage",
             payload={
-                "schema_version": "analysis_state_review.v1",
+                "schema_version": "analysis_state_review.v2",
                 "artifact_id": artifact_id,
                 "candidate_state_id": candidate.id,
                 "accepted_state_id": accepted.id,
                 "transition_id": accepted_transition.id,
                 "asset": candidate.asset,
+                "state_scope": request.state_scope,
                 "run_id": candidate.task_run_id,
                 "analysis_snapshot_db_id": snapshot.id,
                 "snapshot_id": snapshot.snapshot_id,
@@ -332,6 +409,7 @@ def accept_candidate(
 
     return CandidateReviewResponse(
         disposition="canonical_accepted",
+        state_scope=request.state_scope,
         canonical_state=_state_view(db, accepted, state_kind="accepted_canonical"),
         head_version=materialization.canonical_version,
         review_artifact=ReviewArtifactView(
@@ -339,6 +417,7 @@ def accept_candidate(
             candidate_state_id=candidate.id,
             accepted_state_id=accepted.id,
             transition_id=accepted_transition.id,
+            state_scope=request.state_scope,
             actor=request.actor,
             reason=request.reason,
             request_id=request.request_id,
@@ -357,6 +436,10 @@ def _state_view(
     state_kind: str,
 ) -> AnalysisStateView:
     transition = get_transition_to_state(db, state.id)
+    if transition is not None and (
+        transition.asset != state.asset or transition.state_scope != state.state_scope
+    ):
+        raise AnalysisMemoryConflictError("state transition scope binding is invalid")
     artifact_ids = [f"analysis-state:{state.id}"]
     if transition is not None:
         artifact_ids.append(f"analysis-transition:{transition.id}")
@@ -365,6 +448,7 @@ def _state_view(
         state_kind=state_kind,
         schema_version=state.schema_version,
         asset=state.asset,
+        state_scope=state.state_scope,
         as_of=state.as_of,
         previous_state_id=state.previous_state_id,
         quality_gate_action=state.quality_gate_action,
@@ -392,6 +476,7 @@ def _transition_view(row: AnalysisTransition) -> AnalysisTransitionView:
         transition_id=row.id,
         schema_version=row.schema_version,
         asset=row.asset,
+        state_scope=row.state_scope,
         from_state_id=row.from_state_id,
         to_state_id=row.to_state_id,
         run_id=row.task_run_id,
@@ -403,28 +488,49 @@ def _transition_view(row: AnalysisTransition) -> AnalysisTransitionView:
     )
 
 
-def _context_bundle_rows(*, asset: str, storage_root: Path | None) -> list[ContextBundleMetadata]:
+def _context_bundle_rows(
+    *,
+    asset: str,
+    state_scope: StateScope,
+    storage_root: Path | None,
+) -> list[ContextBundleMetadata]:
     root = (storage_root or (_PROJECT_ROOT / "storage")).resolve()
-    base = root / "outputs" / "context_bundles" / asset
-    rows = [
-        metadata
-        for path in base.glob("*/*.json") if base.is_dir()
-        if (metadata := _load_bundle_metadata(root=root, path=path)) is not None
-    ]
+    asset_base = root / "outputs" / "context_bundles" / asset
+    paths = list((asset_base / state_scope).glob("*/*.json"))
+    if state_scope == "daily_close" and asset_base.is_dir():
+        paths.extend(asset_base.glob("*/*.json"))
+    rows = []
+    for path in paths:
+        metadata = _load_bundle_metadata(
+            root=root,
+            path=path,
+            requested_scope=state_scope,
+        )
+        if metadata is not None:
+            rows.append(metadata)
     return sorted(rows, key=lambda item: (item.assembled_at, item.bundle_id), reverse=True)
 
 
-def _load_bundle_metadata(*, root: Path, path: Path) -> ContextBundleMetadata | None:
+def _load_bundle_metadata(
+    *,
+    root: Path,
+    path: Path,
+    requested_scope: StateScope,
+) -> ContextBundleMetadata | None:
     try:
         relative = path.resolve().relative_to(root).as_posix()
         bundle = load_context_bundle(storage_root=root, storage_relative_path=relative)
     except (OSError, ValueError, ContextBundleLoadError):
+        return None
+    bundle_scope: StateScope = bundle.state_scope or "daily_close"
+    if bundle_scope != requested_scope:
         return None
     return ContextBundleMetadata(
         schema_version=bundle.schema_version,
         bundle_id=bundle.bundle_id,
         content_hash=bundle.content_hash,
         asset=bundle.asset,
+        state_scope=bundle_scope,
         run_id=bundle.run_id,
         canonical_state_id=bundle.canonical_state_id,
         cutoff_at=bundle.cutoff_at,

--- a/apps/api/services/analysis_memory_service.py
+++ b/apps/api/services/analysis_memory_service.py
@@ -229,12 +229,13 @@ def accept_candidate(
         raise AnalysisMemoryNotFoundError("analysis candidate not found")
     if candidate.publish_allowed or candidate.quality_gate_action != "manual_review":
         raise AnalysisMemoryReviewError("candidate is not eligible for manual acceptance")
-    if candidate.state_scope != request.state_scope:
+    candidate_scope = candidate.state_scope
+    if candidate_scope != request.state_scope:
         raise AnalysisMemoryReviewError("candidate belongs to a different state scope")
     head = get_head_scoped(
         db,
         asset=candidate.asset,
-        state_scope=request.state_scope,
+        state_scope=candidate_scope,
     )
     if head is None:
         raise AnalysisMemoryConflictError("canonical head not found")
@@ -247,12 +248,12 @@ def accept_candidate(
     previous = get_state(db, head.canonical_state_id)
     if previous is None or not _is_accepted(previous):
         raise AnalysisMemoryConflictError("canonical head does not reference an accepted state")
-    if previous.state_scope != request.state_scope:
+    if previous.state_scope != candidate_scope:
         raise AnalysisMemoryConflictError("canonical head belongs to a different state scope")
     candidate_transition = get_transition_to_state(db, candidate.id)
     if candidate_transition is None:
         raise AnalysisMemoryConflictError("candidate transition is missing")
-    if candidate_transition.state_scope != request.state_scope:
+    if candidate_transition.state_scope != candidate_scope:
         raise AnalysisMemoryConflictError("candidate transition belongs to a different state scope")
 
     acceptance_lineage = get_candidate_acceptance_lineage(db, state=candidate)
@@ -273,7 +274,7 @@ def accept_candidate(
         "actor": request.actor,
         "reason": request.reason,
         "request_id": request.request_id,
-        "state_scope": request.state_scope,
+        "state_scope": candidate_scope,
     }
     document = parse_analysis_state_document(candidate.payload)
     transition_payload = {
@@ -283,7 +284,7 @@ def accept_candidate(
     }
     transition = (
         AnalysisTransitionDocumentV11(
-            state_scope=request.state_scope,
+            state_scope=candidate_scope,
             **transition_payload,
         )
         if isinstance(document, AnalysisStateDocumentV11)
@@ -312,7 +313,7 @@ def accept_candidate(
                     "candidate_state_id": candidate.id,
                     "review_artifact_id": artifact_id,
                     "request_id": request.request_id,
-                    "state_scope": request.state_scope,
+                    "state_scope": candidate_scope,
                 },
             )
         ],
@@ -342,11 +343,11 @@ def accept_candidate(
         if isinstance(document, AnalysisStateDocumentV11):
             materialization = materialize_reviewed_transition_scoped(
                 db,
-                state_scope=request.state_scope,
+                state_scope=candidate_scope,
                 **materializer_kwargs,
             )
         else:
-            if request.state_scope != "daily_close":  # pragma: no cover - row contract
+            if candidate_scope != "daily_close":  # pragma: no cover - row contract
                 raise AnalysisMemoryReviewError("legacy candidate is only valid for daily_close")
             materialization = materialize_reviewed_transition(db, **materializer_kwargs)
         if (
@@ -363,8 +364,8 @@ def accept_candidate(
         if accepted_transition is None:  # pragma: no cover - append contract
             raise AnalysisMemoryConflictError("accepted transition was not persisted")
         if (
-            accepted.state_scope != request.state_scope
-            or accepted_transition.state_scope != request.state_scope
+            accepted.state_scope != candidate_scope
+            or accepted_transition.state_scope != candidate_scope
         ):
             raise AnalysisMemoryConflictError("accepted review scope binding is invalid")
         reviewed_at = accepted_transition.created_at or candidate.created_at or candidate.as_of
@@ -377,7 +378,7 @@ def accept_candidate(
                 "accepted_state_id": accepted.id,
                 "transition_id": accepted_transition.id,
                 "asset": candidate.asset,
-                "state_scope": request.state_scope,
+                "state_scope": candidate_scope,
                 "run_id": candidate.task_run_id,
                 "analysis_snapshot_db_id": snapshot.id,
                 "snapshot_id": snapshot.snapshot_id,
@@ -409,7 +410,7 @@ def accept_candidate(
 
     return CandidateReviewResponse(
         disposition="canonical_accepted",
-        state_scope=request.state_scope,
+        state_scope=candidate_scope,
         canonical_state=_state_view(db, accepted, state_kind="accepted_canonical"),
         head_version=materialization.canonical_version,
         review_artifact=ReviewArtifactView(
@@ -417,7 +418,7 @@ def accept_candidate(
             candidate_state_id=candidate.id,
             accepted_state_id=accepted.id,
             transition_id=accepted_transition.id,
-            state_scope=request.state_scope,
+            state_scope=candidate_scope,
             actor=request.actor,
             reason=request.reason,
             request_id=request.request_id,

--- a/apps/frontend-web/scripts/check-analysis-memory-contract.mjs
+++ b/apps/frontend-web/scripts/check-analysis-memory-contract.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const adapter = readFileSync(new URL("../src/adapters/analysisMemory.ts", import.meta.url), "utf8");
+const hook = readFileSync(new URL("../src/hooks/useAnalysisMemory.ts", import.meta.url), "utf8");
 const panel = readFileSync(new URL("../src/components/analysis-memory/AnalysisMemoryPanel.tsx", import.meta.url), "utf8");
 const processingPage = readFileSync(new URL("../src/pages/ProcessingMonitorPage.tsx", import.meta.url), "utf8");
 const reviewPage = readFileSync(new URL("../src/pages/ReviewCenterPage.tsx", import.meta.url), "utf8");
@@ -12,6 +13,13 @@ assert.match(adapter, /X-Finance-Analysis-Memory-Token/, "review action must car
 assert.match(adapter, /stateScope=/, "all asset reads must send an explicit state scope");
 assert.match(adapter, /state_scope: params\.stateScope/, "candidate acceptance must bind the selected scope");
 assert.match(adapter, /state_scope 不匹配/, "frontend adapter must fail closed on cross-scope payloads");
+assert.match(hook, /const requestGenerationRef = useRef\(0\)/, "reads must use a monotonic request generation");
+assert.match(hook, /requestGenerationRef\.current === requestGeneration/, "stale reads must fail the generation guard");
+assert.match(hook, /currentScopeRef\.current === requestedScope/, "read completion must still match the requested scope");
+assert.ok((hook.match(/if \(!isCurrentRequest\(\)\) return;/g) ?? []).length >= 2, "stale read success and failure must not update state");
+assert.match(hook, /if \(isCurrentRequest\(\)\) setIsLoading\(false\)/, "stale reads must not clear the active loading state");
+assert.match(hook, /currentScopeRef\.current !== stateScope \|\| currentAssetRef\.current !== asset/, "a stale review callback must not start an old-scope write");
+assert.match(hook, /currentScopeRef\.current === acceptScope && currentAssetRef\.current === acceptAsset/, "candidate acceptance must re-check scope before refetch");
 assert.match(panel, /正式 accepted canonical/, "panel must label the only official state");
 assert.match(panel, /candidate \/ 待复核/, "panel must isolate candidate state");
 assert.match(panel, /blocked \/ 不可采用/, "panel must isolate blocked state");

--- a/apps/frontend-web/scripts/check-analysis-memory-contract.mjs
+++ b/apps/frontend-web/scripts/check-analysis-memory-contract.mjs
@@ -9,10 +9,15 @@ const reviewPage = readFileSync(new URL("../src/pages/ReviewCenterPage.tsx", imp
 assert.match(adapter, /Promise\.allSettled/, "independent reads must keep candidates visible without canonical");
 assert.match(adapter, /state_kind !== "accepted_canonical" \|\| !canonicalState\.publish_allowed/, "canonical projection must fail closed");
 assert.match(adapter, /X-Finance-Analysis-Memory-Token/, "review action must carry the dedicated write token");
+assert.match(adapter, /stateScope=/, "all asset reads must send an explicit state scope");
+assert.match(adapter, /state_scope: params\.stateScope/, "candidate acceptance must bind the selected scope");
+assert.match(adapter, /state_scope 不匹配/, "frontend adapter must fail closed on cross-scope payloads");
 assert.match(panel, /正式 accepted canonical/, "panel must label the only official state");
 assert.match(panel, /candidate \/ 待复核/, "panel must isolate candidate state");
 assert.match(panel, /blocked \/ 不可采用/, "panel must isolate blocked state");
 assert.match(panel, /ContextBundle token composition/, "panel must expose bundle token composition");
+assert.match(panel, /Analysis Memory state scope/, "panel must expose a scope selector");
+assert.match(panel, /weekly_fundamental/, "panel must expose all persisted state scopes");
 assert.match(processingPage, /<AnalysisMemoryPanel \/>/, "Processing Monitor must render state observability");
 assert.match(reviewPage, /<AnalysisMemoryPanel allowReview \/>/, "Review Center must render permission-gated review controls");
 

--- a/apps/frontend-web/src/adapters/analysisMemory.ts
+++ b/apps/frontend-web/src/adapters/analysisMemory.ts
@@ -1,6 +1,7 @@
 import { fetchJson } from "@/adapters/apiClient";
 import type {
   AnalysisMemorySnapshot,
+  AnalysisStateScope,
   AnalysisStateLineage,
   AnalysisStateView,
   AnalysisTransitionView,
@@ -37,10 +38,21 @@ function strings(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
 }
 
-function transition(value: unknown): AnalysisTransitionView | null {
+function stateScope(value: unknown): AnalysisStateScope | null {
+  return value === "intraday" || value === "daily_close" || value === "weekly_fundamental" ? value : null;
+}
+
+function requireScope(value: unknown, expected: AnalysisStateScope, context: string): AnalysisStateScope {
+  const parsed = stateScope(value);
+  if (parsed !== expected) throw new Error(`${context} state_scope 不匹配`);
+  return parsed;
+}
+
+function transition(value: unknown, expectedScope: AnalysisStateScope): AnalysisTransitionView | null {
   const item = record(value);
   if (!text(item.transition_id)) return null;
   return {
+    state_scope: requireScope(item.state_scope, expectedScope, "transition"),
     transition_id: text(item.transition_id),
     from_state_id: optionalText(item.from_state_id),
     to_state_id: text(item.to_state_id),
@@ -67,7 +79,7 @@ function lineage(value: unknown): AnalysisStateLineage {
   };
 }
 
-function state(value: unknown): AnalysisStateView {
+function state(value: unknown, expectedScope: AnalysisStateScope): AnalysisStateView {
   const item = record(value);
   const rawKind = text(item.state_kind);
   const stateKind = rawKind === "accepted_canonical" || rawKind === "candidate" || rawKind === "blocked" ? rawKind : "blocked";
@@ -75,6 +87,7 @@ function state(value: unknown): AnalysisStateView {
     state_id: text(item.state_id),
     state_kind: stateKind,
     asset: text(item.asset),
+    state_scope: requireScope(item.state_scope, expectedScope, "state"),
     as_of: text(item.as_of),
     previous_state_id: optionalText(item.previous_state_id),
     quality_gate_action: text(item.quality_gate_action),
@@ -84,7 +97,7 @@ function state(value: unknown): AnalysisStateView {
     content_hash: text(item.content_hash),
     payload: record(item.payload),
     lineage: lineage(item.lineage),
-    transition: transition(item.transition),
+    transition: transition(item.transition, expectedScope),
     created_at: optionalText(item.created_at),
   };
 }
@@ -99,23 +112,35 @@ function pagination(value: unknown) {
   };
 }
 
-function canonical(value: unknown): CanonicalStateResponse {
+function canonical(value: unknown, expectedScope: AnalysisStateScope): CanonicalStateResponse {
   const item = record(value);
-  const canonicalState = state(item.state);
+  if (item.schema_version !== "analysis_memory_read.v2") throw new Error("analysis-memory canonical schema 不兼容");
+  requireScope(item.state_scope, expectedScope, "canonical response");
+  const canonicalState = state(item.state, expectedScope);
   if (canonicalState.state_kind !== "accepted_canonical" || !canonicalState.publish_allowed) {
     throw new Error("analysis-memory canonical contract rejected non-accepted state");
   }
   return {
+    schema_version: "analysis_memory_read.v2",
     asset: text(item.asset),
+    state_scope: expectedScope,
     head_version: numberValue(item.head_version),
     state: canonicalState,
-    canonical_chain: records(item.canonical_chain).map(state),
+    canonical_chain: records(item.canonical_chain).map((entry) => state(entry, expectedScope)),
   };
 }
 
-function candidates(value: unknown): CandidateStatePage {
+function candidates(value: unknown, expectedScope: AnalysisStateScope): CandidateStatePage {
   const item = record(value);
-  return { asset: text(item.asset), data: records(item.data).map(state), pagination: pagination(item.pagination) };
+  if (item.schema_version !== "analysis_memory_read.v2") throw new Error("analysis-memory candidates schema 不兼容");
+  requireScope(item.state_scope, expectedScope, "candidate response");
+  return {
+    schema_version: "analysis_memory_read.v2",
+    asset: text(item.asset),
+    state_scope: expectedScope,
+    data: records(item.data).map((entry) => state(entry, expectedScope)),
+    pagination: pagination(item.pagination),
+  };
 }
 
 function block(value: unknown): ContextBlockMetadata {
@@ -129,12 +154,14 @@ function block(value: unknown): ContextBlockMetadata {
   };
 }
 
-function bundle(value: unknown): ContextBundleMetadata {
+function bundle(value: unknown, expectedScope: AnalysisStateScope): ContextBundleMetadata {
   const item = record(value);
   return {
+    schema_version: text(item.schema_version),
     bundle_id: text(item.bundle_id),
     content_hash: text(item.content_hash),
     asset: text(item.asset),
+    state_scope: requireScope(item.state_scope, expectedScope, "ContextBundle"),
     run_id: text(item.run_id),
     canonical_state_id: text(item.canonical_state_id),
     cutoff_at: text(item.cutoff_at),
@@ -149,23 +176,32 @@ function bundle(value: unknown): ContextBundleMetadata {
   };
 }
 
-function bundles(value: unknown): ContextBundleMetadataPage {
+function bundles(value: unknown, expectedScope: AnalysisStateScope): ContextBundleMetadataPage {
   const item = record(value);
-  return { asset: text(item.asset), data: records(item.data).map(bundle), pagination: pagination(item.pagination) };
+  if (item.schema_version !== "analysis_memory_read.v2") throw new Error("analysis-memory bundles schema 不兼容");
+  requireScope(item.state_scope, expectedScope, "ContextBundle response");
+  return {
+    schema_version: "analysis_memory_read.v2",
+    asset: text(item.asset),
+    state_scope: expectedScope,
+    data: records(item.data).map((entry) => bundle(entry, expectedScope)),
+    pagination: pagination(item.pagination),
+  };
 }
 
-export async function fetchAnalysisMemory(asset = "XAUUSD"): Promise<AnalysisMemorySnapshot> {
+export async function fetchAnalysisMemory(stateScopeValue: AnalysisStateScope, asset = "XAUUSD"): Promise<AnalysisMemorySnapshot> {
   const encoded = encodeURIComponent(asset);
+  const scopeQuery = `stateScope=${encodeURIComponent(stateScopeValue)}`;
   const [canonicalResult, candidateResult, bundleResult] = await Promise.allSettled([
-    fetchJson<unknown>(`/api/analysis-memory/assets/${encoded}/canonical?maxDepth=20`),
-    fetchJson<unknown>(`/api/analysis-memory/assets/${encoded}/candidates?page=1&pageSize=20`),
-    fetchJson<unknown>(`/api/analysis-memory/assets/${encoded}/context-bundles?page=1&pageSize=20`),
+    fetchJson<unknown>(`/api/analysis-memory/assets/${encoded}/canonical?${scopeQuery}&maxDepth=20`),
+    fetchJson<unknown>(`/api/analysis-memory/assets/${encoded}/candidates?${scopeQuery}&page=1&pageSize=20`),
+    fetchJson<unknown>(`/api/analysis-memory/assets/${encoded}/context-bundles?${scopeQuery}&page=1&pageSize=20`),
   ]);
   const warnings: string[] = [];
   let canonicalValue: CanonicalStateResponse | null = null;
   if (canonicalResult.status === "fulfilled") {
     try {
-      canonicalValue = canonical(canonicalResult.value);
+      canonicalValue = canonical(canonicalResult.value, stateScopeValue);
     } catch (cause) {
       warnings.push(cause instanceof Error ? cause.message : "canonical contract invalid");
     }
@@ -173,11 +209,11 @@ export async function fetchAnalysisMemory(asset = "XAUUSD"): Promise<AnalysisMem
     warnings.push("accepted canonical 尚不可用");
   }
   const candidateValue = candidateResult.status === "fulfilled"
-    ? candidates(candidateResult.value)
-    : { asset, data: [], pagination: { page: 1, page_size: 20, total_items: 0, total_pages: 0 } };
+    ? candidates(candidateResult.value, stateScopeValue)
+    : { schema_version: "analysis_memory_read.v2" as const, asset, state_scope: stateScopeValue, data: [], pagination: { page: 1, page_size: 20, total_items: 0, total_pages: 0 } };
   const bundleValue = bundleResult.status === "fulfilled"
-    ? bundles(bundleResult.value)
-    : { asset, data: [], pagination: { page: 1, page_size: 20, total_items: 0, total_pages: 0 } };
+    ? bundles(bundleResult.value, stateScopeValue)
+    : { schema_version: "analysis_memory_read.v2" as const, asset, state_scope: stateScopeValue, data: [], pagination: { page: 1, page_size: 20, total_items: 0, total_pages: 0 } };
   if (candidateResult.status === "rejected") warnings.push("candidate list 加载失败");
   if (bundleResult.status === "rejected") warnings.push("ContextBundle metadata 加载失败");
   if (!canonicalValue && candidateResult.status === "rejected" && bundleResult.status === "rejected") {
@@ -194,6 +230,7 @@ export async function acceptAnalysisMemoryCandidate(params: {
   requestId: string;
   canonicalStateId: string;
   headVersion: number;
+  stateScope: AnalysisStateScope;
 }): Promise<void> {
   await fetchJson(`/api/analysis-memory/candidates/${encodeURIComponent(params.candidateId)}/reviews`, {
     method: "POST",
@@ -205,6 +242,7 @@ export async function acceptAnalysisMemoryCandidate(params: {
       request_id: params.requestId,
       expected_canonical_state_id: params.canonicalStateId,
       expected_head_version: params.headVersion,
+      state_scope: params.stateScope,
     }),
   });
 }

--- a/apps/frontend-web/src/components/analysis-memory/AnalysisMemoryPanel.tsx
+++ b/apps/frontend-web/src/components/analysis-memory/AnalysisMemoryPanel.tsx
@@ -3,7 +3,13 @@ import { useState } from "react";
 import { FACard } from "@/components/shared/FACard";
 import { FAStatusPill } from "@/components/shared/FAStatusPill";
 import { useAnalysisMemory } from "@/hooks/useAnalysisMemory";
-import type { AnalysisStateView } from "@/types/analysis-memory";
+import type { AnalysisStateScope, AnalysisStateView } from "@/types/analysis-memory";
+
+const SCOPE_LABELS: Record<AnalysisStateScope, string> = {
+  intraday: "日内",
+  daily_close: "日收盘",
+  weekly_fundamental: "周度基本面",
+};
 
 function shortId(value: string | null | undefined): string {
   return value ? (value.length > 18 ? `${value.slice(0, 8)}…${value.slice(-6)}` : value) : "—";
@@ -29,7 +35,8 @@ function TransitionDiff({ state }: { state: AnalysisStateView }) {
 }
 
 export function AnalysisMemoryPanel({ allowReview = false }: { allowReview?: boolean }) {
-  const memory = useAnalysisMemory();
+  const [stateScope, setStateScope] = useState<AnalysisStateScope>("daily_close");
+  const memory = useAnalysisMemory(stateScope);
   const [token, setToken] = useState("");
   const [actor, setActor] = useState("review-center");
   const [reason, setReason] = useState("");
@@ -53,9 +60,26 @@ export function AnalysisMemoryPanel({ allowReview = false }: { allowReview?: boo
     >
       {memory.error || memory.data.warnings.length ? <div className="rounded-[var(--radius-md)] border border-[var(--warn-border)] bg-[var(--warn-soft)] px-3 py-2 text-[length:var(--type-body-sm)] text-[var(--warn)]">{memory.error?.message ?? memory.data.warnings.join("；")}</div> : null}
 
+      <div className="flex flex-wrap items-center justify-between gap-2 rounded-[var(--radius-md)] border border-[var(--border-faint)] bg-[var(--bg-card-inner)] px-3 py-2">
+        <div>
+          <div className="fa-label">State scope</div>
+          <div className="text-[length:var(--type-caption)] text-[var(--fg-4)]">当前仅观察 {SCOPE_LABELS[stateScope]}（{stateScope}）状态链。</div>
+        </div>
+        <select
+          value={stateScope}
+          onChange={(event) => setStateScope(event.target.value as AnalysisStateScope)}
+          className="h-8 rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--bg-card)] px-2 text-[length:var(--type-label)] text-[var(--fg-2)]"
+          aria-label="Analysis Memory state scope"
+        >
+          {(Object.entries(SCOPE_LABELS) as Array<[AnalysisStateScope, string]>).map(([value, label]) => (
+            <option key={value} value={value}>{label} · {value}</option>
+          ))}
+        </select>
+      </div>
+
       {canonical ? <div className="rounded-[var(--radius-md)] border border-[var(--up-border)] bg-[var(--up-soft)] p-3">
         <div className="flex flex-wrap items-center gap-2">
-          <FAStatusPill tone="up">正式 accepted canonical</FAStatusPill>
+          <FAStatusPill tone="up">正式 accepted canonical · {canonical.state_scope}</FAStatusPill>
           <span className="fa-num text-[length:var(--type-caption)] text-[var(--fg-4)]">head v{canonical.head_version} · {shortId(canonical.state.state_id)}</span>
         </div>
         <div className="mt-2 fa-card-title text-[var(--fg-1)]">{thesis(canonical.state)}</div>
@@ -87,7 +111,7 @@ export function AnalysisMemoryPanel({ allowReview = false }: { allowReview?: boo
           {candidates.data.length ? candidates.data.map((candidate) => (
             <div key={candidate.state_id} className={`rounded-[var(--radius-md)] border p-3 ${candidate.state_kind === "blocked" ? "border-[var(--down-border)] bg-[var(--down-soft)]" : "border-[var(--warn-border)] bg-[var(--warn-soft)]"}`}>
               <div className="flex flex-wrap items-center gap-2">
-                <FAStatusPill tone={candidate.state_kind === "blocked" ? "down" : "warn"}>{candidate.state_kind === "blocked" ? "blocked / 不可采用" : "candidate / 待复核"}</FAStatusPill>
+                <FAStatusPill tone={candidate.state_kind === "blocked" ? "down" : "warn"}>{candidate.state_kind === "blocked" ? "blocked / 不可采用" : "candidate / 待复核"} · {candidate.state_scope}</FAStatusPill>
                 <span className="fa-num text-[length:var(--type-caption)] text-[var(--fg-4)]">{shortId(candidate.state_id)} · run {shortId(candidate.lineage.run_id)}</span>
               </div>
               <div className="mt-2 text-[length:var(--type-body)] text-[var(--fg-2)]">{thesis(candidate)}</div>
@@ -129,7 +153,7 @@ export function AnalysisMemoryPanel({ allowReview = false }: { allowReview?: boo
               ))}
             </div>
             <div className="mt-2 break-all text-[length:var(--type-caption)] text-[var(--fg-4)]">
-              run {shortId(latestBundle.run_id)} · canonical {shortId(latestBundle.canonical_state_id)} · sources {latestBundle.source_refs.length} · artifact {latestBundle.artifact_path}
+              scope {latestBundle.state_scope} · run {shortId(latestBundle.run_id)} · canonical {shortId(latestBundle.canonical_state_id)} · sources {latestBundle.source_refs.length} · artifact {latestBundle.artifact_path}
             </div>
           </div>
         ) : <div className="fa-faint-text">暂无 ContextBundle metadata；不会从 GET 触发重新生成。</div>}

--- a/apps/frontend-web/src/hooks/useAnalysisMemory.ts
+++ b/apps/frontend-web/src/hooks/useAnalysisMemory.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { acceptAnalysisMemoryCandidate, fetchAnalysisMemory } from "@/adapters/analysisMemory";
-import type { AnalysisMemorySnapshot } from "@/types/analysis-memory";
+import type { AnalysisMemorySnapshot, AnalysisStateScope } from "@/types/analysis-memory";
 
-export function useAnalysisMemory(asset = "XAUUSD") {
+export function useAnalysisMemory(stateScope: AnalysisStateScope, asset = "XAUUSD") {
   const [data, setData] = useState<AnalysisMemorySnapshot | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -13,33 +13,44 @@ export function useAnalysisMemory(asset = "XAUUSD") {
     setIsLoading(true);
     setError(null);
     try {
-      setData(await fetchAnalysisMemory(asset));
+      setData(await fetchAnalysisMemory(stateScope, asset));
     } catch (cause) {
       setError(cause instanceof Error ? cause : new Error("Analysis Memory 加载失败"));
     } finally {
       setIsLoading(false);
     }
-  }, [asset]);
+  }, [asset, stateScope]);
 
-  useEffect(() => { void refetch(); }, [refetch]);
+  useEffect(() => {
+    setData(null);
+    void refetch();
+  }, [refetch]);
+
+  const scopedData = data
+    && data.candidates.state_scope === stateScope
+    && data.bundles.state_scope === stateScope
+    && (!data.canonical || data.canonical.state_scope === stateScope)
+    ? data
+    : null;
 
   return {
-    data,
-    isLoading,
+    data: scopedData,
+    isLoading: isLoading || (data !== null && scopedData === null),
     error,
     actionCandidateId,
     refetch,
     acceptCandidate: async (params: { candidateId: string; token: string; actor: string; reason: string }) => {
-      if (!data) return;
-      if (!data.canonical) throw new Error("accepted canonical 不可用，不能推进候选");
+      if (!scopedData) return;
+      if (!scopedData.canonical) throw new Error("accepted canonical 不可用，不能推进候选");
       setActionCandidateId(params.candidateId);
       setError(null);
       try {
         await acceptAnalysisMemoryCandidate({
           ...params,
           requestId: crypto.randomUUID(),
-          canonicalStateId: data.canonical.state.state_id,
-          headVersion: data.canonical.head_version,
+          canonicalStateId: scopedData.canonical.state.state_id,
+          headVersion: scopedData.canonical.head_version,
+          stateScope,
         });
         await refetch();
       } catch (cause) {

--- a/apps/frontend-web/src/hooks/useAnalysisMemory.ts
+++ b/apps/frontend-web/src/hooks/useAnalysisMemory.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { acceptAnalysisMemoryCandidate, fetchAnalysisMemory } from "@/adapters/analysisMemory";
 import type { AnalysisMemorySnapshot, AnalysisStateScope } from "@/types/analysis-memory";
@@ -8,22 +8,43 @@ export function useAnalysisMemory(stateScope: AnalysisStateScope, asset = "XAUUS
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [actionCandidateId, setActionCandidateId] = useState<string | null>(null);
+  const requestGenerationRef = useRef(0);
+  const currentScopeRef = useRef(stateScope);
+  const currentAssetRef = useRef(asset);
+  currentScopeRef.current = stateScope;
+  currentAssetRef.current = asset;
 
   const refetch = useCallback(async () => {
+    const requestedScope = stateScope;
+    const requestedAsset = asset;
+    if (currentScopeRef.current !== requestedScope || currentAssetRef.current !== requestedAsset) return;
+    const requestGeneration = ++requestGenerationRef.current;
+    const isCurrentRequest = () => (
+      requestGenerationRef.current === requestGeneration
+      && currentScopeRef.current === requestedScope
+      && currentAssetRef.current === requestedAsset
+    );
     setIsLoading(true);
     setError(null);
     try {
-      setData(await fetchAnalysisMemory(stateScope, asset));
+      const nextData = await fetchAnalysisMemory(requestedScope, requestedAsset);
+      if (!isCurrentRequest()) return;
+      setData(nextData);
     } catch (cause) {
+      if (!isCurrentRequest()) return;
       setError(cause instanceof Error ? cause : new Error("Analysis Memory 加载失败"));
     } finally {
-      setIsLoading(false);
+      if (isCurrentRequest()) setIsLoading(false);
     }
   }, [asset, stateScope]);
 
   useEffect(() => {
     setData(null);
+    setActionCandidateId(null);
     void refetch();
+    return () => {
+      requestGenerationRef.current += 1;
+    };
   }, [refetch]);
 
   const scopedData = data
@@ -40,8 +61,11 @@ export function useAnalysisMemory(stateScope: AnalysisStateScope, asset = "XAUUS
     actionCandidateId,
     refetch,
     acceptCandidate: async (params: { candidateId: string; token: string; actor: string; reason: string }) => {
+      if (currentScopeRef.current !== stateScope || currentAssetRef.current !== asset) return;
       if (!scopedData) return;
       if (!scopedData.canonical) throw new Error("accepted canonical 不可用，不能推进候选");
+      const acceptScope = stateScope;
+      const acceptAsset = asset;
       setActionCandidateId(params.candidateId);
       setError(null);
       try {
@@ -50,13 +74,19 @@ export function useAnalysisMemory(stateScope: AnalysisStateScope, asset = "XAUUS
           requestId: crypto.randomUUID(),
           canonicalStateId: scopedData.canonical.state.state_id,
           headVersion: scopedData.canonical.head_version,
-          stateScope,
+          stateScope: acceptScope,
         });
-        await refetch();
+        if (currentScopeRef.current === acceptScope && currentAssetRef.current === acceptAsset) {
+          await refetch();
+        }
       } catch (cause) {
-        setError(cause instanceof Error ? cause : new Error("候选复核失败"));
+        if (currentScopeRef.current === acceptScope && currentAssetRef.current === acceptAsset) {
+          setError(cause instanceof Error ? cause : new Error("候选复核失败"));
+        }
       } finally {
-        setActionCandidateId(null);
+        if (currentScopeRef.current === acceptScope && currentAssetRef.current === acceptAsset) {
+          setActionCandidateId(null);
+        }
       }
     },
   };

--- a/apps/frontend-web/src/types/analysis-memory.ts
+++ b/apps/frontend-web/src/types/analysis-memory.ts
@@ -1,6 +1,8 @@
 export type AnalysisStateKind = "accepted_canonical" | "candidate" | "blocked";
+export type AnalysisStateScope = "intraday" | "daily_close" | "weekly_fundamental";
 
 export interface AnalysisTransitionView {
+  state_scope: AnalysisStateScope;
   transition_id: string;
   from_state_id: string | null;
   to_state_id: string;
@@ -26,6 +28,7 @@ export interface AnalysisStateView {
   state_id: string;
   state_kind: AnalysisStateKind;
   asset: string;
+  state_scope: AnalysisStateScope;
   as_of: string;
   previous_state_id: string | null;
   quality_gate_action: string;
@@ -40,14 +43,18 @@ export interface AnalysisStateView {
 }
 
 export interface CanonicalStateResponse {
+  schema_version: "analysis_memory_read.v2";
   asset: string;
+  state_scope: AnalysisStateScope;
   head_version: number;
   state: AnalysisStateView;
   canonical_chain: AnalysisStateView[];
 }
 
 export interface CandidateStatePage {
+  schema_version: "analysis_memory_read.v2";
   asset: string;
+  state_scope: AnalysisStateScope;
   data: AnalysisStateView[];
   pagination: { page: number; page_size: number; total_items: number; total_pages: number };
 }
@@ -61,9 +68,11 @@ export interface ContextBlockMetadata {
 }
 
 export interface ContextBundleMetadata {
+  schema_version: string;
   bundle_id: string;
   content_hash: string;
   asset: string;
+  state_scope: AnalysisStateScope;
   run_id: string;
   canonical_state_id: string;
   cutoff_at: string;
@@ -78,7 +87,9 @@ export interface ContextBundleMetadata {
 }
 
 export interface ContextBundleMetadataPage {
+  schema_version: "analysis_memory_read.v2";
   asset: string;
+  state_scope: AnalysisStateScope;
   data: ContextBundleMetadata[];
   pagination: { page: number; page_size: number; total_items: number; total_pages: number };
 }

--- a/apps/output/analysis_state_review.py
+++ b/apps/output/analysis_state_review.py
@@ -47,6 +47,7 @@ def write_analysis_state_review(
         "outputs",
         "analysis_state_reviews",
         _validate_path_component("asset", str(payload["asset"])),
+        _validate_path_component("state_scope", str(payload["state_scope"])),
         _validate_path_component("run_id", str(payload["run_id"])),
         f"{_validate_path_component('artifact_id', artifact_id)}.json",
     )

--- a/apps/output/context_bundle.py
+++ b/apps/output/context_bundle.py
@@ -9,7 +9,11 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from apps.analysis.context_bundle.schemas import AnalysisContextBundle
+from apps.analysis.context_bundle.schemas import (
+    CONTEXT_BUNDLE_SCHEMA_VERSION,
+    LEGACY_CONTEXT_BUNDLE_SCHEMA_VERSION,
+    AnalysisContextBundle,
+)
 from apps.output.artifacts import _validate_path_component
 from apps.runtime.immutable_artifact import (
     ImmutableArtifactConflictError,
@@ -41,11 +45,14 @@ def write_context_bundle(
     bundle: AnalysisContextBundle | dict[str, Any],
 ) -> ContextBundleWriteResult:
     validated = _validate_bundle(bundle)
+    if validated.schema_version != CONTEXT_BUNDLE_SCHEMA_VERSION or validated.state_scope is None:
+        raise ValueError("context bundle writer only persists scoped v2 bundles")
     storage_dir = Path(storage_root).resolve()
     relative = Path(
         "outputs",
         "context_bundles",
         _validate_path_component("asset", validated.asset),
+        _validate_path_component("state_scope", validated.state_scope),
         _validate_path_component("run_id", validated.run_id),
         f"{_validate_path_component('bundle_id', validated.bundle_id)}.json",
     )
@@ -74,6 +81,7 @@ def write_context_bundle(
             "bundle_id": validated.bundle_id,
             "content_hash": validated.content_hash,
             "asset": validated.asset,
+            "state_scope": validated.state_scope,
             "run_id": validated.run_id,
             "canonical_state_id": validated.canonical_state_id,
             "estimated_tokens": validated.budget_trace.estimated_tokens,
@@ -103,13 +111,25 @@ def load_context_bundle(
         bundle = AnalysisContextBundle.model_validate(payload)
     except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
         raise ContextBundleLoadError("context bundle failed JSON/schema/hash validation") from exc
-    expected = (
-        "outputs",
-        "context_bundles",
-        bundle.asset,
-        bundle.run_id,
-        f"{bundle.bundle_id}.json",
-    )
+    if bundle.schema_version == LEGACY_CONTEXT_BUNDLE_SCHEMA_VERSION:
+        expected = (
+            "outputs",
+            "context_bundles",
+            bundle.asset,
+            bundle.run_id,
+            f"{bundle.bundle_id}.json",
+        )
+    else:
+        if bundle.state_scope is None:  # pragma: no cover - schema contract
+            raise ContextBundleLoadError("scoped context bundle is missing state_scope")
+        expected = (
+            "outputs",
+            "context_bundles",
+            bundle.asset,
+            bundle.state_scope,
+            bundle.run_id,
+            f"{bundle.bundle_id}.json",
+        )
     if relative.parts != expected:
         raise ContextBundleLoadError("context bundle payload identity does not match path")
     return bundle
@@ -128,7 +148,7 @@ def _validate_relative_path(value: str) -> Path:
         raise ContextBundleLoadError("context bundle path must be storage-relative")
     if any(part in {"", ".", ".."} for part in path.parts):
         raise ContextBundleLoadError("context bundle path contains unsafe segments")
-    if len(path.parts) != 5 or path.parts[:2] != ("outputs", "context_bundles"):
+    if len(path.parts) not in {5, 6} or path.parts[:2] != ("outputs", "context_bundles"):
         raise ContextBundleLoadError("context bundle path has an invalid shape")
     if path.suffix != ".json":
         raise ContextBundleLoadError("context bundle artifact must be JSON")

--- a/apps/worker/composite_analysis_pipeline.py
+++ b/apps/worker/composite_analysis_pipeline.py
@@ -48,6 +48,17 @@ from apps.worker.composite_state_shadow import (
 logger = logging.getLogger(__name__)
 
 
+def _safe_requested_state_scope(shadow_input: dict[str, Any] | None) -> str | None:
+    value = shadow_input.get("state_scope") if isinstance(shadow_input, dict) else None
+    if isinstance(value, str) and value in {
+        "intraday",
+        "daily_close",
+        "weekly_fundamental",
+    }:
+        return value
+    return None
+
+
 def evaluate_quality_gate(**kwargs: Any) -> Any:
     from apps.worker import runner
 
@@ -101,8 +112,9 @@ def run_composite_analysis_pipeline(
             logger.exception("State-delta shadow setup failed; continuing legacy output")
             shadow_runtime = None
             shadow_trace = {
-                "schema_version": "composite_state_shadow.v1",
+                "schema_version": "composite_state_shadow.v2",
                 "mode": STATE_DELTA_CONTEXT_MODE,
+                "requested_state_scope": _safe_requested_state_scope(state_shadow_input),
                 "status": "shadow_setup_failed",
                 "model_invocation": "skipped",
                 "shadow_review_status": "needs_review",

--- a/apps/worker/composite_state_shadow.py
+++ b/apps/worker/composite_state_shadow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
 from time import perf_counter
 from typing import Any, Callable, Literal
@@ -14,9 +14,13 @@ from pydantic import BaseModel
 from apps.analysis.context_bundle import AnalysisContextBundle, assemble_context_bundle
 from apps.analysis.figure_facts import project_confirmed_evidence
 from apps.analysis.state import (
-    AnalysisStateDocument,
+    ANALYSIS_STATE_MACHINE_VERSION,
+    AnalysisStateDocumentV1,
+    AnalysisStateDocumentV11,
+    StateScope,
     TransitionCandidate,
-    review_transition_candidate,
+    parse_analysis_state_document,
+    review_transition_candidate_scoped,
 )
 from apps.output.context_bundle import ContextBundleWriteResult, write_context_bundle
 
@@ -32,7 +36,11 @@ StateDeltaAnalyzer = Callable[[AnalysisContextBundle], TransitionCandidate | dic
 class CompositeStateShadowRuntime:
     bundle: AnalysisContextBundle
     artifact: ContextBundleWriteResult
-    previous_state: AnalysisStateDocument
+    previous_state: AnalysisStateDocumentV1 | AnalysisStateDocumentV11
+    state_scope: StateScope
+    state_machine_version: str
+    session: str
+    trade_date: date
     available_evidence_refs: list[dict[str, Any]]
     no_material_delta: bool
     assembly_latency_ms: int
@@ -55,7 +63,24 @@ def prepare_composite_state_shadow(
     """Build and persist exactly one bundle for one shadow composite run."""
 
     started = perf_counter()
-    previous_state = AnalysisStateDocument.model_validate(shadow_input["canonical_state"])
+    state_scope = _state_scope(shadow_input.get("state_scope"))
+    canonical_payload = shadow_input["canonical_state"]
+    if isinstance(canonical_payload, dict) and "schema_version" not in canonical_payload:
+        canonical_payload = {**canonical_payload, "schema_version": "1.0"}
+    previous_state = parse_analysis_state_document(canonical_payload)
+    if isinstance(previous_state, AnalysisStateDocumentV11):
+        if previous_state.state_scope != state_scope:
+            raise ValueError("shadow canonical state belongs to a different state_scope")
+        state_machine_version = previous_state.state_machine_version
+        session = previous_state.session
+        trade_date = previous_state.trade_date
+    else:
+        if state_scope != "daily_close":
+            raise ValueError("legacy v1 canonical state is only valid for daily_close shadow")
+        state_machine_version = ANALYSIS_STATE_MACHINE_VERSION
+        session = str(shadow_input.get("expected_session") or "daily_close").strip()
+        if not session:
+            raise ValueError("shadow session must not be blank")
     confirmed_facts = []
     for raw_fact in shadow_input.get("figure_facts") or []:
         confirmed = project_confirmed_evidence(raw_fact)
@@ -63,9 +88,12 @@ def prepare_composite_state_shadow(
             confirmed_facts.append(confirmed.model_dump(mode="json"))
     cutoff_at = _datetime_value(shadow_input.get("cutoff_at") or created_at)
     assembled_at = _datetime_value(shadow_input.get("assembled_at") or created_at)
+    if isinstance(previous_state, AnalysisStateDocumentV1):
+        trade_date = cutoff_at.date()
     bundle = assemble_context_bundle(
         run_id=run_id,
         asset=previous_state.asset,
+        state_scope=state_scope,
         canonical_state_id=str(shadow_input["canonical_state_id"]),
         canonical_state=previous_state.model_dump(mode="json"),
         evidence=list(shadow_input.get("evidence") or []),
@@ -95,6 +123,10 @@ def prepare_composite_state_shadow(
         bundle=bundle,
         artifact=artifact,
         previous_state=previous_state,
+        state_scope=state_scope,
+        state_machine_version=state_machine_version,
+        session=session,
+        trade_date=trade_date,
         available_evidence_refs=available_refs,
         no_material_delta=no_material_delta,
         assembly_latency_ms=max(0, round((perf_counter() - started) * 1000)),
@@ -135,11 +167,15 @@ def execute_composite_state_shadow(
             else raw_candidate
         )
         candidate = TransitionCandidate.model_validate(candidate_payload)
-        review = review_transition_candidate(
+        review = review_transition_candidate_scoped(
             candidate=candidate,
             previous_state_id=runtime.bundle.canonical_state_id,
             previous_state=runtime.previous_state,
             available_evidence_refs=runtime.available_evidence_refs,
+            state_scope=runtime.state_scope,
+            state_machine_version=runtime.state_machine_version,
+            session=runtime.session,
+            trade_date=runtime.trade_date,
         )
     except Exception as exc:
         return {
@@ -196,8 +232,11 @@ def finalize_composite_state_shadow(
 
 def _base_trace(runtime: CompositeStateShadowRuntime) -> dict[str, Any]:
     return {
-        "schema_version": "composite_state_shadow.v1",
+        "schema_version": "composite_state_shadow.v2",
         "mode": STATE_DELTA_CONTEXT_MODE,
+        "asset": runtime.bundle.asset,
+        "state_scope": runtime.state_scope,
+        "canonical_state_id": runtime.bundle.canonical_state_id,
         "bundle_id": runtime.bundle.bundle_id,
         "bundle_content_hash": runtime.bundle.content_hash,
         "bundle_path": runtime.artifact.storage_relative_path,
@@ -215,3 +254,10 @@ def _datetime_value(value: Any) -> datetime:
     if parsed.tzinfo is None or parsed.utcoffset() is None:
         raise ValueError("shadow timestamps must be timezone-aware")
     return parsed.astimezone(UTC)
+
+
+def _state_scope(value: Any) -> StateScope:
+    normalized = str(value or "").strip()
+    if normalized not in {"intraday", "daily_close", "weekly_fundamental"}:
+        raise ValueError("shadow state_scope is required and must be valid")
+    return normalized  # type: ignore[return-value]

--- a/database/queries/analysis_state_observability.py
+++ b/database/queries/analysis_state_observability.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from database.models.analysis import AgentOutput, AnalysisSnapshot, FinalAnalysisResult
 from database.models.analysis_state import AnalysisState, AnalysisStateHead, AnalysisTransition
+
+if TYPE_CHECKING:
+    from apps.analysis.state.schemas import StateScope
 
 
 def get_state(session: Session, state_id: str) -> AnalysisState | None:
@@ -14,7 +19,23 @@ def get_state(session: Session, state_id: str) -> AnalysisState | None:
 
 
 def get_head(session: Session, asset: str) -> AnalysisStateHead | None:
-    return session.scalar(select(AnalysisStateHead).where(AnalysisStateHead.asset == asset))
+    """Legacy daily-close lookup; scoped callers must use get_head_scoped."""
+
+    return get_head_scoped(session, asset=asset, state_scope="daily_close")
+
+
+def get_head_scoped(
+    session: Session,
+    *,
+    asset: str,
+    state_scope: StateScope,
+) -> AnalysisStateHead | None:
+    return session.scalar(
+        select(AnalysisStateHead).where(
+            AnalysisStateHead.asset == asset,
+            AnalysisStateHead.state_scope == state_scope,
+        )
+    )
 
 
 def get_transition(session: Session, transition_id: str) -> AnalysisTransition | None:
@@ -70,11 +91,31 @@ def list_candidate_states_page(
     page: int,
     page_size: int,
 ) -> tuple[list[AnalysisState], int]:
-    """List non-canonical, non-publishable states without mutating read state."""
+    """Legacy daily-close candidate lookup."""
+
+    return list_candidate_states_page_scoped(
+        session,
+        asset=asset,
+        state_scope="daily_close",
+        page=page,
+        page_size=page_size,
+    )
+
+
+def list_candidate_states_page_scoped(
+    session: Session,
+    *,
+    asset: str,
+    state_scope: StateScope,
+    page: int,
+    page_size: int,
+) -> tuple[list[AnalysisState], int]:
+    """List one scope's non-canonical, non-publishable states."""
 
     canonical_ids = select(AnalysisStateHead.canonical_state_id)
     predicate = (
         AnalysisState.asset == asset,
+        AnalysisState.state_scope == state_scope,
         AnalysisState.publish_allowed.is_(False),
         AnalysisState.id.not_in(canonical_ids),
     )

--- a/tests/analysis/test_context_bundle.py
+++ b/tests/analysis/test_context_bundle.py
@@ -39,8 +39,14 @@ def _bundle(**overrides):
     values = {
         "run_id": "run-67",
         "asset": "XAUUSD",
+        "state_scope": "daily_close",
         "canonical_state_id": "state-66",
-        "canonical_state": {"core_thesis": "等待突破", "key_levels": [4000, 4126]},
+        "canonical_state": {
+            "asset": "XAUUSD",
+            "state_scope": "daily_close",
+            "core_thesis": "等待突破",
+            "key_levels": [4000, 4126],
+        },
         "evidence": [
             _evidence(
                 "market",
@@ -128,6 +134,8 @@ def test_per_source_cursor_keeps_late_business_evidence() -> None:
 def test_history_bodies_are_omitted_but_lineage_and_summary_remain() -> None:
     bundle = _bundle(
         canonical_state={
+            "asset": "XAUUSD",
+            "state_scope": "daily_close",
             "one_line_conclusion": "维持等待",
             "previous_report": "不应进入 bundle" * 100,
             "previous_analysis_report": {"body": "过期日报正文" * 100},
@@ -184,7 +192,11 @@ def test_budget_defers_newest_evidence_without_skipping_its_cursor() -> None:
 def test_budget_fails_closed_when_canonical_state_alone_is_too_large() -> None:
     with pytest.raises(ContextBundleBudgetExceeded) as exc_info:
         _bundle(
-            canonical_state={"thesis": "x" * 2_000},
+            canonical_state={
+                "asset": "XAUUSD",
+                "state_scope": "daily_close",
+                "thesis": "x" * 2_000,
+            },
             evidence=[],
             facts=[],
             budget_tokens=10,
@@ -252,3 +264,27 @@ def test_bundle_rejects_forged_budget_metrics() -> None:
 
     with pytest.raises(ValidationError, match="estimated_tokens"):
         type(bundle).model_validate(payload)
+
+
+def test_scope_is_part_of_bundle_hash_and_identity() -> None:
+    daily = _bundle()
+    intraday = _bundle(
+        state_scope="intraday",
+        canonical_state={
+            "asset": "XAUUSD",
+            "state_scope": "intraday",
+            "core_thesis": "等待突破",
+            "key_levels": [4000, 4126],
+        },
+    )
+
+    assert daily.schema_version == "analysis_context_bundle.v2"
+    assert daily.state_scope == "daily_close"
+    assert intraday.state_scope == "intraday"
+    assert intraday.content_hash != daily.content_hash
+    assert intraday.bundle_id != daily.bundle_id
+
+
+def test_bundle_rejects_cross_scope_canonical_state() -> None:
+    with pytest.raises(ValueError, match="different state_scope"):
+        _bundle(state_scope="intraday")

--- a/tests/api/test_analysis_memory_api.py
+++ b/tests/api/test_analysis_memory_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import uuid
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
@@ -16,14 +17,21 @@ from sqlalchemy.pool import StaticPool
 os.environ["FINANCE_AGENT_DISABLE_BACKGROUND_JOBS"] = "1"
 
 from apps.analysis.context_bundle import assemble_context_bundle
+from apps.analysis.context_bundle.schemas import compute_bundle_content_hash
 from apps.analysis.state import (
+    ANALYSIS_STATE_MACHINE_VERSION,
     AnalysisStateDocument,
+    AnalysisStateDocumentV11,
     AnalysisTransitionDocument,
+    AnalysisTransitionDocumentV11,
     StateChange,
+    StateScope,
     StateMaterializationAuthority,
     TransitionAction,
     advance_canonical_head,
+    advance_canonical_head_scoped,
     append_analysis_state,
+    append_analysis_state_scoped,
 )
 from apps.api import main as api_main
 from apps.api.services import analysis_memory_service
@@ -81,6 +89,60 @@ def _transition(*, action: TransitionAction = TransitionAction.MAINTAIN) -> Anal
     )
 
 
+def _scoped_document(
+    *,
+    state_scope: StateScope,
+    thesis: str,
+    as_of: datetime,
+    snapshot_id: str,
+) -> AnalysisStateDocumentV11:
+    return AnalysisStateDocumentV11(
+        state_scope=state_scope,
+        state_machine_version=ANALYSIS_STATE_MACHINE_VERSION,
+        session=state_scope,
+        trade_date=as_of.date(),
+        asset="XAUUSD",
+        as_of=as_of,
+        market_stage="direction_decision",
+        core_thesis=thesis,
+        net_bias="mixed_bullish",
+        dominant_drivers=[
+            {
+                "driver_id": "real_yield",
+                "label": "real yield",
+                "direction": "mixed",
+            }
+        ],
+        key_levels=[{"value": 4126.63, "role": "resistance", "source": "market"}],
+        scenario_states=[
+            {"scenario_id": "base", "condition": "range holds", "status": "active"}
+        ],
+        evidence_cursors={"market": {"evidence_id": snapshot_id}},
+        input_snapshot_ids={"market": snapshot_id},
+        source_refs=[{"source": "market", "snapshot_id": snapshot_id}],
+    )
+
+
+def _scoped_transition(
+    *,
+    state_scope: StateScope,
+    action: TransitionAction = TransitionAction.MAINTAIN,
+) -> AnalysisTransitionDocumentV11:
+    return AnalysisTransitionDocumentV11(
+        state_scope=state_scope,
+        summary="reviewable scoped state transition",
+        changes=[
+            StateChange(
+                target="core_thesis",
+                action=action,
+                reason="new persisted evidence",
+                evidence_refs=[{"source": "market", "snapshot_id": f"{state_scope}-snapshot"}],
+            )
+        ],
+        evidence_refs=[{"source": "market", "snapshot_id": f"{state_scope}-snapshot"}],
+    )
+
+
 def _accepted_authority() -> StateMaterializationAuthority:
     return StateMaterializationAuthority(
         quality_gate_action="pass",
@@ -110,6 +172,65 @@ def _seed_root(db: Session) -> AnalysisState:
     )
     db.flush()
     return root
+
+
+def _seed_scoped_root(db: Session, *, state_scope: StateScope) -> AnalysisState:
+    snapshot_id = f"{state_scope}-snapshot"
+    root = append_analysis_state_scoped(
+        db,
+        state_scope=state_scope,
+        document=_scoped_document(
+            state_scope=state_scope,
+            thesis=f"{state_scope} accepted root",
+            as_of=NOW,
+            snapshot_id=snapshot_id,
+        ),
+        transition=_scoped_transition(state_scope=state_scope),
+        authority=_accepted_authority(),
+        previous_state_id=None,
+        task_run_id=f"run-{state_scope}",
+    )
+    advance_canonical_head_scoped(
+        db,
+        asset="XAUUSD",
+        state_scope=state_scope,
+        new_state_id=root.id,
+        expected_state_id=None,
+        expected_version=0,
+        authority=_accepted_authority(),
+    )
+    db.flush()
+    return root
+
+
+def _seed_scoped_candidate(
+    db: Session,
+    *,
+    root: AnalysisState,
+    state_scope: StateScope,
+) -> AnalysisState:
+    candidate = append_analysis_state_scoped(
+        db,
+        state_scope=state_scope,
+        document=_scoped_document(
+            state_scope=state_scope,
+            thesis=f"{state_scope} candidate",
+            as_of=NOW + timedelta(hours=1),
+            snapshot_id=f"{state_scope}-candidate",
+        ),
+        transition=_scoped_transition(
+            state_scope=state_scope,
+            action=TransitionAction.STRENGTHEN,
+        ),
+        authority=StateMaterializationAuthority(
+            quality_gate_action="manual_review",
+            publish_allowed=False,
+        ),
+        previous_state_id=root.id,
+        task_run_id=f"run-{state_scope}-candidate",
+    )
+    db.flush()
+    return candidate
 
 
 def _seed_candidate_lineage(db: Session, *, run_id: str = "run-71") -> tuple[str, str]:
@@ -228,18 +349,29 @@ def test_get_routes_are_read_only_and_isolate_canonical_from_candidates(db: Sess
     )
     client = _client(db)
     try:
-        canonical = client.get("/api/analysis-memory/assets/XAUUSD/canonical")
+        canonical = client.get(
+            "/api/analysis-memory/assets/XAUUSD/canonical",
+            params={"stateScope": "daily_close"},
+        )
         candidates = client.get(
             "/api/analysis-memory/assets/XAUUSD/candidates",
-            params={"page": 1, "pageSize": 10},
+            params={"stateScope": "daily_close", "page": 1, "pageSize": 10},
         )
-        state = client.get(f"/api/analysis-memory/states/{candidate.id}")
+        state = client.get(
+            f"/api/analysis-memory/states/{candidate.id}",
+            params={"stateScope": "daily_close"},
+        )
         transition_id = state.json()["transition"]["transition_id"]
-        transition = client.get(f"/api/analysis-memory/transitions/{transition_id}")
+        transition = client.get(
+            f"/api/analysis-memory/transitions/{transition_id}",
+            params={"stateScope": "daily_close"},
+        )
     finally:
         api_main.app.dependency_overrides.pop(get_db, None)
 
     assert canonical.status_code == 200
+    assert canonical.json()["schema_version"] == "analysis_memory_read.v2"
+    assert canonical.json()["state_scope"] == "daily_close"
     assert canonical.json()["state"]["state_kind"] == "accepted_canonical"
     assert canonical.json()["state"]["state_id"] == root.id
     canonical_ids = {item["state_id"] for item in canonical.json()["canonical_chain"]}
@@ -254,6 +386,7 @@ def test_get_routes_are_read_only_and_isolate_canonical_from_candidates(db: Sess
         "total_pages": 1,
     }
     assert transition.status_code == 200
+    assert transition.json()["state_scope"] == "daily_close"
     assert transition.json()["to_state_id"] == candidate.id
     after = (
         db.scalar(select(func.count()).select_from(AnalysisState)),
@@ -296,6 +429,7 @@ def test_candidate_review_appends_accepted_state_transition_and_real_artifact(
                 "request_id": "review-71-001",
                 "expected_canonical_state_id": root.id,
                 "expected_head_version": 1,
+                "state_scope": "daily_close",
             },
         )
         wrong = client.post(
@@ -308,6 +442,7 @@ def test_candidate_review_appends_accepted_state_transition_and_real_artifact(
                 "request_id": "review-71-001",
                 "expected_canonical_state_id": root.id,
                 "expected_head_version": 1,
+                "state_scope": "daily_close",
             },
         )
         response = client.post(
@@ -320,6 +455,7 @@ def test_candidate_review_appends_accepted_state_transition_and_real_artifact(
                 "request_id": "review-71-001",
                 "expected_canonical_state_id": root.id,
                 "expected_head_version": 1,
+                "state_scope": "daily_close",
             },
         )
     finally:
@@ -343,6 +479,9 @@ def test_candidate_review_appends_accepted_state_transition_and_real_artifact(
     artifact_path = tmp_path / "storage" / artifact["artifact_path"]
     assert artifact_path.is_file()
     artifact_payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert artifact_payload["schema_version"] == "analysis_state_review.v2"
+    assert artifact_payload["state_scope"] == "daily_close"
+    assert "/daily_close/" in artifact["artifact_path"]
     assert artifact_payload["quality_gate"]["action"] == "pass"
     assert artifact_payload["agent_loop"]["accepted_output"]["snapshot_id"] == "snapshot-71"
     assert artifact["artifact_id"] != artifact["transition_id"]
@@ -378,6 +517,7 @@ def test_candidate_review_rejects_missing_persisted_authority_and_stale_head(
         "request_id": "review-invalid",
         "expected_canonical_state_id": root.id,
         "expected_head_version": 1,
+        "state_scope": "daily_close",
     }
     try:
         missing_lineage = client.post(
@@ -406,8 +546,13 @@ def test_context_bundle_metadata_is_validated_paginated_and_payload_free(
     bundle = assemble_context_bundle(
         run_id="run-71",
         asset="XAUUSD",
+        state_scope="daily_close",
         canonical_state_id="state-root",
-        canonical_state={"core_thesis": "accepted root"},
+        canonical_state={
+            "asset": "XAUUSD",
+            "state_scope": "daily_close",
+            "core_thesis": "accepted root",
+        },
         evidence=[
             {
                 "source": "market",
@@ -427,19 +572,196 @@ def test_context_bundle_metadata_is_validated_paginated_and_payload_free(
     client = TestClient(api_main.app)
     page = client.get(
         "/api/analysis-memory/assets/XAUUSD/context-bundles",
-        params={"page": 1, "pageSize": 10},
+        params={"stateScope": "daily_close", "page": 1, "pageSize": 10},
     )
-    detail = client.get(f"/api/analysis-memory/context-bundles/{bundle.bundle_id}")
+    detail = client.get(
+        f"/api/analysis-memory/context-bundles/{bundle.bundle_id}",
+        params={"stateScope": "daily_close"},
+    )
+    wrong_scope = client.get(
+        f"/api/analysis-memory/context-bundles/{bundle.bundle_id}",
+        params={"stateScope": "intraday"},
+    )
 
     assert page.status_code == 200
     assert page.json()["pagination"]["total_items"] == 1
     metadata = detail.json()
     assert detail.status_code == 200
     assert metadata["estimated_tokens"] == bundle.budget_trace.estimated_tokens
+    assert metadata["state_scope"] == "daily_close"
     assert metadata["blocks"][1]["name"] == "delta_evidence"
     assert "payload" not in metadata["blocks"][1]
     assert metadata["source_refs"] == bundle.source_refs
     assert metadata["artifact_path"].startswith("outputs/context_bundles/")
-    invalid = client.get("/api/analysis-memory/context-bundles/not-a-uuid")
+    assert wrong_scope.status_code == 404
+    invalid = client.get(
+        "/api/analysis-memory/context-bundles/not-a-uuid",
+        params={"stateScope": "daily_close"},
+    )
     assert invalid.status_code == 422
     assert invalid.json()["detail"]["code"] == "ANALYSIS_MEMORY_INVALID"
+
+
+def test_api_requires_valid_scope_and_isolates_all_three_heads(db: Session) -> None:
+    daily_root = _seed_root(db)
+    intraday_root = _seed_scoped_root(db, state_scope="intraday")
+    weekly_root = _seed_scoped_root(db, state_scope="weekly_fundamental")
+    candidates = {
+        "daily_close": _seed_candidate(db, root=daily_root),
+        "intraday": _seed_scoped_candidate(
+            db,
+            root=intraday_root,
+            state_scope="intraday",
+        ),
+        "weekly_fundamental": _seed_scoped_candidate(
+            db,
+            root=weekly_root,
+            state_scope="weekly_fundamental",
+        ),
+    }
+    roots = {
+        "daily_close": daily_root,
+        "intraday": intraday_root,
+        "weekly_fundamental": weekly_root,
+    }
+    client = _client(db)
+    try:
+        missing = client.get("/api/analysis-memory/assets/XAUUSD/canonical")
+        invalid = client.get(
+            "/api/analysis-memory/assets/XAUUSD/canonical",
+            params={"stateScope": "monthly"},
+        )
+        responses = {}
+        for state_scope in roots:
+            canonical = client.get(
+                "/api/analysis-memory/assets/XAUUSD/canonical",
+                params={"stateScope": state_scope},
+            )
+            candidate_page = client.get(
+                "/api/analysis-memory/assets/XAUUSD/candidates",
+                params={"stateScope": state_scope, "page": 1, "pageSize": 20},
+            )
+            responses[state_scope] = (canonical, candidate_page)
+        cross_scope_detail = client.get(
+            f"/api/analysis-memory/states/{candidates['intraday'].id}",
+            params={"stateScope": "daily_close"},
+        )
+    finally:
+        api_main.app.dependency_overrides.pop(get_db, None)
+
+    assert missing.status_code == 422
+    assert invalid.status_code == 422
+    assert cross_scope_detail.status_code == 404
+    for state_scope, (canonical, candidate_page) in responses.items():
+        assert canonical.status_code == 200
+        assert canonical.json()["state_scope"] == state_scope
+        assert canonical.json()["state"]["state_id"] == roots[state_scope].id
+        assert {item["state_scope"] for item in canonical.json()["canonical_chain"]} == {
+            state_scope
+        }
+        assert candidate_page.status_code == 200
+        assert candidate_page.json()["state_scope"] == state_scope
+        assert [item["state_id"] for item in candidate_page.json()["data"]] == [
+            candidates[state_scope].id
+        ]
+
+
+def test_cross_scope_candidate_review_fails_before_write(
+    db: Session,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = _seed_root(db)
+    candidate = _seed_candidate(db, root=root)
+    before = (
+        db.scalar(select(func.count()).select_from(AnalysisState)),
+        db.scalar(select(func.count()).select_from(AnalysisTransition)),
+        db.scalar(select(func.count()).select_from(AnalysisStateHead)),
+    )
+    monkeypatch.setattr("apps.api.services.analysis_memory_service._PROJECT_ROOT", tmp_path)
+    monkeypatch.setenv("FINANCE_AGENT_ANALYSIS_MEMORY_WRITE_TOKEN", "review-secret")
+    client = _client(db)
+    try:
+        response = client.post(
+            f"/api/analysis-memory/candidates/{candidate.id}/reviews",
+            headers={"X-Finance-Analysis-Memory-Token": "review-secret"},
+            json={
+                "action": "accept",
+                "state_scope": "intraday",
+                "actor": "reviewer",
+                "reason": "cross-scope request must fail",
+                "request_id": "review-cross-scope",
+                "expected_canonical_state_id": root.id,
+                "expected_head_version": 1,
+            },
+        )
+    finally:
+        api_main.app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "ANALYSIS_MEMORY_REVIEW_INVALID"
+    after = (
+        db.scalar(select(func.count()).select_from(AnalysisState)),
+        db.scalar(select(func.count()).select_from(AnalysisTransition)),
+        db.scalar(select(func.count()).select_from(AnalysisStateHead)),
+    )
+    assert after == before
+    assert not (tmp_path / "storage" / "outputs" / "analysis_state_reviews").exists()
+
+
+def test_legacy_bundle_is_only_observable_as_daily_close(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = assemble_context_bundle(
+        run_id="run-legacy-bundle",
+        asset="XAUUSD",
+        state_scope="daily_close",
+        canonical_state_id="state-legacy",
+        canonical_state={
+            "asset": "XAUUSD",
+            "state_scope": "daily_close",
+            "core_thesis": "legacy daily close",
+        },
+        evidence=[],
+        evidence_cursors={},
+        cutoff_at=NOW,
+        assembled_at=NOW,
+    )
+    payload = bundle.model_dump(mode="json")
+    payload["schema_version"] = "analysis_context_bundle.v1"
+    payload.pop("state_scope")
+    payload["content_hash"] = compute_bundle_content_hash(payload)
+    payload["bundle_id"] = str(
+        uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"finance-agent:context-bundle:{payload['content_hash']}",
+        )
+    )
+    path = (
+        tmp_path
+        / "storage"
+        / "outputs"
+        / "context_bundles"
+        / "XAUUSD"
+        / "run-legacy-bundle"
+        / f"{payload['bundle_id']}.json"
+    )
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr("apps.api.services.analysis_memory_service._PROJECT_ROOT", tmp_path)
+    client = TestClient(api_main.app)
+
+    daily = client.get(
+        f"/api/analysis-memory/context-bundles/{payload['bundle_id']}",
+        params={"stateScope": "daily_close"},
+    )
+    intraday = client.get(
+        f"/api/analysis-memory/context-bundles/{payload['bundle_id']}",
+        params={"stateScope": "intraday"},
+    )
+
+    assert daily.status_code == 200
+    assert daily.json()["schema_version"] == "analysis_context_bundle.v1"
+    assert daily.json()["state_scope"] == "daily_close"
+    assert intraday.status_code == 404

--- a/tests/api/test_analysis_memory_api.py
+++ b/tests/api/test_analysis_memory_api.py
@@ -649,7 +649,9 @@ def test_api_requires_valid_scope_and_isolates_all_three_heads(db: Session) -> N
     finally:
         api_main.app.dependency_overrides.pop(get_db, None)
 
-    assert missing.status_code == 422
+    assert missing.status_code == 200
+    assert missing.json()["state_scope"] == "daily_close"
+    assert missing.json()["state"]["state_id"] == daily_root.id
     assert invalid.status_code == 422
     assert cross_scope_detail.status_code == 404
     for state_scope, (canonical, candidate_page) in responses.items():

--- a/tests/architecture/test_analysis_memory_observability_guards.py
+++ b/tests/architecture/test_analysis_memory_observability_guards.py
@@ -18,7 +18,9 @@ def test_review_service_uses_the_existing_materializer_gate_only() -> None:
 
     assert "materialize_reviewed_transition_scoped(" in source
     assert "materialize_reviewed_transition(" in source
-    assert "state_scope=request.state_scope" in source
+    assert "candidate_scope = candidate.state_scope" in source
+    assert "candidate_scope != request.state_scope" in source
+    assert "state_scope=candidate_scope" in source
     assert "append_analysis_state" not in source
     assert "advance_canonical_head" not in source
 

--- a/tests/architecture/test_analysis_memory_observability_guards.py
+++ b/tests/architecture/test_analysis_memory_observability_guards.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from apps.api.routes import analysis_memory_routes
 from apps.api.services import analysis_memory_service
+from database.queries import analysis_state_observability
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -15,7 +16,9 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 def test_review_service_uses_the_existing_materializer_gate_only() -> None:
     source = inspect.getsource(analysis_memory_service.accept_candidate)
 
+    assert "materialize_reviewed_transition_scoped(" in source
     assert "materialize_reviewed_transition(" in source
+    assert "state_scope=request.state_scope" in source
     assert "append_analysis_state" not in source
     assert "advance_canonical_head" not in source
 
@@ -33,3 +36,11 @@ def test_review_write_token_is_declared_in_env_example() -> None:
     env_example = (PROJECT_ROOT / ".env.example").read_text(encoding="utf-8")
 
     assert "FINANCE_AGENT_ANALYSIS_MEMORY_WRITE_TOKEN=" in env_example
+
+
+def test_database_observability_queries_do_not_runtime_import_apps() -> None:
+    source = inspect.getsource(analysis_state_observability)
+
+    assert "if TYPE_CHECKING:" in source
+    runtime_prefix = source.split("if TYPE_CHECKING:", maxsplit=1)[0]
+    assert "from apps." not in runtime_prefix

--- a/tests/output/test_context_bundle_artifacts.py
+++ b/tests/output/test_context_bundle_artifacts.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import json
+import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
 from pydantic import ValidationError
 
 from apps.analysis.context_bundle import assemble_context_bundle
+from apps.analysis.context_bundle.schemas import (
+    AnalysisContextBundle,
+    compute_bundle_content_hash,
+)
 from apps.output.context_bundle import (
     ContextBundleLoadError,
     load_context_bundle,
@@ -17,12 +22,17 @@ from apps.output.context_bundle import (
 NOW = datetime(2026, 7, 22, 8, tzinfo=UTC)
 
 
-def _bundle():
+def _bundle(state_scope="daily_close"):
     return assemble_context_bundle(
         run_id="run-67",
         asset="XAUUSD",
+        state_scope=state_scope,
         canonical_state_id="state-66",
-        canonical_state={"core_thesis": "等待突破"},
+        canonical_state={
+            "asset": "XAUUSD",
+            "state_scope": state_scope,
+            "core_thesis": "等待突破",
+        },
         evidence=[
             {
                 "source": "market",
@@ -47,12 +57,13 @@ def test_writer_is_storage_relative_idempotent_and_run_artifact_ready(tmp_path) 
     assert first.written is True
     assert replay.written is False
     assert first.storage_relative_path == (
-        f"outputs/context_bundles/XAUUSD/run-67/{bundle.bundle_id}.json"
+        f"outputs/context_bundles/XAUUSD/daily_close/run-67/{bundle.bundle_id}.json"
     )
     assert first.registry_artifact["artifact_type"] == "structured_json"
     assert first.registry_artifact["metadata"]["artifact_family"] == (
         "analysis_context_bundle"
     )
+    assert first.registry_artifact["metadata"]["state_scope"] == "daily_close"
     assert load_context_bundle(
         storage_root=tmp_path,
         storage_relative_path=first.storage_relative_path,
@@ -85,3 +96,47 @@ def test_writer_revalidates_nested_mutation_before_persisting(tmp_path) -> None:
     with pytest.raises(ValidationError, match="utf8_bytes"):
         write_context_bundle(storage_root=tmp_path, bundle=bundle)
     assert not (tmp_path / "outputs").exists()
+
+
+def test_loader_reads_legacy_v1_as_daily_close_but_writer_rejects_it(tmp_path) -> None:
+    payload = _bundle().model_dump(mode="json")
+    payload["schema_version"] = "analysis_context_bundle.v1"
+    payload.pop("state_scope")
+    payload["content_hash"] = compute_bundle_content_hash(payload)
+    payload["bundle_id"] = str(
+        uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"finance-agent:context-bundle:{payload['content_hash']}",
+        )
+    )
+    legacy = AnalysisContextBundle.model_validate(payload)
+    path = (
+        tmp_path
+        / "outputs"
+        / "context_bundles"
+        / "XAUUSD"
+        / "run-67"
+        / f"{legacy.bundle_id}.json"
+    )
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = load_context_bundle(
+        storage_root=tmp_path,
+        storage_relative_path=path.relative_to(tmp_path).as_posix(),
+    )
+
+    assert loaded.schema_version == "analysis_context_bundle.v1"
+    assert loaded.state_scope is None
+    with pytest.raises(ValueError, match="only persists scoped v2"):
+        write_context_bundle(storage_root=tmp_path, bundle=loaded)
+
+
+def test_writer_path_isolated_by_scope_for_same_asset_and_run(tmp_path) -> None:
+    daily = write_context_bundle(storage_root=tmp_path, bundle=_bundle("daily_close"))
+    intraday = write_context_bundle(storage_root=tmp_path, bundle=_bundle("intraday"))
+
+    assert "/daily_close/" in daily.storage_relative_path
+    assert "/intraday/" in intraday.storage_relative_path
+    assert daily.storage_relative_path != intraday.storage_relative_path
+    assert daily.content_hash != intraday.content_hash

--- a/tests/worker/test_composite_state_shadow.py
+++ b/tests/worker/test_composite_state_shadow.py
@@ -53,6 +53,7 @@ def _evidence(*, provider_metadata: bool = False) -> dict:
 
 def _shadow_input(*, evidence: list[dict] | None = None) -> dict:
     return {
+        "state_scope": "daily_close",
         "canonical_state_id": "state-66",
         "canonical_state": _state(),
         "evidence": list(evidence or []),
@@ -150,6 +151,9 @@ def test_shadow_candidate_is_reviewed_and_all_consumers_share_bundle(tmp_path) -
 
     assert trace["status"] == "candidate_accepted_shadow_only"
     assert trace["shadow_review_status"] == "accepted"
+    assert trace["schema_version"] == "composite_state_shadow.v2"
+    assert trace["state_scope"] == "daily_close"
+    assert "/daily_close/" in trace["bundle_path"]
     assert trace["transition_diff"][0]["action"] == "strengthen"
     assert set(final["bundle_consumers"].values()) == {runtime.bundle.bundle_id}
     assert final["quality_distribution"] == {
@@ -214,3 +218,25 @@ def test_context_mode_validation(monkeypatch) -> None:
     assert resolve_analysis_context_mode() == "legacy_full_context"
     with pytest.raises(ValueError, match="unsupported"):
         resolve_analysis_context_mode("invalid")
+
+
+def test_shadow_requires_explicit_scope_and_rejects_legacy_cross_scope(tmp_path) -> None:
+    missing = _shadow_input()
+    missing.pop("state_scope")
+    with pytest.raises(ValueError, match="state_scope is required"):
+        prepare_composite_state_shadow(
+            storage_root=tmp_path,
+            run_id="run-missing-scope",
+            created_at=NOW,
+            shadow_input=missing,
+        )
+
+    cross_scope = _shadow_input()
+    cross_scope["state_scope"] = "intraday"
+    with pytest.raises(ValueError, match="only valid for daily_close"):
+        prepare_composite_state_shadow(
+            storage_root=tmp_path,
+            run_id="run-cross-scope",
+            created_at=NOW,
+            shadow_input=cross_scope,
+        )

--- a/tests/worker/test_premarket_composite_output_integration.py
+++ b/tests/worker/test_premarket_composite_output_integration.py
@@ -158,6 +158,7 @@ def test_composite_state_delta_shadow_shares_one_bundle_without_canonical_write(
     snapshot = _make_rich_snapshot(run_id=run_id)
     evidence_ref = {"snapshot_id": "market-shadow-2"}
     shadow_input = {
+        "state_scope": "daily_close",
         "canonical_state_id": "state-shadow-root",
         "canonical_state": {
             "asset": "XAUUSD",
@@ -257,12 +258,14 @@ def test_composite_shadow_setup_failure_does_not_break_legacy_outputs(tmp_path: 
         run_id="run-shadow-setup-failure",
         created_at=_CREATED_AT,
         analysis_context_mode="state_delta_context",
-        state_shadow_input=None,
+        state_shadow_input={"state_scope": {"untrusted": "must-not-enter-trace"}},
     )
 
     assert summaries["final_report"]["status"] == "success"
     assert outputs["report_result"]["paths"]
     assert outputs["state_delta_shadow"]["status"] == "shadow_setup_failed"
+    assert outputs["state_delta_shadow"]["requested_state_scope"] is None
+    assert "must-not-enter-trace" not in str(outputs["state_delta_shadow"])
     assert outputs["state_delta_shadow"]["production_canonical_write_allowed"] is False
 
 


### PR DESCRIPTION
## Summary
- propagate state_scope through Analysis Memory API, ContextBundle, shadow trace, candidate review, and frontend observability
- preserve daily_close compatibility when stateScope is omitted and isolate scoped reads/writes
- guard frontend request generations so stale scope responses cannot overwrite the active view

## Verification
- Analysis Memory backend regression: 111 passed
- frontend contract tests: passed
- frontend typecheck: passed
- frontend production build: passed
- Ruff and git diff --check: passed
- changed-file sensitive path scan: passed

Closes #82