### PR TITLE
feat: add deterministic evidence delta evaluator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
           uv run ruff check
           apps/analysis/state
           apps/analysis/context_bundle
+          apps/analysis/evidence_delta
           apps/analysis/figure_facts.py
           apps/output/context_bundle.py
           apps/output/figure_facts.py
@@ -78,6 +79,7 @@ jobs:
           database/models/analysis_state.py
           scripts/bootstrap_analysis_state.py
           tests/analysis/test_context_bundle.py
+          tests/analysis/test_evidence_delta_evaluator.py
           tests/analysis/test_figure_facts.py
           tests/analysis/test_state_bootstrap.py
           tests/analysis/test_state_materializer.py
@@ -100,6 +102,7 @@ jobs:
           tests/database/test_alembic_runtime_unification.py
           tests/database/test_analysis_state_core.py
           tests/analysis/test_context_bundle.py
+          tests/analysis/test_evidence_delta_evaluator.py
           tests/analysis/test_state_materializer.py
           tests/analysis/test_figure_facts.py
           tests/output/test_context_bundle_artifacts.py

--- a/apps/analysis/evidence_delta/__init__.py
+++ b/apps/analysis/evidence_delta/__init__.py
@@ -1,0 +1,48 @@
+"""Deterministic materiality decisions over state-scoped evidence deltas."""
+
+from .evaluator import evaluate_evidence_delta
+from .rules import adapt_context_evidence, adapt_figure_fact, semantic_hash, semantic_identity
+from .schemas import (
+    EVIDENCE_DELTA_RULESET_VERSION,
+    EVIDENCE_DELTA_SCHEMA_VERSION,
+    AffectedStateField,
+    ConfirmationStatus,
+    DeltaEvidence,
+    EvidenceIdentity,
+    EvaluatedEvidence,
+    EvaluationOutcome,
+    EvidenceDeltaDecision,
+    FigureFactEvidence,
+    KeyLevelEvidence,
+    MacroMetricEvidence,
+    MaterialEventEvidence,
+    Materiality,
+    OptionsRegimeEvidence,
+    RecommendedAction,
+    SourceQuality,
+)
+
+__all__ = [
+    "EVIDENCE_DELTA_RULESET_VERSION",
+    "EVIDENCE_DELTA_SCHEMA_VERSION",
+    "AffectedStateField",
+    "ConfirmationStatus",
+    "DeltaEvidence",
+    "EvidenceIdentity",
+    "EvaluatedEvidence",
+    "EvaluationOutcome",
+    "EvidenceDeltaDecision",
+    "FigureFactEvidence",
+    "KeyLevelEvidence",
+    "MacroMetricEvidence",
+    "MaterialEventEvidence",
+    "Materiality",
+    "OptionsRegimeEvidence",
+    "RecommendedAction",
+    "SourceQuality",
+    "adapt_context_evidence",
+    "adapt_figure_fact",
+    "evaluate_evidence_delta",
+    "semantic_hash",
+    "semantic_identity",
+]

--- a/apps/analysis/evidence_delta/evaluator.py
+++ b/apps/analysis/evidence_delta/evaluator.py
@@ -1,0 +1,185 @@
+"""Pure EvidenceDeltaEvaluator with deterministic aggregation and replay identity."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+
+from .rules import RuleResult, evaluate_rule, semantic_hash, semantic_identity
+from .schemas import (
+    DeltaEvidence,
+    EvidenceIdentity,
+    EvaluatedEvidence,
+    EvaluationOutcome,
+    EvidenceDeltaDecision,
+    Materiality,
+    RecommendedAction,
+    StateScope,
+)
+
+
+_MATERIALITY_RANK = {
+    Materiality.NONE: 0,
+    Materiality.LOW: 1,
+    Materiality.MEDIUM: 2,
+    Materiality.HIGH: 3,
+    Materiality.CRITICAL: 4,
+}
+_ACTION_RANK = {
+    RecommendedAction.NO_OP: 0,
+    RecommendedAction.UPDATE_CONTEXT_ONLY: 1,
+    RecommendedAction.RUN_TRANSITION_ANALYSIS: 2,
+    RecommendedAction.MANUAL_REVIEW: 3,
+}
+
+
+def evaluate_evidence_delta(
+    *,
+    asset: str,
+    state_scope: StateScope,
+    canonical_state_id: str,
+    evidence: Sequence[DeltaEvidence],
+    previous_semantic_hashes: Mapping[str, str] | None = None,
+) -> EvidenceDeltaDecision:
+    """Evaluate already-adapted facts without I/O, clocks, models, or state mutation."""
+
+    normalized_asset = _required_text(asset)
+    normalized_state_id = _required_text(canonical_state_id)
+    previous = _validate_previous_hashes(previous_semantic_hashes or {})
+    grouped: dict[tuple[str, str], list[DeltaEvidence]] = defaultdict(list)
+    by_identity_hashes: dict[str, set[str]] = defaultdict(set)
+    authoritative_hashes: dict[tuple[str, str], set[str]] = defaultdict(set)
+
+    for item in evidence:
+        if item.asset != normalized_asset:
+            raise ValueError(
+                f"evidence asset mismatch: expected {normalized_asset}, got {item.asset} ({item.evidence_id})"
+            )
+        key = semantic_identity(item)
+        item_hash = semantic_hash(item)
+        grouped[(key, item_hash)].append(item)
+        by_identity_hashes[key].add(item_hash)
+        authoritative_hashes[(item.source, item.evidence_id)].add(item_hash)
+
+    conflicting_semantic_keys = {
+        key for key, hashes in by_identity_hashes.items() if len(hashes) > 1
+    }
+    conflicting_authoritative_keys = {
+        key for key, hashes in authoritative_hashes.items() if len(hashes) > 1
+    }
+    evaluated: list[EvaluatedEvidence] = []
+    semantic_hashes: dict[str, str] = {}
+    for key, item_hash in sorted(grouped):
+        items = grouped[(key, item_hash)]
+        representative = min(items, key=lambda item: (item.evidence_id, item.source))
+        has_authoritative_conflict = any(
+            (item.source, item.evidence_id) in conflicting_authoritative_keys for item in items
+        )
+        if len(by_identity_hashes[key]) == 1 and not has_authoritative_conflict:
+            semantic_hashes[key] = item_hash
+        if has_authoritative_conflict:
+            result = RuleResult(
+                materiality=Materiality.HIGH,
+                outcome=EvaluationOutcome.MANUAL_REVIEW,
+                action=RecommendedAction.MANUAL_REVIEW,
+                affected_state_fields=("unresolved_items",),
+                reasons=("authoritative_evidence_key:conflicting_payload",),
+            )
+        elif key in conflicting_semantic_keys:
+            result = RuleResult(
+                materiality=Materiality.HIGH,
+                outcome=EvaluationOutcome.MANUAL_REVIEW,
+                action=RecommendedAction.MANUAL_REVIEW,
+                affected_state_fields=("unresolved_items",),
+                reasons=("semantic_identity:conflicting_payload",),
+            )
+        elif previous.get(key) == item_hash:
+            result = RuleResult(
+                materiality=Materiality.NONE,
+                outcome=EvaluationOutcome.DUPLICATE,
+                action=RecommendedAction.NO_OP,
+                affected_state_fields=(),
+                reasons=("semantic_content_unchanged",),
+            )
+        else:
+            result = evaluate_rule(representative)
+        evaluated.append(
+            EvaluatedEvidence(
+                evidence_key=key,
+                evidence_type=representative.evidence_type,
+                semantic_hash=item_hash,
+                evidence_refs=[
+                    EvidenceIdentity(source=source, evidence_id=evidence_id)
+                    for source, evidence_id in sorted(
+                        {(item.source, item.evidence_id) for item in items}
+                    )
+                ],
+                materiality=result.materiality,
+                outcome=result.outcome,
+                recommended_action=result.action,
+                affected_state_fields=sorted(set(result.affected_state_fields)),
+                reasons=sorted(set(result.reasons)),
+            )
+        )
+
+    if evaluated:
+        action = max(
+            (item.recommended_action for item in evaluated),
+            key=lambda candidate: _ACTION_RANK[candidate],
+        )
+        materiality = max(
+            (item.materiality for item in evaluated),
+            key=lambda candidate: _MATERIALITY_RANK[candidate],
+        )
+        affected = sorted(
+            {
+                field
+                for item in evaluated
+                if item.recommended_action is not RecommendedAction.NO_OP
+                for field in item.affected_state_fields
+            }
+        )
+        reasons = sorted(
+            {
+                reason
+                for item in evaluated
+                for reason in item.reasons
+                if item.recommended_action is action
+            }
+        )
+    else:
+        action = RecommendedAction.NO_OP
+        materiality = Materiality.NONE
+        affected = []
+        reasons = ["no_evidence"]
+
+    return EvidenceDeltaDecision.build(
+        asset=normalized_asset,
+        state_scope=state_scope,
+        canonical_state_id=normalized_state_id,
+        has_relevant_delta=action is not RecommendedAction.NO_OP,
+        materiality=materiality,
+        recommended_action=action,
+        affected_state_fields=affected,
+        trigger_reasons=reasons,
+        evaluated_items=evaluated,
+        semantic_hashes=semantic_hashes,
+    )
+
+
+def _validate_previous_hashes(values: Mapping[str, str]) -> dict[str, str]:
+    normalized: dict[str, str] = {}
+    for raw_key, raw_hash in values.items():
+        key = _required_text(raw_key)
+        digest = str(raw_hash).strip().lower()
+        if len(digest) != 64 or any(char not in "0123456789abcdef" for char in digest):
+            raise ValueError(f"previous semantic hash is invalid for {key}")
+        normalized[key] = digest
+    return normalized
+
+
+def _required_text(value: str) -> str:
+    normalized = str(value).strip()
+    if not normalized:
+        raise ValueError("value must not be blank")
+    return normalized

--- a/apps/analysis/evidence_delta/rules.py
+++ b/apps/analysis/evidence_delta/rules.py
@@ -1,0 +1,259 @@
+"""Frozen deterministic rules and source adapters for EvidenceDeltaEvaluator."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from apps.analysis.context_bundle.schemas import EvidenceItem
+from apps.analysis.figure_facts import FigureFact, validate_figure_fact
+from apps.analysis.state.hashing import content_hash
+
+from .schemas import (
+    DELTA_EVIDENCE_ADAPTER,
+    ConfirmationStatus,
+    DeltaEvidence,
+    EvaluationOutcome,
+    FigureFactEvidence,
+    KeyLevelEvidence,
+    MacroMetricEvidence,
+    MaterialEventEvidence,
+    Materiality,
+    OptionsRegimeEvidence,
+    RecommendedAction,
+    SourceQuality,
+)
+
+
+TRUSTED_MARKET_SOURCES = frozenset(
+    {SourceQuality.OFFICIAL, SourceQuality.EXCHANGE, SourceQuality.PRIMARY, SourceQuality.VALIDATED}
+)
+MACRO_THRESHOLDS: dict[str, tuple[float, float]] = {
+    # context threshold, transition threshold; rates are percentage-point changes.
+    "dxy": (0.20, 0.50),
+    "us02y": (0.03, 0.08),
+    "us10y": (0.03, 0.08),
+    "real10y": (0.03, 0.07),
+    "breakeven10y": (0.03, 0.07),
+    "oil": (1.00, 3.00),
+}
+
+
+@dataclass(frozen=True)
+class RuleResult:
+    materiality: Materiality
+    outcome: EvaluationOutcome
+    action: RecommendedAction
+    affected_state_fields: tuple[str, ...]
+    reasons: tuple[str, ...]
+
+
+def adapt_context_evidence(item: EvidenceItem | Mapping[str, Any]) -> DeltaEvidence:
+    """Adapt one ContextBundle item using an explicit ``payload.evidence_type`` contract."""
+
+    validated = item if isinstance(item, EvidenceItem) else EvidenceItem.model_validate(item)
+    evidence_type = str(validated.payload.get("evidence_type") or "").strip()
+    if not evidence_type:
+        raise ValueError("payload.evidence_type is required for evidence delta adaptation")
+    payload = dict(validated.payload)
+    payload.update(
+        {
+            "source": validated.source,
+            "evidence_id": validated.evidence_id,
+            "observed_at": validated.business_time,
+            "source_ref": dict(validated.source_ref),
+        }
+    )
+    if "asset" not in payload:
+        raise ValueError("payload.asset is required for evidence delta adaptation")
+    if "source_quality" not in payload:
+        raise ValueError("payload.source_quality is required for evidence delta adaptation")
+    return DELTA_EVIDENCE_ADAPTER.validate_python(payload)
+
+
+def adapt_figure_fact(
+    fact: FigureFact | Mapping[str, Any], *, observed_at: datetime, source: str = "figure_fact"
+) -> FigureFactEvidence:
+    """Project a validated FigureFact without promoting non-accepted facts."""
+
+    validated = validate_figure_fact(dict(fact) if isinstance(fact, Mapping) else fact)
+    return FigureFactEvidence(
+        source=source,
+        evidence_id=validated.figure_fact_id,
+        asset=validated.asset,
+        observed_at=observed_at,
+        source_quality=(
+            SourceQuality.VALIDATED
+            if validated.quality_status.value == "accepted"
+            else SourceQuality.UNVERIFIED
+        ),
+        source_ref=dict(validated.source_ref),
+        metadata={"review_ref": validated.review_ref} if validated.review_ref else {},
+        figure_fact_id=validated.figure_fact_id,
+        figure_id=validated.figure_id,
+        report_id=validated.report_id,
+        figure_content_hash=validated.content_hash,
+        quality_status=validated.quality_status.value,
+        has_direct_evidence=bool(validated.observations or validated.numeric_values),
+    )
+
+
+def semantic_identity(item: DeltaEvidence) -> str:
+    if isinstance(item, MacroMetricEvidence):
+        return f"macro_metric:{item.metric}"
+    if isinstance(item, KeyLevelEvidence):
+        return _semantic_key("key_level", item.level_id)
+    if isinstance(item, OptionsRegimeEvidence):
+        return _semantic_key("options_regime", item.regime_id, item.event)
+    if isinstance(item, MaterialEventEvidence):
+        return _semantic_key("material_event", item.cluster_key.casefold())
+    return _semantic_key("figure_fact", item.report_id, item.figure_id)
+
+
+def semantic_hash(item: DeltaEvidence) -> str:
+    """Hash business meaning, excluding delivery/provenance-only metadata."""
+
+    payload = item.model_dump(
+        mode="json",
+        exclude={"source", "evidence_id", "observed_at", "source_ref", "metadata"},
+    )
+    if isinstance(item, MaterialEventEvidence):
+        # Different collectors may assign different IDs to the same clustered claim.
+        payload.pop("event_id", None)
+        payload.pop("source_quality", None)
+        payload["claim"] = " ".join(item.claim.casefold().split())
+        payload["cluster_key"] = item.cluster_key.casefold()
+    return content_hash(payload, exclude_keys=frozenset())
+
+
+def evaluate_rule(item: DeltaEvidence) -> RuleResult:
+    if isinstance(item, MacroMetricEvidence):
+        return _macro_rule(item)
+    if isinstance(item, KeyLevelEvidence):
+        return _key_level_rule(item)
+    if isinstance(item, OptionsRegimeEvidence):
+        return _options_rule(item)
+    if isinstance(item, MaterialEventEvidence):
+        return _material_event_rule(item)
+    return _figure_rule(item)
+
+
+def _macro_rule(item: MacroMetricEvidence) -> RuleResult:
+    if item.previous_value == 0:
+        return _manual("macro_previous_value_zero", ("dominant_drivers",))
+    if item.metric in {"dxy", "oil"}:
+        movement = abs((item.current_value - item.previous_value) / item.previous_value) * 100.0
+        unit = "pct"
+    else:
+        movement = abs(item.current_value - item.previous_value)
+        unit = "percentage_point"
+    context_threshold, transition_threshold = MACRO_THRESHOLDS[item.metric]
+    prefix = f"macro:{item.metric}:movement_{movement:.6f}_{unit}"
+    if movement < context_threshold:
+        return _no_op(f"{prefix}:below_context_threshold")
+    if item.source_quality not in TRUSTED_MARKET_SOURCES:
+        if movement >= transition_threshold:
+            return _manual(f"{prefix}:untrusted_material_move", ("dominant_drivers",))
+        return _no_op(f"{prefix}:untrusted_source")
+    if movement < transition_threshold:
+        return _context(f"{prefix}:context_only", ("dominant_drivers",))
+    return _transition(f"{prefix}:transition_threshold", ("dominant_drivers", "scenario_states"))
+
+
+def _key_level_rule(item: KeyLevelEvidence) -> RuleResult:
+    affected = ("invalidation_conditions", "key_levels", "scenario_states")
+    if item.confirmation_status is ConfirmationStatus.CONFLICTING:
+        return _manual("key_level:conflicting_confirmation", affected)
+    if item.event in {"approach", "touch"}:
+        return _context(f"key_level:{item.event}", ("key_levels",))
+    if item.confirmation_status is not ConfirmationStatus.CONFIRMED:
+        return _manual(f"key_level:{item.event}:confirmation_required", affected)
+    if item.source_quality not in TRUSTED_MARKET_SOURCES:
+        return _manual(f"key_level:{item.event}:trusted_source_required", affected)
+    return _transition(f"key_level:{item.event}:confirmed", affected, critical=True)
+
+
+def _options_rule(item: OptionsRegimeEvidence) -> RuleResult:
+    affected = ("dominant_drivers", "key_levels", "scenario_states")
+    if item.confirmation_status is ConfirmationStatus.CONFLICTING:
+        return _manual("options_regime:conflicting_confirmation", affected)
+    if item.event == "gamma_sign_flip":
+        significant = bool(item.previous_value and item.current_value and item.previous_value * item.current_value < 0)
+    else:
+        significant = abs(item.change_pct or 0.0) >= 0.50
+    if not significant:
+        return _no_op(f"options_regime:{item.event}:below_threshold")
+    if item.confirmation_status is not ConfirmationStatus.CONFIRMED:
+        return _manual(f"options_regime:{item.event}:confirmation_required", affected)
+    if item.source_quality is not SourceQuality.EXCHANGE:
+        return _manual(f"options_regime:{item.event}:exchange_source_required", affected)
+    return _transition(f"options_regime:{item.event}:confirmed", affected)
+
+
+def _material_event_rule(item: MaterialEventEvidence) -> RuleResult:
+    affected = ("dominant_drivers", "scenario_states", "unresolved_items")
+    high_risk = item.risk_level in {"high", "critical"} or item.materiality_score >= 70.0
+    if item.confirmation_status is ConfirmationStatus.CONFLICTING:
+        return _manual("material_event:conflicting_claims", affected)
+    if high_risk and (
+        item.confirmation_status is not ConfirmationStatus.CONFIRMED or not item.recompute_eligible
+    ):
+        return _manual("material_event:high_risk_unconfirmed", affected)
+    if item.recompute_eligible and item.materiality_score >= 70.0:
+        return _transition("material_event:confirmed_material_event", affected, critical=item.risk_level == "critical")
+    if item.materiality_score >= 40.0:
+        return _context("material_event:context_only", affected)
+    return _no_op("material_event:below_materiality_threshold")
+
+
+def _figure_rule(item: FigureFactEvidence) -> RuleResult:
+    if item.quality_status != "accepted" or not item.has_direct_evidence:
+        return _no_op(f"figure_fact:{item.quality_status}:not_accepted")
+    return _context("figure_fact:accepted_change", ("dominant_drivers", "key_levels"))
+
+
+def _no_op(reason: str) -> RuleResult:
+    return RuleResult(
+        materiality=Materiality.NONE,
+        outcome=EvaluationOutcome.IGNORED,
+        action=RecommendedAction.NO_OP,
+        affected_state_fields=(),
+        reasons=(reason,),
+    )
+
+
+def _context(reason: str, affected: tuple[str, ...]) -> RuleResult:
+    return RuleResult(
+        materiality=Materiality.MEDIUM,
+        outcome=EvaluationOutcome.CONTEXT_UPDATE,
+        action=RecommendedAction.UPDATE_CONTEXT_ONLY,
+        affected_state_fields=affected,
+        reasons=(reason,),
+    )
+
+
+def _transition(reason: str, affected: tuple[str, ...], *, critical: bool = False) -> RuleResult:
+    return RuleResult(
+        materiality=Materiality.CRITICAL if critical else Materiality.HIGH,
+        outcome=EvaluationOutcome.TRANSITION_TRIGGER,
+        action=RecommendedAction.RUN_TRANSITION_ANALYSIS,
+        affected_state_fields=affected,
+        reasons=(reason,),
+    )
+
+
+def _manual(reason: str, affected: tuple[str, ...]) -> RuleResult:
+    return RuleResult(
+        materiality=Materiality.HIGH,
+        outcome=EvaluationOutcome.MANUAL_REVIEW,
+        action=RecommendedAction.MANUAL_REVIEW,
+        affected_state_fields=affected,
+        reasons=(reason,),
+    )
+
+
+def _semantic_key(kind: str, *parts: object) -> str:
+    return f"{kind}:{json.dumps(parts, ensure_ascii=False, separators=(',', ':'))}"

--- a/apps/analysis/evidence_delta/schemas.py
+++ b/apps/analysis/evidence_delta/schemas.py
@@ -1,0 +1,418 @@
+"""Strict, provider-independent contracts for deterministic evidence deltas."""
+
+from __future__ import annotations
+
+from collections import Counter
+from enum import StrEnum
+from typing import Annotated, Any, Literal
+
+from pydantic import (
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    Field,
+    TypeAdapter,
+    field_validator,
+    model_validator,
+)
+
+from apps.analysis.state.hashing import content_hash
+from apps.analysis.state.schemas import StateScope
+
+
+EVIDENCE_DELTA_SCHEMA_VERSION = "evidence_delta.v1"
+EVIDENCE_DELTA_RULESET_VERSION = "evidence_delta.rules.v1"
+SHA256_LENGTH = 64
+
+
+class Materiality(StrEnum):
+    NONE = "none"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class RecommendedAction(StrEnum):
+    NO_OP = "no_op"
+    UPDATE_CONTEXT_ONLY = "update_context_only"
+    RUN_TRANSITION_ANALYSIS = "run_transition_analysis"
+    MANUAL_REVIEW = "manual_review"
+
+
+class EvaluationOutcome(StrEnum):
+    DUPLICATE = "duplicate"
+    IGNORED = "ignored"
+    CONTEXT_UPDATE = "context_update"
+    TRANSITION_TRIGGER = "transition_trigger"
+    MANUAL_REVIEW = "manual_review"
+
+
+_MATERIALITY_RANK = {
+    Materiality.NONE: 0,
+    Materiality.LOW: 1,
+    Materiality.MEDIUM: 2,
+    Materiality.HIGH: 3,
+    Materiality.CRITICAL: 4,
+}
+_ACTION_RANK = {
+    RecommendedAction.NO_OP: 0,
+    RecommendedAction.UPDATE_CONTEXT_ONLY: 1,
+    RecommendedAction.RUN_TRANSITION_ANALYSIS: 2,
+    RecommendedAction.MANUAL_REVIEW: 3,
+}
+
+
+class SourceQuality(StrEnum):
+    OFFICIAL = "official"
+    EXCHANGE = "exchange"
+    PRIMARY = "primary"
+    VALIDATED = "validated"
+    SUPPLEMENTAL = "supplemental"
+    UNVERIFIED = "unverified"
+
+
+class ConfirmationStatus(StrEnum):
+    CONFIRMED = "confirmed"
+    UNCONFIRMED = "unconfirmed"
+    CONFLICTING = "conflicting"
+
+
+class _StrictFrozenModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, allow_inf_nan=False)
+
+
+class _EvidenceBase(_StrictFrozenModel):
+    source: str = Field(min_length=1, max_length=128)
+    evidence_id: str = Field(min_length=1, max_length=255)
+    asset: str = Field(min_length=1, max_length=32)
+    observed_at: AwareDatetime
+    source_quality: SourceQuality
+    source_ref: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("source", "evidence_id", "asset")
+    @classmethod
+    def strip_identity(cls, value: str) -> str:
+        return _required_text(value)
+
+
+MacroMetric = Literal["dxy", "us02y", "us10y", "real10y", "breakeven10y", "oil"]
+AffectedStateField = Literal[
+    "dominant_drivers",
+    "key_levels",
+    "scenario_states",
+    "unresolved_items",
+    "invalidation_conditions",
+]
+
+
+class MacroMetricEvidence(_EvidenceBase):
+    evidence_type: Literal["macro_metric"] = "macro_metric"
+    metric: MacroMetric
+    current_value: float
+    previous_value: float
+    unit: Literal["index", "percent", "usd"]
+
+    @model_validator(mode="after")
+    def validate_metric_unit(self) -> "MacroMetricEvidence":
+        expected = {
+            "dxy": "index",
+            "us02y": "percent",
+            "us10y": "percent",
+            "real10y": "percent",
+            "breakeven10y": "percent",
+            "oil": "usd",
+        }[self.metric]
+        if self.unit != expected:
+            raise ValueError(f"{self.metric} requires unit={expected}")
+        return self
+
+
+class KeyLevelEvidence(_EvidenceBase):
+    evidence_type: Literal["key_level_event"] = "key_level_event"
+    level_id: str = Field(min_length=1, max_length=128)
+    level_role: Literal["support", "resistance", "invalidation", "gamma_zero", "option_wall"]
+    level_value: float
+    observed_value: float
+    event: Literal["approach", "touch", "confirmed_break", "confirmed_reclaim"]
+    confirmation_status: ConfirmationStatus
+
+    @field_validator("level_id")
+    @classmethod
+    def strip_level_id(cls, value: str) -> str:
+        return _required_text(value)
+
+
+class OptionsRegimeEvidence(_EvidenceBase):
+    evidence_type: Literal["options_regime"] = "options_regime"
+    regime_id: str = Field(min_length=1, max_length=128)
+    event: Literal["gamma_zero_migration", "wall_migration", "gamma_sign_flip"]
+    previous_value: float | None = None
+    current_value: float | None = None
+    change_pct: float | None = None
+    confirmation_status: ConfirmationStatus
+
+    @field_validator("regime_id")
+    @classmethod
+    def strip_regime_id(cls, value: str) -> str:
+        return _required_text(value)
+
+    @model_validator(mode="after")
+    def validate_measurement(self) -> "OptionsRegimeEvidence":
+        if self.event == "gamma_sign_flip":
+            if self.previous_value is None or self.current_value is None:
+                raise ValueError("gamma_sign_flip requires previous_value and current_value")
+            if self.previous_value == 0 or self.current_value == 0:
+                raise ValueError("gamma_sign_flip values must be non-zero")
+        elif self.change_pct is None:
+            raise ValueError(f"{self.event} requires change_pct")
+        return self
+
+
+class MaterialEventEvidence(_EvidenceBase):
+    evidence_type: Literal["material_event"] = "material_event"
+    event_id: str = Field(min_length=1, max_length=255)
+    cluster_key: str = Field(min_length=1, max_length=255)
+    event_type: str = Field(min_length=1, max_length=128)
+    claim: str = Field(min_length=1, max_length=2000)
+    materiality_score: float = Field(ge=0.0, le=100.0)
+    risk_level: Literal["low", "medium", "high", "critical"]
+    recompute_eligible: bool
+    confirmation_status: ConfirmationStatus
+
+    @field_validator("event_id", "cluster_key", "event_type", "claim")
+    @classmethod
+    def strip_event_text(cls, value: str) -> str:
+        return _required_text(value)
+
+
+class FigureFactEvidence(_EvidenceBase):
+    evidence_type: Literal["figure_fact"] = "figure_fact"
+    figure_fact_id: str = Field(min_length=1, max_length=255)
+    figure_id: str = Field(min_length=1, max_length=255)
+    report_id: str = Field(min_length=1, max_length=255)
+    figure_content_hash: str
+    quality_status: Literal["accepted", "needs_review", "blocked"]
+    has_direct_evidence: bool
+
+    @field_validator("figure_fact_id", "figure_id", "report_id")
+    @classmethod
+    def strip_figure_identity(cls, value: str) -> str:
+        return _required_text(value)
+
+    @field_validator("figure_content_hash")
+    @classmethod
+    def validate_figure_hash(cls, value: str) -> str:
+        return _sha256(value, "figure_content_hash")
+
+    @model_validator(mode="after")
+    def validate_acceptance(self) -> "FigureFactEvidence":
+        if self.quality_status == "accepted" and not self.has_direct_evidence:
+            raise ValueError("accepted FigureFact requires has_direct_evidence=true")
+        if self.quality_status == "accepted" and self.source_quality is not SourceQuality.VALIDATED:
+            raise ValueError("accepted FigureFact requires validated source quality")
+        return self
+
+
+DeltaEvidence = Annotated[
+    MacroMetricEvidence
+    | KeyLevelEvidence
+    | OptionsRegimeEvidence
+    | MaterialEventEvidence
+    | FigureFactEvidence,
+    Field(discriminator="evidence_type"),
+]
+DELTA_EVIDENCE_ADAPTER = TypeAdapter(DeltaEvidence)
+
+
+class EvidenceIdentity(_StrictFrozenModel):
+    source: str = Field(min_length=1, max_length=128)
+    evidence_id: str = Field(min_length=1, max_length=255)
+
+    @field_validator("source", "evidence_id")
+    @classmethod
+    def strip_identity(cls, value: str) -> str:
+        return _required_text(value)
+
+
+class EvaluatedEvidence(_StrictFrozenModel):
+    evidence_key: str
+    evidence_type: Literal[
+        "macro_metric", "key_level_event", "options_regime", "material_event", "figure_fact"
+    ]
+    semantic_hash: str
+    evidence_refs: list[EvidenceIdentity] = Field(min_length=1)
+    materiality: Materiality
+    outcome: EvaluationOutcome
+    recommended_action: RecommendedAction
+    affected_state_fields: list[AffectedStateField] = Field(default_factory=list)
+    reasons: list[str] = Field(min_length=1)
+
+    @field_validator("evidence_key")
+    @classmethod
+    def strip_evidence_key(cls, value: str) -> str:
+        return _required_text(value)
+
+    @field_validator("semantic_hash")
+    @classmethod
+    def validate_semantic_hash(cls, value: str) -> str:
+        return _sha256(value, "semantic_hash")
+
+    @field_validator("affected_state_fields", "reasons")
+    @classmethod
+    def validate_sorted_unique(cls, values: list[str], info: Any) -> list[str]:
+        normalized = [_required_text(value) for value in values]
+        if normalized != sorted(set(normalized)):
+            raise ValueError(f"{info.field_name} must be sorted and unique")
+        return normalized
+
+    @field_validator("evidence_refs")
+    @classmethod
+    def validate_evidence_refs(cls, values: list[EvidenceIdentity]) -> list[EvidenceIdentity]:
+        keys = [(value.source, value.evidence_id) for value in values]
+        if keys != sorted(set(keys)):
+            raise ValueError("evidence_refs must be sorted and unique by (source, evidence_id)")
+        return values
+
+
+class EvidenceDeltaDecision(_StrictFrozenModel):
+    schema_version: Literal["evidence_delta.v1"] = EVIDENCE_DELTA_SCHEMA_VERSION
+    decision_id: str
+    content_hash: str
+    ruleset_version: Literal["evidence_delta.rules.v1"] = EVIDENCE_DELTA_RULESET_VERSION
+    asset: str = Field(min_length=1, max_length=32)
+    state_scope: StateScope
+    canonical_state_id: str = Field(min_length=1, max_length=255)
+    has_relevant_delta: bool
+    materiality: Materiality
+    recommended_action: RecommendedAction
+    affected_state_fields: list[AffectedStateField] = Field(default_factory=list)
+    trigger_reasons: list[str] = Field(min_length=1)
+    evaluated_items: list[EvaluatedEvidence] = Field(default_factory=list)
+    semantic_hashes: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("decision_id", "asset", "canonical_state_id")
+    @classmethod
+    def strip_decision_identity(cls, value: str) -> str:
+        return _required_text(value)
+
+    @field_validator("content_hash")
+    @classmethod
+    def validate_content_hash(cls, value: str) -> str:
+        return _sha256(value, "content_hash")
+
+    @field_validator("affected_state_fields", "trigger_reasons")
+    @classmethod
+    def validate_sorted_unique(cls, values: list[str], info: Any) -> list[str]:
+        normalized = [_required_text(value) for value in values]
+        if normalized != sorted(set(normalized)):
+            raise ValueError(f"{info.field_name} must be sorted and unique")
+        return normalized
+
+    @field_validator("semantic_hashes")
+    @classmethod
+    def validate_semantic_hashes(cls, values: dict[str, str]) -> dict[str, str]:
+        return {
+            _required_text(key): _sha256(value, f"semantic_hashes[{key}]")
+            for key, value in sorted(values.items())
+        }
+
+    @model_validator(mode="after")
+    def validate_decision(self) -> "EvidenceDeltaDecision":
+        expected_hash = compute_decision_content_hash(self)
+        if self.content_hash != expected_hash:
+            raise ValueError("content_hash does not match decision content")
+        if self.decision_id != f"evidence_delta_{expected_hash[:24]}":
+            raise ValueError("decision_id does not match content_hash")
+        relevant = self.recommended_action is not RecommendedAction.NO_OP
+        if self.has_relevant_delta != relevant:
+            raise ValueError("has_relevant_delta contradicts recommended_action")
+        item_keys = [(item.evidence_key, item.semantic_hash) for item in self.evaluated_items]
+        if item_keys != sorted(item_keys) or len(item_keys) != len(set(item_keys)):
+            raise ValueError("evaluated_items must be sorted and unique by evidence_key/hash")
+        if not self.evaluated_items:
+            if self.recommended_action is not RecommendedAction.NO_OP:
+                raise ValueError("empty evaluation must be no_op")
+            if self.materiality is not Materiality.NONE or self.affected_state_fields:
+                raise ValueError("empty evaluation must have no materiality or affected fields")
+            if self.trigger_reasons != ["no_evidence"] or self.semantic_hashes:
+                raise ValueError("empty evaluation trace is invalid")
+            return self
+        expected_action = max(
+            (item.recommended_action for item in self.evaluated_items),
+            key=lambda candidate: _ACTION_RANK[candidate],
+        )
+        expected_materiality = max(
+            (item.materiality for item in self.evaluated_items),
+            key=lambda candidate: _MATERIALITY_RANK[candidate],
+        )
+        if self.recommended_action is not expected_action or self.materiality is not expected_materiality:
+            raise ValueError("decision action/materiality does not match evaluated items")
+        expected_affected = sorted(
+            {
+                field
+                for item in self.evaluated_items
+                if item.recommended_action is not RecommendedAction.NO_OP
+                for field in item.affected_state_fields
+            }
+        )
+        if self.affected_state_fields != expected_affected:
+            raise ValueError("affected_state_fields do not match evaluated items")
+        expected_reasons = sorted(
+            {
+                reason
+                for item in self.evaluated_items
+                if item.recommended_action is expected_action
+                for reason in item.reasons
+            }
+        )
+        if self.trigger_reasons != expected_reasons:
+            raise ValueError("trigger_reasons do not match evaluated items")
+        identity_counts = Counter(item.evidence_key for item in self.evaluated_items)
+        hashes_by_key = {
+            item.evidence_key: item.semantic_hash
+            for item in self.evaluated_items
+            if identity_counts[item.evidence_key] == 1
+            and "authoritative_evidence_key:conflicting_payload" not in item.reasons
+        }
+        if self.semantic_hashes != hashes_by_key:
+            raise ValueError("semantic_hashes must contain only unambiguous evaluated identities")
+        return self
+
+    @classmethod
+    def build(cls, **values: Any) -> "EvidenceDeltaDecision":
+        payload = {
+            "schema_version": EVIDENCE_DELTA_SCHEMA_VERSION,
+            "ruleset_version": EVIDENCE_DELTA_RULESET_VERSION,
+            **values,
+        }
+        resolved_hash = compute_decision_content_hash(payload)
+        return cls.model_validate(
+            {
+                **payload,
+                "decision_id": f"evidence_delta_{resolved_hash[:24]}",
+                "content_hash": resolved_hash,
+            }
+        )
+
+
+def compute_decision_content_hash(value: EvidenceDeltaDecision | dict[str, Any]) -> str:
+    payload = value.model_dump(mode="json") if isinstance(value, BaseModel) else dict(value)
+    payload.pop("decision_id", None)
+    payload.pop("content_hash", None)
+    return content_hash(payload, exclude_keys=frozenset())
+
+
+def _required_text(value: str) -> str:
+    normalized = str(value).strip()
+    if not normalized:
+        raise ValueError("value must not be blank")
+    return normalized
+
+
+def _sha256(value: str, field: str) -> str:
+    normalized = str(value).strip().lower()
+    if len(normalized) != SHA256_LENGTH or any(char not in "0123456789abcdef" for char in normalized):
+        raise ValueError(f"{field} must be a lowercase SHA-256 digest")
+    return normalized

--- a/tests/analysis/test_evidence_delta_evaluator.py
+++ b/tests/analysis/test_evidence_delta_evaluator.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from apps.analysis.context_bundle.schemas import EvidenceItem
+from apps.analysis.evidence_delta import (
+    ConfirmationStatus,
+    FigureFactEvidence,
+    KeyLevelEvidence,
+    MacroMetricEvidence,
+    MaterialEventEvidence,
+    OptionsRegimeEvidence,
+    RecommendedAction,
+    SourceQuality,
+    adapt_context_evidence,
+    adapt_figure_fact,
+    evaluate_evidence_delta,
+    semantic_hash,
+    semantic_identity,
+)
+from apps.analysis.evidence_delta.schemas import EvidenceDeltaDecision
+from apps.analysis.figure_facts import FigureFact
+
+
+NOW = datetime(2026, 7, 22, 8, 0, tzinfo=timezone.utc)
+
+
+def _macro(
+    *,
+    evidence_id: str = "dxy-1",
+    source: str = "fred",
+    metric: str = "dxy",
+    current: float = 100.6,
+    previous: float = 100.0,
+    unit: str | None = None,
+    source_quality: SourceQuality = SourceQuality.PRIMARY,
+) -> MacroMetricEvidence:
+    resolved_unit = unit or {"dxy": "index", "oil": "usd"}.get(metric, "percent")
+    return MacroMetricEvidence(
+        source=source,
+        evidence_id=evidence_id,
+        asset="XAUUSD",
+        observed_at=NOW,
+        source_quality=source_quality,
+        source_ref={"series": metric},
+        metadata={"retrieved_at": "transport-only"},
+        metric=metric,
+        current_value=current,
+        previous_value=previous,
+        unit=resolved_unit,
+    )
+
+
+def _key_level(
+    *,
+    evidence_id: str = "level-1",
+    event: str = "confirmed_break",
+    confirmation: ConfirmationStatus = ConfirmationStatus.CONFIRMED,
+) -> KeyLevelEvidence:
+    return KeyLevelEvidence(
+        source="xauusd_5m",
+        evidence_id=evidence_id,
+        asset="XAUUSD",
+        observed_at=NOW,
+        source_quality=SourceQuality.VALIDATED,
+        level_id="daily_support_3300",
+        level_role="support",
+        level_value=3300.0,
+        observed_value=3294.0,
+        event=event,
+        confirmation_status=confirmation,
+    )
+
+
+def _options(
+    *,
+    evidence_id: str = "options-1",
+    change_pct: float = 0.8,
+    confirmation: ConfirmationStatus = ConfirmationStatus.CONFIRMED,
+) -> OptionsRegimeEvidence:
+    return OptionsRegimeEvidence(
+        source="cme",
+        evidence_id=evidence_id,
+        asset="XAUUSD",
+        observed_at=NOW,
+        source_quality=SourceQuality.EXCHANGE,
+        regime_id="front_month_gamma_zero",
+        event="gamma_zero_migration",
+        change_pct=change_pct,
+        confirmation_status=confirmation,
+    )
+
+
+def _event(
+    *,
+    evidence_id: str = "event-1",
+    source: str = "federal_reserve",
+    claim: str = "Federal Reserve changes its policy stance",
+    score: float = 85.0,
+    eligible: bool = True,
+    confirmation: ConfirmationStatus = ConfirmationStatus.CONFIRMED,
+) -> MaterialEventEvidence:
+    return MaterialEventEvidence(
+        source=source,
+        evidence_id=evidence_id,
+        asset="XAUUSD",
+        observed_at=NOW,
+        source_quality=SourceQuality.OFFICIAL,
+        event_id=evidence_id,
+        cluster_key="fomc-policy-change",
+        event_type="fomc_statement",
+        claim=claim,
+        materiality_score=score,
+        risk_level="high",
+        recompute_eligible=eligible,
+        confirmation_status=confirmation,
+    )
+
+
+def _evaluate(*items, previous_semantic_hashes=None):
+    return evaluate_evidence_delta(
+        asset="XAUUSD",
+        state_scope="daily_close",
+        canonical_state_id="state-001",
+        evidence=list(items),
+        previous_semantic_hashes=previous_semantic_hashes,
+    )
+
+
+def _figure(*, quality_status: str = "accepted") -> FigureFact:
+    return FigureFact.build(
+        figure_id="figure-1",
+        report_id="report-1",
+        page_no=1,
+        bbox=(0, 0, 100, 100),
+        asset="XAUUSD",
+        observations=["Gamma zero moved higher"] if quality_status == "accepted" else [],
+        numeric_values=[],
+        derived_claims=[],
+        interpretation_limits=[] if quality_status == "accepted" else ["manual review required"],
+        source_ref={
+            "figure_id": "figure-1",
+            "report_id": "report-1",
+            "page_no": 1,
+            "bbox": [0, 0, 100, 100],
+        },
+        quality_status=quality_status,
+        image_content_hash="a" * 64 if quality_status == "accepted" else None,
+        created_by_run_id="run-1",
+    )
+
+
+def test_empty_evidence_is_stable_no_op() -> None:
+    first = _evaluate()
+    second = _evaluate()
+
+    assert first == second
+    assert first.has_relevant_delta is False
+    assert first.recommended_action is RecommendedAction.NO_OP
+    assert first.trigger_reasons == ["no_evidence"]
+    assert first.decision_id == f"evidence_delta_{first.content_hash[:24]}"
+
+
+def test_input_order_does_not_change_decision_identity() -> None:
+    first = _evaluate(_macro(), _options())
+    second = _evaluate(_options(), _macro())
+
+    assert first == second
+    assert first.recommended_action is RecommendedAction.RUN_TRANSITION_ANALYSIS
+
+
+def test_duplicate_news_from_different_sources_is_clustered_with_source_aware_refs() -> None:
+    first = _event(source="federal_reserve", evidence_id="official-1")
+    second = _event(source="reuters", evidence_id="wire-9")
+    second = second.model_copy(update={"source_quality": SourceQuality.VALIDATED})
+
+    decision = _evaluate(second, first)
+
+    assert len(decision.evaluated_items) == 1
+    assert [(ref.source, ref.evidence_id) for ref in decision.evaluated_items[0].evidence_refs] == [
+        ("federal_reserve", "official-1"),
+        ("reuters", "wire-9"),
+    ]
+    assert decision.recommended_action is RecommendedAction.RUN_TRANSITION_ANALYSIS
+
+
+def test_same_evidence_id_from_different_sources_is_not_collapsed() -> None:
+    first = _event(source="federal_reserve", evidence_id="shared-id")
+    second = _event(source="reuters", evidence_id="shared-id")
+    second = second.model_copy(update={"source_quality": SourceQuality.VALIDATED})
+
+    item = _evaluate(first, second).evaluated_items[0]
+
+    assert len(item.evidence_refs) == 2
+
+
+def test_previous_semantic_hash_makes_metadata_only_update_no_op() -> None:
+    original = _macro()
+    replay = original.model_copy(
+        update={
+            "evidence_id": "dxy-new-delivery",
+            "source_ref": {"series": "dxy", "path": "new-path"},
+            "metadata": {"retrieved_at": "later"},
+        }
+    )
+    key = semantic_identity(original)
+
+    decision = _evaluate(replay, previous_semantic_hashes={key: semantic_hash(original)})
+
+    assert decision.recommended_action is RecommendedAction.NO_OP
+    assert decision.evaluated_items[0].outcome == "duplicate"
+    assert decision.evaluated_items[0].reasons == ["semantic_content_unchanged"]
+
+
+@pytest.mark.parametrize(
+    ("current", "expected"),
+    [
+        (100.1, RecommendedAction.NO_OP),
+        (100.3, RecommendedAction.UPDATE_CONTEXT_ONLY),
+        (100.6, RecommendedAction.RUN_TRANSITION_ANALYSIS),
+    ],
+)
+def test_macro_threshold_bands_are_deterministic(current: float, expected: RecommendedAction) -> None:
+    assert _evaluate(_macro(current=current)).recommended_action is expected
+
+
+def test_large_untrusted_macro_move_goes_to_manual_review_not_model() -> None:
+    decision = _evaluate(
+        _macro(current=101.0, source_quality=SourceQuality.UNVERIFIED, source="unknown_feed")
+    )
+
+    assert decision.recommended_action is RecommendedAction.MANUAL_REVIEW
+    assert "untrusted_material_move" in decision.trigger_reasons[0]
+
+
+@pytest.mark.parametrize(
+    ("metric", "bad_unit", "expected_unit"),
+    [
+        ("dxy", "percent", "index"),
+        ("us10y", "index", "percent"),
+        ("real10y", "usd", "percent"),
+        ("oil", "index", "usd"),
+    ],
+)
+def test_metric_unit_mismatch_fails_closed(metric: str, bad_unit: str, expected_unit: str) -> None:
+    with pytest.raises(ValidationError, match=f"requires unit={expected_unit}"):
+        _macro(metric=metric, unit=bad_unit)
+
+
+def test_confirmed_key_level_break_triggers_transition() -> None:
+    decision = _evaluate(_key_level())
+
+    assert decision.recommended_action is RecommendedAction.RUN_TRANSITION_ANALYSIS
+    assert decision.materiality == "critical"
+    assert decision.affected_state_fields == [
+        "invalidation_conditions",
+        "key_levels",
+        "scenario_states",
+    ]
+
+
+def test_unconfirmed_key_level_break_requires_manual_review() -> None:
+    decision = _evaluate(_key_level(confirmation=ConfirmationStatus.UNCONFIRMED))
+
+    assert decision.recommended_action is RecommendedAction.MANUAL_REVIEW
+    assert "confirmation_required" in decision.trigger_reasons[0]
+
+
+def test_options_regime_only_triggers_for_confirmed_exchange_change() -> None:
+    assert _evaluate(_options(change_pct=0.49)).recommended_action is RecommendedAction.NO_OP
+    assert _evaluate(_options(change_pct=0.8)).recommended_action is RecommendedAction.RUN_TRANSITION_ANALYSIS
+    assert (
+        _evaluate(_options(change_pct=0.8, confirmation=ConfirmationStatus.UNCONFIRMED)).recommended_action
+        is RecommendedAction.MANUAL_REVIEW
+    )
+
+
+def test_confirmed_material_event_triggers_and_unconfirmed_high_risk_stays_manual() -> None:
+    assert _evaluate(_event()).recommended_action is RecommendedAction.RUN_TRANSITION_ANALYSIS
+    assert (
+        _evaluate(_event(eligible=False, confirmation=ConfirmationStatus.UNCONFIRMED)).recommended_action
+        is RecommendedAction.MANUAL_REVIEW
+    )
+
+
+def test_same_semantic_identity_with_conflicting_payloads_fails_closed() -> None:
+    first = _macro(evidence_id="dxy-1", current=100.6)
+    decision = _evaluate(
+        first,
+        _macro(evidence_id="dxy-2", current=101.0),
+        previous_semantic_hashes={semantic_identity(first): semantic_hash(first)},
+    )
+
+    assert decision.recommended_action is RecommendedAction.MANUAL_REVIEW
+    assert decision.semantic_hashes == {}
+    assert all(item.reasons == ["semantic_identity:conflicting_payload"] for item in decision.evaluated_items)
+
+
+def test_same_authoritative_source_key_with_different_payloads_fails_closed() -> None:
+    first = _macro(evidence_id="same-key", current=100.6)
+    second = _event(evidence_id="same-key", source="fred")
+
+    decision = _evaluate(first, second)
+
+    assert decision.recommended_action is RecommendedAction.MANUAL_REVIEW
+    assert decision.semantic_hashes == {}
+    assert all(
+        item.reasons == ["authoritative_evidence_key:conflicting_payload"]
+        for item in decision.evaluated_items
+    )
+
+
+def test_accepted_figure_fact_is_context_only_and_nonaccepted_fact_is_ignored() -> None:
+    accepted = adapt_figure_fact(_figure(), observed_at=NOW)
+    needs_review = adapt_figure_fact(_figure(quality_status="needs_review"), observed_at=NOW)
+
+    assert _evaluate(accepted).recommended_action is RecommendedAction.UPDATE_CONTEXT_ONLY
+    assert _evaluate(needs_review).recommended_action is RecommendedAction.NO_OP
+
+
+@pytest.mark.parametrize(
+    ("source_quality", "has_direct_evidence", "message"),
+    [
+        (SourceQuality.VALIDATED, False, "has_direct_evidence"),
+        (SourceQuality.OFFICIAL, True, "validated source quality"),
+        (SourceQuality.EXCHANGE, True, "validated source quality"),
+        (SourceQuality.PRIMARY, True, "validated source quality"),
+        (SourceQuality.SUPPLEMENTAL, True, "validated source quality"),
+        (SourceQuality.UNVERIFIED, True, "validated source quality"),
+    ],
+)
+def test_figure_evidence_acceptance_requires_direct_validated_fact(
+    source_quality: SourceQuality, has_direct_evidence: bool, message: str
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        FigureFactEvidence(
+            source="figure_fact",
+            evidence_id="fact-1",
+            asset="XAUUSD",
+            observed_at=NOW,
+            source_quality=source_quality,
+            figure_fact_id="fact-1",
+            figure_id="figure-1",
+            report_id="report-1",
+            figure_content_hash="a" * 64,
+            quality_status="accepted",
+            has_direct_evidence=has_direct_evidence,
+        )
+
+
+def test_context_adapter_requires_explicit_known_kind_quality_asset_and_unit() -> None:
+    base = EvidenceItem(
+        source="fred",
+        evidence_id="dxy-1",
+        business_time=NOW,
+        ingested_at=NOW,
+        payload={
+            "evidence_type": "macro_metric",
+            "asset": "XAUUSD",
+            "source_quality": "primary",
+            "metric": "dxy",
+            "current_value": 100.6,
+            "previous_value": 100.0,
+            "unit": "index",
+        },
+    )
+    adapted = adapt_context_evidence(base)
+    assert isinstance(adapted, MacroMetricEvidence)
+
+    for payload, message in [
+        ({**base.payload, "evidence_type": "unknown"}, "Input tag"),
+        ({key: value for key, value in base.payload.items() if key != "source_quality"}, "source_quality"),
+        ({key: value for key, value in base.payload.items() if key != "unit"}, "unit"),
+    ]:
+        item = base.model_copy(update={"payload": payload})
+        with pytest.raises((ValueError, ValidationError), match=message):
+            adapt_context_evidence(item)
+
+
+def test_asset_mismatch_fails_closed_before_decision() -> None:
+    with pytest.raises(ValueError, match="evidence asset mismatch"):
+        evaluate_evidence_delta(
+            asset="GC",
+            state_scope="daily_close",
+            canonical_state_id="state-1",
+            evidence=[_macro()],
+        )
+
+
+def test_decision_hash_rejects_tampering_and_contains_no_state_patch() -> None:
+    decision = _evaluate(_macro())
+    payload = decision.model_dump(mode="json")
+    assert "core_thesis" not in payload
+    assert "net_bias" not in payload
+    assert "state_patch" not in payload
+    payload["affected_state_fields"] = ["core_thesis"]
+
+    with pytest.raises(ValidationError, match="literal|content_hash"):
+        EvidenceDeltaDecision.model_validate(payload)

--- a/tests/architecture/test_analysis_memory_ci_guards.py
+++ b/tests/architecture/test_analysis_memory_ci_guards.py
@@ -11,6 +11,7 @@ def test_ci_runs_analysis_memory_focused_and_postgres_suites() -> None:
     focused_suites = {
         "tests/database/test_analysis_state_core.py",
         "tests/analysis/test_context_bundle.py",
+        "tests/analysis/test_evidence_delta_evaluator.py",
         "tests/analysis/test_state_materializer.py",
         "tests/analysis/test_figure_facts.py",
         "tests/output/test_context_bundle_artifacts.py",
@@ -23,6 +24,7 @@ def test_ci_runs_analysis_memory_focused_and_postgres_suites() -> None:
     for suite in focused_suites:
         assert suite in workflow
 
+    assert "apps/analysis/evidence_delta" in workflow
     assert "analysis-memory-postgres:" in workflow
     assert "services:" in workflow
     assert "postgres:" in workflow


### PR DESCRIPTION
## Summary
- add a pure deterministic EvidenceDeltaEvaluator with fixed no_op, update_context_only, run_transition_analysis, and manual_review outcomes
- preserve source-aware semantic identity, deterministic reasons, affected fields, and replay hashes while failing closed on conflicts or insufficient evidence quality
- register the evaluator package and regression test in the required Analysis Memory CI gates

## Verification
- full Analysis Memory regression including evaluator: 140 passed
- focused evaluator, ContextBundle, FigureFact, and architecture suite: 52 passed
- Ruff and git diff --check: passed
- CI workflow YAML parse and changed-file sensitive path scan: passed

Closes #76