### PR TITLE
feat: add materiality-aware context bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
           database/models/analysis_state.py
           scripts/bootstrap_analysis_state.py
           tests/analysis/test_context_bundle.py
+          tests/analysis/test_context_bundle_selection.py
           tests/analysis/test_evidence_delta_evaluator.py
           tests/analysis/test_figure_facts.py
           tests/analysis/test_state_bootstrap.py
@@ -102,6 +103,7 @@ jobs:
           tests/database/test_alembic_runtime_unification.py
           tests/database/test_analysis_state_core.py
           tests/analysis/test_context_bundle.py
+          tests/analysis/test_context_bundle_selection.py
           tests/analysis/test_evidence_delta_evaluator.py
           tests/analysis/test_state_materializer.py
           tests/analysis/test_figure_facts.py

--- a/apps/analysis/context_bundle/__init__.py
+++ b/apps/analysis/context_bundle/__init__.py
@@ -8,6 +8,7 @@ from .assembler import (
 from .schemas import (
     CONTEXT_BUNDLE_SCHEMA_VERSION,
     LEGACY_CONTEXT_BUNDLE_SCHEMA_VERSION,
+    SCOPED_CONTEXT_BUNDLE_SCHEMA_VERSION,
     AnalysisContextBundle,
     ContextBlock,
     EvidenceCursor,
@@ -17,6 +18,7 @@ from .schemas import (
 __all__ = [
     "CONTEXT_BUNDLE_SCHEMA_VERSION",
     "LEGACY_CONTEXT_BUNDLE_SCHEMA_VERSION",
+    "SCOPED_CONTEXT_BUNDLE_SCHEMA_VERSION",
     "AnalysisContextBundle",
     "ContextBlock",
     "ContextBundleBudgetExceeded",

--- a/apps/analysis/context_bundle/assembler.py
+++ b/apps/analysis/context_bundle/assembler.py
@@ -8,6 +8,12 @@ from collections import defaultdict
 from datetime import UTC, datetime
 from typing import Any
 
+from apps.analysis.context_bundle.selection import (
+    DeferredEvidencePointer,
+    EvidencePriority,
+    EvidencePriorityClass,
+    select_material_evidence,
+)
 from apps.analysis.context_bundle.schemas import (
     CONTEXT_BUNDLE_SCHEMA_VERSION,
     AnalysisContextBundle,
@@ -17,10 +23,20 @@ from apps.analysis.context_bundle.schemas import (
     EvidenceItem,
     compute_bundle_content_hash,
 )
+from apps.analysis.evidence_delta import (
+    DeltaEvidence,
+    EvidenceDeltaDecision,
+    FigureFactEvidence,
+    Materiality,
+    RecommendedAction,
+    adapt_context_evidence,
+    evaluate_evidence_delta,
+)
 from apps.analysis.state.schemas import StateScope
 
 
 DEFAULT_CONTEXT_TOKEN_BUDGET = 15_000
+DEFAULT_SOURCE_FRESHNESS_SLA_SECONDS = 86_400
 _HISTORY_BODY_KEYS = frozenset(
     {
         "article_markdown",
@@ -101,16 +117,31 @@ def assemble_context_bundle(
     cutoff_at: datetime,
     assembled_at: datetime,
     facts: list[dict[str, Any]] | None = None,
+    delta_facts: list[DeltaEvidence] | None = None,
+    previous_semantic_hashes: dict[str, str] | None = None,
+    deferred_queue: tuple[DeferredEvidencePointer | dict[str, Any], ...] = (),
+    processed_above_frontier: dict[
+        str, tuple[DeferredEvidencePointer | dict[str, Any], ...]
+    ]
+    | None = None,
+    freshness_sla_seconds: dict[str, int] | None = None,
+    default_freshness_sla_seconds: int = DEFAULT_SOURCE_FRESHNESS_SLA_SECONDS,
     expected_session: str | None = None,
     max_alignment_seconds: int = 86_400,
     budget_tokens: int = DEFAULT_CONTEXT_TOKEN_BUDGET,
 ) -> AnalysisContextBundle:
-    """Build a stable bundle; dropped evidence never advances its source cursor."""
+    """Build a v3 bundle from one materiality-evaluated, gap-safe evidence set."""
 
     if budget_tokens < 1:
         raise ValueError("budget_tokens must be positive")
     if max_alignment_seconds < 0:
         raise ValueError("max_alignment_seconds must be non-negative")
+    if (
+        isinstance(default_freshness_sla_seconds, bool)
+        or not isinstance(default_freshness_sla_seconds, int)
+        or default_freshness_sla_seconds < 0
+    ):
+        raise ValueError("default_freshness_sla_seconds must be a non-negative integer")
     _require_aware_datetime(cutoff_at, field="cutoff_at")
     _require_aware_datetime(assembled_at, field="assembled_at")
     normalized_asset = str(asset).strip()
@@ -128,20 +159,29 @@ def assemble_context_bundle(
         trim_reasons=trim_reasons,
         block="canonical_state",
     )
-    selected = select_incremental_evidence(
+    incremental = select_incremental_evidence(
         evidence,
         cursors=evidence_cursors,
         cutoff_at=cutoff_at,
         trim_reasons=trim_reasons,
     )
-    evidence_payload = [
-        _compact_value(
+    processed = _normalize_processed(processed_above_frontier)
+    processed_keys = {
+        (pointer.source, pointer.evidence_id)
+        for pointers in processed.values()
+        for pointer in pointers
+    }
+    eligible = [
+        item for item in incremental if (item.source, item.evidence_id) not in processed_keys
+    ]
+    compacted_evidence = {
+        (item.source, item.evidence_id): _compact_value(
             item.model_dump(mode="json"),
             trim_reasons=trim_reasons,
             block="delta_evidence",
         )
-        for item in selected
-    ]
+        for item in incremental
+    }
     facts_payload = [
         _compact_value(
             _sanitize_value(item, trim_reasons=trim_reasons, block="facts"),
@@ -151,49 +191,103 @@ def assemble_context_bundle(
         for item in (facts or [])
     ]
 
-    retained = list(selected)
-    while True:
-        blocks = _build_blocks(
-            state_payload=state_payload,
-            evidence_payload=evidence_payload,
-            facts_payload=facts_payload,
-            retained_evidence=retained,
-            trim_reasons=trim_reasons,
-        )
-        trace = _budget_trace(blocks, budget_tokens=budget_tokens, trim_reasons=trim_reasons)
-        if trace["within_budget"]:
-            break
-        if evidence_payload:
-            evidence_payload.pop()
-            deferred = retained.pop()
-            trim_reasons["delta_evidence"].append(
-                f"budget_deferred:{deferred.evidence_id}"
-            )
-            continue
-        if facts_payload:
-            facts_payload.pop(0)
-            trim_reasons["facts"].append("budget_dropped_oldest_fact")
-            continue
-        raise ContextBundleBudgetExceeded(trace)
-
     normalized_cursors = {
         source: value if isinstance(value, EvidenceCursor) else EvidenceCursor.model_validate(value)
         for source, value in (evidence_cursors or {}).items()
     }
-    next_cursors = dict(normalized_cursors)
-    for item in retained:
-        cursor = EvidenceCursor(ingested_at=item.ingested_at, evidence_id=item.evidence_id)
-        current = next_cursors.get(item.source)
-        if current is None or (cursor.ingested_at, cursor.evidence_id) > (
-            current.ingested_at,
-            current.evidence_id,
-        ):
-            next_cursors[item.source] = cursor
+    normalized_delta_facts = _accepted_delta_facts(delta_facts or [])
+    preliminary_decision = evaluate_evidence_delta(
+        asset=normalized_asset,
+        state_scope=state_scope,
+        canonical_state_id=str(canonical_state_id).strip(),
+        evidence=[*(adapt_context_evidence(item) for item in eligible), *normalized_delta_facts],
+        previous_semantic_hashes=previous_semantic_hashes,
+    )
+    priorities = _priorities_from_decision(
+        decision=preliminary_decision,
+        evidence=eligible,
+        compacted_evidence=compacted_evidence,
+    )
+    priorities.extend(
+        _processed_priorities(
+            processed=processed,
+            incremental=incremental,
+            compacted_evidence=compacted_evidence,
+        )
+    )
 
-    freshness = _freshness(retained, cutoff_at=cutoff_at)
-    session = _session_status(retained, expected_session=expected_session)
-    alignment = _alignment_status(retained, max_alignment_seconds=max_alignment_seconds)
-    source_refs = [dict(item.source_ref) for item in retained if item.source_ref]
+    empty_blocks = _build_blocks(
+        state_payload=state_payload,
+        evidence_payload=[],
+        facts_payload=facts_payload,
+        retained_evidence=[],
+        trim_reasons=trim_reasons,
+    )
+    fixed_trace = _budget_trace(
+        empty_blocks,
+        budget_tokens=budget_tokens,
+        trim_reasons=trim_reasons,
+    )
+    if not fixed_trace["within_budget"]:
+        raise ContextBundleBudgetExceeded(fixed_trace)
+    fixed_tokens = sum(
+        block.estimated_tokens for block in empty_blocks if block.name != "delta_evidence"
+    )
+    selection = select_material_evidence(
+        evidence=incremental,
+        priorities=priorities,
+        evidence_cursors=normalized_cursors,
+        cutoff_at=cutoff_at,
+        evidence_budget_tokens=max(0, budget_tokens - fixed_tokens - 1),
+        deferred_queue=deferred_queue,
+        processed_above_frontier=processed,
+    )
+    incremental_by_key = {(item.source, item.evidence_id): item for item in incremental}
+    retained = [
+        incremental_by_key[(key.source, key.evidence_id)]
+        for key in selection.retained_evidence_keys
+    ]
+    evidence_payload = [
+        compacted_evidence[(item.source, item.evidence_id)] for item in retained
+    ]
+    for decision in selection.decisions:
+        if decision.outcome == "deferred":
+            trim_reasons["delta_evidence"].append(
+                f"budget_deferred:{decision.source}/{decision.evidence_id}"
+            )
+    blocks = _build_blocks(
+        state_payload=state_payload,
+        evidence_payload=evidence_payload,
+        facts_payload=facts_payload,
+        retained_evidence=retained,
+        trim_reasons=trim_reasons,
+    )
+    trace = _budget_trace(blocks, budget_tokens=budget_tokens, trim_reasons=trim_reasons)
+    if not trace["within_budget"]:
+        raise ContextBundleBudgetExceeded(trace)
+
+    final_decision = evaluate_evidence_delta(
+        asset=normalized_asset,
+        state_scope=state_scope,
+        canonical_state_id=str(canonical_state_id).strip(),
+        evidence=[*(adapt_context_evidence(item) for item in retained), *normalized_delta_facts],
+        previous_semantic_hashes=previous_semantic_hashes,
+    )
+    normalized_slas = _normalize_freshness_slas(freshness_sla_seconds)
+    freshness = _freshness(
+        eligible,
+        cutoff_at=cutoff_at,
+        freshness_sla_seconds=normalized_slas,
+        default_freshness_sla_seconds=default_freshness_sla_seconds,
+    )
+    session = _session_status(eligible, expected_session=expected_session)
+    alignment = _alignment_status(eligible, max_alignment_seconds=max_alignment_seconds)
+    source_refs = [dict(item.source_ref) for item in eligible if item.source_ref]
+    source_refs.extend(
+        dict(item["source_ref"])
+        for item in facts_payload
+        if isinstance(item, dict) and isinstance(item.get("source_ref"), dict)
+    )
     base_payload = {
         "schema_version": CONTEXT_BUNDLE_SCHEMA_VERSION,
         "run_id": str(run_id).strip(),
@@ -205,11 +299,24 @@ def assemble_context_bundle(
             source: cursor.model_dump(mode="json") for source, cursor in normalized_cursors.items()
         },
         "next_evidence_cursors": {
-            source: cursor.model_dump(mode="json") for source, cursor in next_cursors.items()
+            source: cursor.model_dump(mode="json")
+            for source, cursor in selection.next_evidence_cursors.items()
         },
         "freshness": freshness,
         "session": session,
         "alignment": alignment,
+        "evidence_delta_decision": final_decision.model_dump(mode="json"),
+        "deferred_queue": [item.model_dump(mode="json") for item in selection.deferred_queue],
+        "processed_above_frontier": {
+            source: [item.model_dump(mode="json") for item in pointers]
+            for source, pointers in selection.processed_above_frontier.items()
+        },
+        "selection_decisions": [
+            item.model_dump(mode="json") for item in selection.decisions
+        ],
+        "selection_trace": selection.trace.model_dump(mode="json"),
+        "freshness_sla_seconds": normalized_slas,
+        "default_freshness_sla_seconds": default_freshness_sla_seconds,
         "blocks": [block.model_dump(mode="json") for block in blocks],
         "budget_trace": trace,
         "source_refs": source_refs,
@@ -226,6 +333,137 @@ def assemble_context_bundle(
             "assembled_at": assembled_at,
         }
     )
+
+
+def _accepted_delta_facts(items: list[DeltaEvidence]) -> list[FigureFactEvidence]:
+    accepted: list[FigureFactEvidence] = []
+    for item in items:
+        if not isinstance(item, FigureFactEvidence):
+            raise ValueError("delta_facts only accepts FigureFactEvidence")
+        if item.quality_status != "accepted" or not item.has_direct_evidence:
+            raise ValueError("only accepted FigureFact evidence may enter a context bundle")
+        if item.source != "figure_fact" or item.evidence_id != item.figure_fact_id:
+            raise ValueError("FigureFact delta evidence must use its canonical figure_fact identity")
+        accepted.append(item)
+    return accepted
+
+
+def _priorities_from_decision(
+    *,
+    decision: EvidenceDeltaDecision,
+    evidence: list[EvidenceItem],
+    compacted_evidence: dict[tuple[str, str], dict[str, Any]],
+) -> list[EvidencePriority]:
+    evaluated_by_ref = {
+        (ref.source, ref.evidence_id): item
+        for item in decision.evaluated_items
+        for ref in item.evidence_refs
+    }
+    priorities: list[EvidencePriority] = []
+    for item in evidence:
+        key = (item.source, item.evidence_id)
+        evaluated = evaluated_by_ref.get(key)
+        if evaluated is None:
+            raise ValueError(f"evidence delta decision omitted eligible evidence: {item.source}/{item.evidence_id}")
+        priority_class = _priority_class(evaluated)
+        priorities.append(
+            EvidencePriority(
+                source=item.source,
+                evidence_id=item.evidence_id,
+                semantic_hash=evaluated.semantic_hash,
+                priority_class=priority_class,
+                materiality=evaluated.materiality.value,
+                mandatory=priority_class is EvidencePriorityClass.MANDATORY_CRITICAL,
+                reason_codes=tuple(evaluated.reasons),
+                estimated_tokens=max(
+                    1,
+                    _estimate_tokens(_canonical_bytes(compacted_evidence[key])) + 1,
+                ),
+            )
+        )
+    return priorities
+
+
+def _priority_class(evaluated: Any) -> EvidencePriorityClass:
+    if (
+        evaluated.materiality is Materiality.CRITICAL
+        or evaluated.recommended_action is RecommendedAction.MANUAL_REVIEW
+    ):
+        return EvidencePriorityClass.MANDATORY_CRITICAL
+    if (
+        evaluated.recommended_action is RecommendedAction.RUN_TRANSITION_ANALYSIS
+        and "invalidation_conditions" in evaluated.affected_state_fields
+    ):
+        return EvidencePriorityClass.CONFIRMED_INVALIDATION
+    if (
+        evaluated.evidence_type == "key_level_event"
+        and evaluated.recommended_action is RecommendedAction.RUN_TRANSITION_ANALYSIS
+    ):
+        return EvidencePriorityClass.CONFIRMED_KEY_LEVEL
+    if evaluated.evidence_type == "options_regime":
+        return EvidencePriorityClass.MARKET_OPTIONS_REGIME
+    if evaluated.materiality is Materiality.HIGH:
+        return EvidencePriorityClass.LATEST_HIGH_QUALITY
+    if evaluated.materiality is Materiality.MEDIUM:
+        return EvidencePriorityClass.ORDINARY_CURRENT
+    return EvidencePriorityClass.BACKLOG
+
+
+def _normalize_processed(
+    values: dict[str, tuple[DeferredEvidencePointer | dict[str, Any], ...]] | None,
+) -> dict[str, tuple[DeferredEvidencePointer, ...]]:
+    return {
+        str(source).strip(): tuple(
+            item
+            if isinstance(item, DeferredEvidencePointer)
+            else DeferredEvidencePointer.model_validate(item)
+            for item in pointers
+        )
+        for source, pointers in sorted((values or {}).items())
+    }
+
+
+def _processed_priorities(
+    *,
+    processed: dict[str, tuple[DeferredEvidencePointer, ...]],
+    incremental: list[EvidenceItem],
+    compacted_evidence: dict[tuple[str, str], dict[str, Any]],
+) -> list[EvidencePriority]:
+    priorities: list[EvidencePriority] = []
+    for pointers in processed.values():
+        for pointer in pointers:
+            key = (pointer.source, pointer.evidence_id)
+            payload = compacted_evidence.get(key)
+            estimated_tokens = (
+                max(1, _estimate_tokens(_canonical_bytes(payload)) + 1)
+                if payload is not None
+                else 1
+            )
+            priorities.append(
+                EvidencePriority(
+                    source=pointer.source,
+                    evidence_id=pointer.evidence_id,
+                    semantic_hash=pointer.semantic_hash,
+                    priority_class=EvidencePriorityClass.BACKLOG,
+                    materiality="processed",
+                    mandatory=False,
+                    reason_codes=("already_processed_above_frontier",),
+                    estimated_tokens=estimated_tokens,
+                )
+            )
+    return priorities
+
+
+def _normalize_freshness_slas(values: dict[str, int] | None) -> dict[str, int]:
+    normalized: dict[str, int] = {}
+    for raw_source, raw_sla in sorted((values or {}).items()):
+        source = str(raw_source).strip()
+        if not source:
+            raise ValueError("freshness SLA source must not be blank")
+        if isinstance(raw_sla, bool) or not isinstance(raw_sla, int) or raw_sla < 0:
+            raise ValueError("freshness SLA seconds must be non-negative integers")
+        normalized[source] = raw_sla
+    return normalized
 
 
 def _build_blocks(
@@ -360,20 +598,40 @@ def _compact_value(
     return value
 
 
-def _freshness(items: list[EvidenceItem], *, cutoff_at: datetime) -> dict[str, Any]:
+def _freshness(
+    items: list[EvidenceItem],
+    *,
+    cutoff_at: datetime,
+    freshness_sla_seconds: dict[str, int],
+    default_freshness_sla_seconds: int,
+) -> dict[str, Any]:
     latest: dict[str, EvidenceItem] = {}
     for item in items:
         current = latest.get(item.source)
         if current is None or item.ingested_at > current.ingested_at:
             latest[item.source] = item
-    return {
-        source: {
-            "status": "current",
+    result: dict[str, Any] = {}
+    for source in sorted(set(latest) | set(freshness_sla_seconds)):
+        sla_seconds = freshness_sla_seconds.get(source, default_freshness_sla_seconds)
+        item = latest.get(source)
+        if item is None:
+            result[source] = {
+                "status": "missing",
+                "latest_ingested_at": None,
+                "age_seconds": None,
+                "sla_seconds": sla_seconds,
+                "sla_policy": "explicit",
+            }
+            continue
+        age_seconds = max(0.0, (cutoff_at - item.ingested_at).total_seconds())
+        result[source] = {
+            "status": "current" if age_seconds <= sla_seconds else "stale",
             "latest_ingested_at": _json_datetime(item.ingested_at),
-            "age_seconds": max(0.0, (cutoff_at - item.ingested_at).total_seconds()),
+            "age_seconds": age_seconds,
+            "sla_seconds": sla_seconds,
+            "sla_policy": "explicit" if source in freshness_sla_seconds else "default",
         }
-        for source, item in sorted(latest.items())
-    }
+    return result
 
 
 def _session_status(

--- a/apps/analysis/context_bundle/schemas.py
+++ b/apps/analysis/context_bundle/schemas.py
@@ -3,16 +3,37 @@
 from __future__ import annotations
 
 import json
+import uuid
 from typing import Any, Literal
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictInt,
+    field_validator,
+    model_validator,
+)
 
 from apps.analysis.state.hashing import content_hash
 from apps.analysis.state.schemas import StateScope
 
 
 LEGACY_CONTEXT_BUNDLE_SCHEMA_VERSION = "analysis_context_bundle.v1"
-CONTEXT_BUNDLE_SCHEMA_VERSION = "analysis_context_bundle.v2"
+SCOPED_CONTEXT_BUNDLE_SCHEMA_VERSION = "analysis_context_bundle.v2"
+CONTEXT_BUNDLE_SCHEMA_VERSION = "analysis_context_bundle.v3"
+_V3_ONLY_FIELDS = frozenset(
+    {
+        "evidence_delta_decision",
+        "deferred_queue",
+        "processed_above_frontier",
+        "selection_decisions",
+        "selection_trace",
+        "freshness_sla_seconds",
+        "default_freshness_sla_seconds",
+    }
+)
 _TRANSPORT_KEYS = frozenset(
     {
         "provider",
@@ -106,6 +127,7 @@ class AnalysisContextBundle(_StrictFrozenModel):
     schema_version: Literal[
         "analysis_context_bundle.v1",
         "analysis_context_bundle.v2",
+        "analysis_context_bundle.v3",
     ] = CONTEXT_BUNDLE_SCHEMA_VERSION
     state_scope: StateScope | None = None
     bundle_id: str
@@ -120,6 +142,13 @@ class AnalysisContextBundle(_StrictFrozenModel):
     freshness: dict[str, Any] = Field(default_factory=dict)
     session: dict[str, Any] = Field(default_factory=dict)
     alignment: dict[str, Any] = Field(default_factory=dict)
+    evidence_delta_decision: dict[str, Any] | None = None
+    deferred_queue: list[dict[str, Any]] = Field(default_factory=list)
+    processed_above_frontier: dict[str, list[dict[str, Any]]] = Field(default_factory=dict)
+    selection_decisions: list[dict[str, Any]] = Field(default_factory=list)
+    selection_trace: dict[str, Any] | None = None
+    freshness_sla_seconds: dict[str, StrictInt] = Field(default_factory=dict)
+    default_freshness_sla_seconds: StrictInt | None = None
     blocks: list[ContextBlock] = Field(min_length=1)
     budget_trace: ContextBudgetTrace
     source_refs: list[dict[str, Any]] = Field(default_factory=list)
@@ -137,6 +166,79 @@ class AnalysisContextBundle(_StrictFrozenModel):
             raise ValueError("content_hash must be a lowercase SHA-256 digest")
         return normalized
 
+    @field_validator("evidence_delta_decision", mode="before")
+    @classmethod
+    def _normalize_evidence_delta_decision(cls, value: Any) -> Any:
+        if value is None:
+            return None
+        from apps.analysis.evidence_delta.schemas import EvidenceDeltaDecision
+
+        return EvidenceDeltaDecision.model_validate(value).model_dump(mode="json")
+
+    @field_validator("deferred_queue", mode="before")
+    @classmethod
+    def _normalize_deferred_queue(cls, value: Any) -> list[dict[str, Any]]:
+        from apps.analysis.context_bundle.selection import DeferredEvidencePointer
+
+        normalized = [
+            DeferredEvidencePointer.model_validate(item).model_dump(mode="json")
+            for item in (value or [])
+        ]
+        return sorted(
+            normalized,
+            key=lambda item: (item["source"], item["ingested_at"], item["evidence_id"]),
+        )
+
+    @field_validator("processed_above_frontier", mode="before")
+    @classmethod
+    def _normalize_processed_above_frontier(cls, value: Any) -> dict[str, list[dict[str, Any]]]:
+        from apps.analysis.context_bundle.selection import DeferredEvidencePointer
+
+        return {
+            str(source).strip(): sorted(
+                [
+                    DeferredEvidencePointer.model_validate(item).model_dump(mode="json")
+                    for item in pointers
+                ],
+                key=lambda item: (item["ingested_at"], item["evidence_id"]),
+            )
+            for source, pointers in sorted(dict(value or {}).items())
+        }
+
+    @field_validator("selection_decisions", mode="before")
+    @classmethod
+    def _normalize_selection_decisions(cls, value: Any) -> list[dict[str, Any]]:
+        from apps.analysis.context_bundle.selection import EvidenceSelectionDecision
+
+        normalized = [
+            EvidenceSelectionDecision.model_validate(item).model_dump(mode="json")
+            for item in (value or [])
+        ]
+        return sorted(
+            normalized,
+            key=lambda item: (item["source"], item["evidence_id"], item["outcome"]),
+        )
+
+    @field_validator("selection_trace", mode="before")
+    @classmethod
+    def _normalize_selection_trace(cls, value: Any) -> Any:
+        if value is None:
+            return None
+        from apps.analysis.context_bundle.selection import EvidenceSelectionTrace
+
+        return EvidenceSelectionTrace.model_validate(value).model_dump(mode="json")
+
+    @field_validator("freshness_sla_seconds")
+    @classmethod
+    def _normalize_freshness_slas(cls, value: dict[str, int]) -> dict[str, int]:
+        normalized: dict[str, int] = {}
+        for source, sla_seconds in sorted(value.items()):
+            source_name = _required_text(source, "freshness SLA source")
+            if sla_seconds < 0:
+                raise ValueError("freshness SLA seconds must be non-negative integers")
+            normalized[source_name] = sla_seconds
+        return normalized
+
     @model_validator(mode="after")
     def _validate_bundle(self) -> "AnalysisContextBundle":
         payload = self.model_dump(mode="json")
@@ -145,7 +247,21 @@ class AnalysisContextBundle(_StrictFrozenModel):
             if self.state_scope is not None:
                 raise ValueError("legacy context bundle must not declare state_scope")
         elif self.state_scope is None:
-            raise ValueError("context bundle v2 requires state_scope")
+            raise ValueError("scoped context bundle requires state_scope")
+        if self.schema_version == CONTEXT_BUNDLE_SCHEMA_VERSION:
+            self._validate_v3_selection_contract()
+        elif any(
+            (
+                self.evidence_delta_decision is not None,
+                bool(self.deferred_queue),
+                bool(self.processed_above_frontier),
+                bool(self.selection_decisions),
+                self.selection_trace is not None,
+                bool(self.freshness_sla_seconds),
+                self.default_freshness_sla_seconds is not None,
+            )
+        ):
+            raise ValueError("context bundle v1/v2 must not carry v3 selection fields")
         if any(not source.strip() for source in self.evidence_cursors):
             raise ValueError("evidence cursor source must not be blank")
         if any(not source.strip() for source in self.next_evidence_cursors):
@@ -177,9 +293,147 @@ class AnalysisContextBundle(_StrictFrozenModel):
         expected = compute_bundle_content_hash(payload)
         if self.content_hash != expected:
             raise ValueError("content_hash does not match bundle content")
+        expected_id = str(
+            uuid.uuid5(uuid.NAMESPACE_URL, f"finance-agent:context-bundle:{expected}")
+        )
+        if self.bundle_id != expected_id:
+            raise ValueError("bundle_id does not match content_hash")
         if self.budget_trace.within_budget is not True:
             raise ValueError("persisted context bundle must be within budget")
         return self
+
+    def _validate_v3_selection_contract(self) -> None:
+        # Imports stay local because selection imports EvidenceItem/EvidenceCursor
+        # from this module.
+        from apps.analysis.evidence_delta.schemas import EvidenceDeltaDecision
+        from apps.analysis.context_bundle.selection import (
+            DeferredEvidencePointer,
+            EvidenceSelectionDecision,
+            EvidenceSelectionTrace,
+        )
+
+        if self.selection_trace is None or self.evidence_delta_decision is None:
+            raise ValueError("context bundle v3 requires decision and selection_trace")
+        trace = EvidenceSelectionTrace.model_validate(self.selection_trace)
+        delta_decision = EvidenceDeltaDecision.model_validate(self.evidence_delta_decision)
+        if (
+            delta_decision.asset != self.asset
+            or delta_decision.state_scope != self.state_scope
+            or delta_decision.canonical_state_id != self.canonical_state_id
+        ):
+            raise ValueError("evidence delta decision identity does not match bundle")
+        for pointer in self.deferred_queue:
+            DeferredEvidencePointer.model_validate(pointer)
+        for source, pointers in self.processed_above_frontier.items():
+            if not str(source).strip():
+                raise ValueError("processed_above_frontier source must not be blank")
+            for pointer in pointers:
+                validated = DeferredEvidencePointer.model_validate(pointer)
+                if validated.source != source:
+                    raise ValueError(
+                        "processed_above_frontier source does not match pointer source"
+                    )
+        decisions = [
+            EvidenceSelectionDecision.model_validate(decision)
+            for decision in self.selection_decisions
+        ]
+        outcome_counts = {
+            outcome: sum(decision.outcome == outcome for decision in decisions)
+            for outcome in ("retained", "deferred", "rejected")
+        }
+        if (
+            trace.retained_count != outcome_counts["retained"]
+            or trace.deferred_count != outcome_counts["deferred"]
+            or trace.rejected_count != outcome_counts["rejected"]
+            or trace.eligible_count != trace.retained_count + trace.deferred_count
+            or len(decisions)
+            != trace.retained_count + trace.deferred_count + trace.rejected_count
+            or len(self.deferred_queue) != trace.deferred_count
+        ):
+            raise ValueError("selection trace counts do not match selection decisions")
+        decision_keys = [(decision.source, decision.evidence_id) for decision in decisions]
+        if len(decision_keys) != len(set(decision_keys)):
+            raise ValueError("selection decisions must be unique by source and evidence_id")
+        deferred_decision_refs = {
+            (decision.source, decision.evidence_id)
+            for decision in decisions
+            if decision.outcome == "deferred"
+        }
+        deferred_pointer_refs = {
+            (str(pointer["source"]), str(pointer["evidence_id"]))
+            for pointer in self.deferred_queue
+        }
+        if deferred_pointer_refs != deferred_decision_refs:
+            raise ValueError("deferred queue does not match deferred selection decisions")
+        processed_refs = [
+            (str(pointer["source"]), str(pointer["evidence_id"]))
+            for pointers in self.processed_above_frontier.values()
+            for pointer in pointers
+        ]
+        if (
+            len(processed_refs) != len(set(processed_refs))
+            or set(processed_refs) & deferred_pointer_refs
+        ):
+            raise ValueError("processed frontier identities must be unique and not deferred")
+        if (
+            trace.retained_tokens
+            != sum(
+                decision.estimated_tokens
+                for decision in decisions
+                if decision.outcome == "retained"
+            )
+            or trace.deferred_tokens
+            != sum(
+                decision.estimated_tokens
+                for decision in decisions
+                if decision.outcome == "deferred"
+            )
+            or trace.mandatory_tokens
+            != sum(decision.estimated_tokens for decision in decisions if decision.mandatory)
+        ):
+            raise ValueError("selection trace token totals do not match selection decisions")
+        if self.default_freshness_sla_seconds is None:
+            raise ValueError("context bundle v3 requires a default freshness SLA")
+        if self.default_freshness_sla_seconds < 0:
+            raise ValueError("default freshness SLA must be non-negative")
+        eligible_sources = {
+            decision.source
+            for decision in decisions
+            if decision.outcome in {"retained", "deferred"}
+        }
+        if not eligible_sources.issubset(self.freshness):
+            raise ValueError("freshness must cover every eligible evidence source")
+
+        retained_refs = {
+            (decision.source, decision.evidence_id)
+            for decision in decisions
+            if decision.outcome == "retained"
+        }
+        facts_block = next(block for block in self.blocks if block.name == "facts")
+        accepted_fact_refs = {
+            ("figure_fact", str(item["figure_fact_id"]))
+            for item in facts_block.payload
+            if isinstance(item, dict)
+            and item.get("quality_status") == "accepted"
+            and item.get("figure_fact_id")
+        }
+        allowed_refs = retained_refs | accepted_fact_refs
+        evaluated_refs = {
+            (ref.source, ref.evidence_id)
+            for item in delta_decision.evaluated_items
+            for ref in item.evidence_refs
+        }
+        if evaluated_refs != allowed_refs:
+            raise ValueError("evidence delta decision refs do not match retained bundle facts")
+
+        delta_block = next(block for block in self.blocks if block.name == "delta_evidence")
+        block_refs = {
+            (str(item.get("source") or ""), str(item.get("evidence_id") or ""))
+            for item in delta_block.payload
+            if isinstance(item, dict)
+        }
+        if block_refs != retained_refs:
+            raise ValueError("retained selection decisions do not match delta evidence block")
 
 
 def compute_bundle_content_hash(value: AnalysisContextBundle | dict[str, Any]) -> str:
@@ -187,9 +441,72 @@ def compute_bundle_content_hash(value: AnalysisContextBundle | dict[str, Any]) -
     payload.pop("bundle_id", None)
     payload.pop("content_hash", None)
     payload.pop("assembled_at", None)
-    if payload.get("schema_version") == LEGACY_CONTEXT_BUNDLE_SCHEMA_VERSION:
+    schema_version = payload.get("schema_version")
+    if schema_version == LEGACY_CONTEXT_BUNDLE_SCHEMA_VERSION:
         payload.pop("state_scope", None)
+    if schema_version in {
+        LEGACY_CONTEXT_BUNDLE_SCHEMA_VERSION,
+        SCOPED_CONTEXT_BUNDLE_SCHEMA_VERSION,
+    }:
+        for field in _V3_ONLY_FIELDS:
+            payload.pop(field, None)
+    elif schema_version == CONTEXT_BUNDLE_SCHEMA_VERSION:
+        payload = _canonicalize_v3_hash_fields(payload)
     return content_hash(payload, exclude_keys=frozenset())
+
+
+def _canonicalize_v3_hash_fields(payload: dict[str, Any]) -> dict[str, Any]:
+    from apps.analysis.context_bundle.selection import (
+        DeferredEvidencePointer,
+        EvidenceSelectionDecision,
+        EvidenceSelectionTrace,
+    )
+    from apps.analysis.evidence_delta.schemas import EvidenceDeltaDecision
+
+    normalized = dict(payload)
+    decision = normalized.get("evidence_delta_decision")
+    if decision is not None:
+        normalized["evidence_delta_decision"] = EvidenceDeltaDecision.model_validate(
+            decision
+        ).model_dump(mode="json")
+    normalized["deferred_queue"] = sorted(
+        [
+            DeferredEvidencePointer.model_validate(item).model_dump(mode="json")
+            for item in normalized.get("deferred_queue") or []
+        ],
+        key=lambda item: (item["source"], item["ingested_at"], item["evidence_id"]),
+    )
+    normalized["processed_above_frontier"] = {
+        str(source).strip(): sorted(
+            [
+                DeferredEvidencePointer.model_validate(item).model_dump(mode="json")
+                for item in pointers
+            ],
+            key=lambda item: (item["ingested_at"], item["evidence_id"]),
+        )
+        for source, pointers in sorted(
+            dict(normalized.get("processed_above_frontier") or {}).items()
+        )
+    }
+    normalized["selection_decisions"] = sorted(
+        [
+            EvidenceSelectionDecision.model_validate(item).model_dump(mode="json")
+            for item in normalized.get("selection_decisions") or []
+        ],
+        key=lambda item: (item["source"], item["evidence_id"], item["outcome"]),
+    )
+    trace = normalized.get("selection_trace")
+    if trace is not None:
+        normalized["selection_trace"] = EvidenceSelectionTrace.model_validate(trace).model_dump(
+            mode="json"
+        )
+    normalized["freshness_sla_seconds"] = {
+        str(source).strip(): value
+        for source, value in sorted(
+            dict(normalized.get("freshness_sla_seconds") or {}).items()
+        )
+    }
+    return normalized
 
 
 def _reject_transport_keys(value: Any, *, path: str = "bundle") -> None:

--- a/apps/analysis/context_bundle/selection.py
+++ b/apps/analysis/context_bundle/selection.py
@@ -1,0 +1,705 @@
+"""Pure, deterministic evidence selection with gap-safe per-source frontiers.
+
+This module deliberately does not infer materiality.  Callers provide stable
+priority metadata and token estimates; the selector only applies that ordering
+to an evidence-only budget and records enough state for a later replay.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import (
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
+
+from apps.analysis.context_bundle.schemas import EvidenceCursor, EvidenceItem
+
+
+class EvidencePriorityClass(StrEnum):
+    MANDATORY_CRITICAL = "mandatory_critical"
+    CONFIRMED_INVALIDATION = "confirmed_invalidation"
+    CONFIRMED_KEY_LEVEL = "confirmed_key_level"
+    MARKET_OPTIONS_REGIME = "market_options_regime"
+    LATEST_HIGH_QUALITY = "latest_high_quality"
+    ORDINARY_CURRENT = "ordinary_current"
+    BACKLOG = "backlog"
+
+
+_PRIORITY_RANK = {
+    EvidencePriorityClass.MANDATORY_CRITICAL: 0,
+    EvidencePriorityClass.CONFIRMED_INVALIDATION: 1,
+    EvidencePriorityClass.CONFIRMED_KEY_LEVEL: 2,
+    EvidencePriorityClass.MARKET_OPTIONS_REGIME: 3,
+    EvidencePriorityClass.LATEST_HIGH_QUALITY: 4,
+    EvidencePriorityClass.ORDINARY_CURRENT: 5,
+    EvidencePriorityClass.BACKLOG: 6,
+}
+
+
+class _StrictFrozenModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class EvidencePriority(_StrictFrozenModel):
+    """Caller-owned priority facts; no importance is inferred here."""
+
+    source: str = Field(min_length=1, max_length=128)
+    evidence_id: str = Field(min_length=1, max_length=255)
+    semantic_hash: str
+    priority_class: EvidencePriorityClass
+    materiality: str = Field(min_length=1, max_length=64)
+    mandatory: bool = False
+    reason_codes: tuple[str, ...] = ()
+    estimated_tokens: int = Field(gt=0)
+
+    @field_validator("source", "evidence_id", "materiality")
+    @classmethod
+    def _strip_required_text(cls, value: str, info: Any) -> str:
+        return _required_text(value, info.field_name)
+
+    @field_validator("semantic_hash")
+    @classmethod
+    def _validate_semantic_hash(cls, value: str) -> str:
+        return _sha256_digest(value, field="semantic_hash")
+
+    @field_validator("reason_codes")
+    @classmethod
+    def _normalize_reason_codes(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(sorted({_required_text(item, "reason_code") for item in value}))
+
+    @model_validator(mode="after")
+    def _validate_mandatory_class(self) -> "EvidencePriority":
+        class_is_mandatory = self.priority_class is EvidencePriorityClass.MANDATORY_CRITICAL
+        if self.mandatory != class_is_mandatory:
+            raise ValueError(
+                "mandatory must be true exactly when priority_class is mandatory_critical"
+            )
+        return self
+
+
+class DeferredEvidencePointer(_StrictFrozenModel):
+    """Immutable identity used by deferred and processed frontier state."""
+
+    source: str = Field(min_length=1, max_length=128)
+    evidence_id: str = Field(min_length=1, max_length=255)
+    ingested_at: AwareDatetime
+    semantic_hash: str
+    deferred_priority_class: EvidencePriorityClass | None = None
+    deferral_reasons: tuple[str, ...] = ()
+
+    @field_validator("source", "evidence_id")
+    @classmethod
+    def _strip_identity(cls, value: str, info: Any) -> str:
+        return _required_text(value, info.field_name)
+
+    @field_validator("semantic_hash")
+    @classmethod
+    def _validate_semantic_hash(cls, value: str) -> str:
+        return _sha256_digest(value, field="semantic_hash")
+
+    @field_validator("deferral_reasons")
+    @classmethod
+    def _normalize_deferral_reasons(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(sorted({_required_text(item, "deferral_reason") for item in value}))
+
+
+class EvidenceSelectionKey(_StrictFrozenModel):
+    """Source-aware evidence identity used for all selection state."""
+
+    source: str = Field(min_length=1, max_length=128)
+    evidence_id: str = Field(min_length=1, max_length=255)
+
+    @field_validator("source", "evidence_id")
+    @classmethod
+    def _strip_identity(cls, value: str, info: Any) -> str:
+        return _required_text(value, info.field_name)
+
+
+class EvidenceSelectionDecision(_StrictFrozenModel):
+    source: str
+    evidence_id: str
+    outcome: Literal["retained", "deferred", "rejected"]
+    estimated_tokens: int = Field(ge=0)
+    priority_class: EvidencePriorityClass | None = None
+    materiality: str | None = None
+    mandatory: bool = False
+    reasons: tuple[str, ...] = ()
+
+    @field_validator("source", "evidence_id")
+    @classmethod
+    def _strip_identity(cls, value: str, info: Any) -> str:
+        return _required_text(value, info.field_name)
+
+    @field_validator("reasons")
+    @classmethod
+    def _normalize_reasons(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(sorted({_required_text(item, "reason") for item in value}))
+
+
+class EvidenceSelectionTrace(_StrictFrozenModel):
+    evidence_budget_tokens: int = Field(ge=0)
+    retained_tokens: int = Field(ge=0)
+    deferred_tokens: int = Field(ge=0)
+    mandatory_tokens: int = Field(ge=0)
+    eligible_count: int = Field(ge=0)
+    retained_count: int = Field(ge=0)
+    deferred_count: int = Field(ge=0)
+    rejected_count: int = Field(ge=0)
+    priority_order: tuple[EvidencePriorityClass, ...]
+
+
+class SelectionResult(_StrictFrozenModel):
+    """Selection output; ``retained_evidence_keys`` is the authoritative identity."""
+
+    retained_evidence_keys: tuple[EvidenceSelectionKey, ...]
+    # Compatibility/display projection only; evidence IDs are not source-unique.
+    retained_evidence_ids: tuple[str, ...]
+    deferred_queue: tuple[DeferredEvidencePointer, ...]
+    processed_above_frontier: dict[str, tuple[DeferredEvidencePointer, ...]]
+    next_evidence_cursors: dict[str, EvidenceCursor]
+    decisions: tuple[EvidenceSelectionDecision, ...]
+    trace: EvidenceSelectionTrace
+
+
+class EvidenceSelectionBudgetError(ValueError):
+    """Raised when mandatory evidence alone cannot fit the evidence budget."""
+
+    def __init__(
+        self,
+        *,
+        required_tokens: int,
+        budget_tokens: int,
+        mandatory_evidence_keys: tuple[EvidenceSelectionKey, ...],
+    ) -> None:
+        super().__init__(
+            "mandatory evidence exceeds evidence budget: "
+            f"required_tokens={required_tokens}; budget_tokens={budget_tokens}"
+        )
+        self.required_tokens = required_tokens
+        self.budget_tokens = budget_tokens
+        self.mandatory_evidence_keys = mandatory_evidence_keys
+        self.mandatory_evidence_ids = tuple(
+            key.evidence_id for key in mandatory_evidence_keys
+        )
+
+
+class EvidenceSelectionStateError(ValueError):
+    """Raised before selection when persisted frontier state is inconsistent."""
+
+
+def select_material_evidence(
+    *,
+    evidence: list[EvidenceItem | dict[str, Any]],
+    priorities: list[EvidencePriority | dict[str, Any]],
+    evidence_cursors: dict[str, EvidenceCursor | dict[str, Any]] | None,
+    cutoff_at: datetime,
+    evidence_budget_tokens: int,
+    deferred_queue: tuple[DeferredEvidencePointer | dict[str, Any], ...] = (),
+    processed_above_frontier: dict[
+        str, tuple[DeferredEvidencePointer | dict[str, Any], ...]
+    ]
+    | None = None,
+) -> SelectionResult:
+    """Select evidence and advance only each source's contiguous frontier.
+
+    The function is side-effect free.  State validation completes before any
+    selection result is built, so corrupt deferred/processed pointers fail
+    closed without returning an advanced cursor.
+    """
+
+    _require_aware_datetime(cutoff_at, field="cutoff_at")
+    if evidence_budget_tokens < 0:
+        raise ValueError("evidence_budget_tokens must be non-negative")
+
+    normalized_evidence = _normalize_evidence(evidence)
+    normalized_priorities = _normalize_priorities(priorities)
+    normalized_cursors = _normalize_cursors(evidence_cursors)
+    normalized_deferred = _normalize_pointer_sequence(deferred_queue, label="deferred_queue")
+    normalized_processed = _normalize_processed(processed_above_frontier)
+
+    _validate_selection_state(
+        evidence=normalized_evidence,
+        priorities=normalized_priorities,
+        cursors=normalized_cursors,
+        cutoff_at=cutoff_at,
+        deferred=normalized_deferred,
+        processed=normalized_processed,
+    )
+
+    processed_keys = {
+        (pointer.source, pointer.evidence_id)
+        for pointers in normalized_processed.values()
+        for pointer in pointers
+    }
+    candidates: list[tuple[EvidenceItem, EvidencePriority]] = []
+    rejected: list[EvidenceSelectionDecision] = []
+
+    for key, item in sorted(normalized_evidence.items(), key=_evidence_map_sort_key):
+        priority = normalized_priorities[key]
+        cursor = normalized_cursors.get(item.source)
+        if item.ingested_at > cutoff_at:
+            rejected.append(_decision(item, priority, outcome="rejected", reasons=("after_cutoff",)))
+            continue
+        if cursor is not None and _position(item) <= _position(cursor):
+            rejected.append(
+                _decision(item, priority, outcome="rejected", reasons=("at_or_before_frontier",))
+            )
+            continue
+        if key in processed_keys:
+            rejected.append(
+                _decision(
+                    item,
+                    priority,
+                    outcome="rejected",
+                    reasons=("already_processed_above_frontier",),
+                )
+            )
+            continue
+        candidates.append((item, priority))
+
+    persisted_deferred_keys = {
+        (pointer.source, pointer.evidence_id) for pointer in normalized_deferred
+    }
+    ranked = sorted(
+        candidates,
+        key=lambda value: _selection_rank(
+            value,
+            persisted_deferred_keys=persisted_deferred_keys,
+        ),
+    )
+    mandatory = [(item, priority) for item, priority in ranked if priority.mandatory]
+    mandatory_tokens = sum(priority.estimated_tokens for _, priority in mandatory)
+    if mandatory_tokens > evidence_budget_tokens:
+        raise EvidenceSelectionBudgetError(
+            required_tokens=mandatory_tokens,
+            budget_tokens=evidence_budget_tokens,
+            mandatory_evidence_keys=tuple(
+                EvidenceSelectionKey(source=item.source, evidence_id=item.evidence_id)
+                for item, _ in mandatory
+            ),
+        )
+
+    retained: list[tuple[EvidenceItem, EvidencePriority]] = []
+    deferred: list[tuple[EvidenceItem, EvidencePriority]] = []
+    used_tokens = 0
+    for item, priority in ranked:
+        if priority.mandatory or used_tokens + priority.estimated_tokens <= evidence_budget_tokens:
+            retained.append((item, priority))
+            used_tokens += priority.estimated_tokens
+        else:
+            deferred.append((item, priority))
+
+    retained_keys = {(item.source, item.evidence_id) for item, _ in retained}
+    deferred_keys = {(item.source, item.evidence_id) for item, _ in deferred}
+    pointer_by_key = {
+        key: _pointer(
+            item,
+            normalized_priorities[key],
+            deferred=key in deferred_keys,
+        )
+        for key, item in normalized_evidence.items()
+        if item.ingested_at <= cutoff_at
+        and (
+            normalized_cursors.get(item.source) is None
+            or _position(item) > _position(normalized_cursors[item.source])
+        )
+    }
+    for pointers in normalized_processed.values():
+        for pointer in pointers:
+            pointer_by_key.setdefault((pointer.source, pointer.evidence_id), pointer)
+
+    next_cursors, next_processed = _advance_frontiers(
+        cursors=normalized_cursors,
+        pointers=pointer_by_key,
+        retained_keys=retained_keys,
+        deferred_keys=deferred_keys,
+        processed_keys=processed_keys,
+    )
+
+    retained_decisions = [
+        _decision(item, priority, outcome="retained", reasons=priority.reason_codes)
+        for item, priority in retained
+    ]
+    deferred_decisions = [
+        _decision(
+            item,
+            priority,
+            outcome="deferred",
+            reasons=(*priority.reason_codes, "evidence_budget_exhausted"),
+        )
+        for item, priority in deferred
+    ]
+    decisions = tuple(
+        [*retained_decisions, *deferred_decisions, *sorted(rejected, key=_decision_sort_key)]
+    )
+    deferred_pointers = tuple(
+        sorted(
+            (pointer_by_key[key] for key in deferred_keys),
+            key=_pointer_sort_key,
+        )
+    )
+    deferred_tokens = sum(priority.estimated_tokens for _, priority in deferred)
+    return SelectionResult(
+        retained_evidence_keys=tuple(
+            EvidenceSelectionKey(source=item.source, evidence_id=item.evidence_id)
+            for item, _ in retained
+        ),
+        retained_evidence_ids=tuple(item.evidence_id for item, _ in retained),
+        deferred_queue=deferred_pointers,
+        processed_above_frontier=next_processed,
+        next_evidence_cursors=next_cursors,
+        decisions=decisions,
+        trace=EvidenceSelectionTrace(
+            evidence_budget_tokens=evidence_budget_tokens,
+            retained_tokens=used_tokens,
+            deferred_tokens=deferred_tokens,
+            mandatory_tokens=mandatory_tokens,
+            eligible_count=len(ranked),
+            retained_count=len(retained),
+            deferred_count=len(deferred),
+            rejected_count=len(rejected),
+            priority_order=tuple(
+                priority_class
+                for priority_class, _ in sorted(_PRIORITY_RANK.items(), key=lambda item: item[1])
+            ),
+        ),
+    )
+
+
+def _normalize_evidence(
+    evidence: list[EvidenceItem | dict[str, Any]],
+) -> dict[tuple[str, str], EvidenceItem]:
+    normalized: dict[tuple[str, str], EvidenceItem] = {}
+    for raw_item in evidence:
+        item = raw_item if isinstance(raw_item, EvidenceItem) else EvidenceItem.model_validate(raw_item)
+        key = (item.source, item.evidence_id)
+        if key in normalized:
+            if normalized[key] == item:
+                continue
+            raise EvidenceSelectionStateError(
+                f"conflicting duplicate evidence identity: {item.source}/{item.evidence_id}"
+            )
+        normalized[key] = item
+    return normalized
+
+
+def _normalize_priorities(
+    priorities: list[EvidencePriority | dict[str, Any]],
+) -> dict[tuple[str, str], EvidencePriority]:
+    normalized: dict[tuple[str, str], EvidencePriority] = {}
+    for raw_priority in priorities:
+        priority = (
+            raw_priority
+            if isinstance(raw_priority, EvidencePriority)
+            else EvidencePriority.model_validate(raw_priority)
+        )
+        key = (priority.source, priority.evidence_id)
+        if key in normalized:
+            if normalized[key] == priority:
+                continue
+            raise EvidenceSelectionStateError(
+                f"conflicting duplicate evidence priority: {priority.source}/{priority.evidence_id}"
+            )
+        normalized[key] = priority
+    return normalized
+
+
+def _normalize_cursors(
+    cursors: dict[str, EvidenceCursor | dict[str, Any]] | None,
+) -> dict[str, EvidenceCursor]:
+    normalized: dict[str, EvidenceCursor] = {}
+    for raw_source, raw_cursor in sorted((cursors or {}).items()):
+        source = _required_text(raw_source, "cursor source")
+        normalized[source] = (
+            raw_cursor
+            if isinstance(raw_cursor, EvidenceCursor)
+            else EvidenceCursor.model_validate(raw_cursor)
+        )
+    return normalized
+
+
+def _normalize_pointer_sequence(
+    pointers: tuple[DeferredEvidencePointer | dict[str, Any], ...],
+    *,
+    label: str,
+) -> tuple[DeferredEvidencePointer, ...]:
+    normalized: dict[tuple[str, str], DeferredEvidencePointer] = {}
+    for raw_pointer in pointers:
+        pointer = (
+            raw_pointer
+            if isinstance(raw_pointer, DeferredEvidencePointer)
+            else DeferredEvidencePointer.model_validate(raw_pointer)
+        )
+        key = (pointer.source, pointer.evidence_id)
+        if key in normalized:
+            raise EvidenceSelectionStateError(
+                f"duplicate {label} identity: {pointer.source}/{pointer.evidence_id}"
+            )
+        normalized[key] = pointer
+    return tuple(sorted(normalized.values(), key=_pointer_sort_key))
+
+
+def _normalize_processed(
+    processed: dict[str, tuple[DeferredEvidencePointer | dict[str, Any], ...]] | None,
+) -> dict[str, tuple[DeferredEvidencePointer, ...]]:
+    normalized: dict[str, tuple[DeferredEvidencePointer, ...]] = {}
+    seen: set[tuple[str, str]] = set()
+    for raw_source, raw_pointers in sorted((processed or {}).items()):
+        source = _required_text(raw_source, "processed source")
+        pointers = _normalize_pointer_sequence(
+            raw_pointers,
+            label=f"processed_above_frontier[{source}]",
+        )
+        for pointer in pointers:
+            if pointer.source != source:
+                raise EvidenceSelectionStateError(
+                    "processed_above_frontier source does not match pointer source"
+                )
+            key = (pointer.source, pointer.evidence_id)
+            if key in seen:
+                raise EvidenceSelectionStateError(
+                    f"duplicate processed identity: {pointer.source}/{pointer.evidence_id}"
+                )
+            seen.add(key)
+        if pointers:
+            normalized[source] = pointers
+    return normalized
+
+
+def _validate_selection_state(
+    *,
+    evidence: dict[tuple[str, str], EvidenceItem],
+    priorities: dict[tuple[str, str], EvidencePriority],
+    cursors: dict[str, EvidenceCursor],
+    cutoff_at: datetime,
+    deferred: tuple[DeferredEvidencePointer, ...],
+    processed: dict[str, tuple[DeferredEvidencePointer, ...]],
+) -> None:
+    missing_priorities = sorted(set(evidence) - set(priorities))
+    if missing_priorities:
+        source, evidence_id = missing_priorities[0]
+        raise EvidenceSelectionStateError(f"missing evidence priority: {source}/{evidence_id}")
+
+    deferred_keys = {(pointer.source, pointer.evidence_id) for pointer in deferred}
+    processed_pointers = {
+        (pointer.source, pointer.evidence_id): pointer
+        for pointers in processed.values()
+        for pointer in pointers
+    }
+    extra_priorities = sorted(set(priorities) - set(evidence) - set(processed_pointers))
+    if extra_priorities:
+        source, evidence_id = extra_priorities[0]
+        raise EvidenceSelectionStateError(
+            f"priority has no current or processed evidence: {source}/{evidence_id}"
+        )
+    overlap = sorted(deferred_keys & set(processed_pointers))
+    if overlap:
+        source, evidence_id = overlap[0]
+        raise EvidenceSelectionStateError(
+            f"evidence is both deferred and processed: {source}/{evidence_id}"
+        )
+
+    for pointer in deferred:
+        key = (pointer.source, pointer.evidence_id)
+        if key not in evidence:
+            raise EvidenceSelectionStateError(
+                f"deferred evidence is missing from replay input: {pointer.source}/{pointer.evidence_id}"
+            )
+        _validate_pointer(pointer, evidence[key], priorities[key], cursors, cutoff_at)
+
+    for key, pointer in processed_pointers.items():
+        item = evidence.get(key)
+        priority = priorities.get(key)
+        if priority is None:
+            raise EvidenceSelectionStateError(
+                f"missing processed evidence priority: {pointer.source}/{pointer.evidence_id}"
+            )
+        if pointer.semantic_hash != priority.semantic_hash:
+            raise EvidenceSelectionStateError(
+                f"processed semantic_hash mismatch: {pointer.source}/{pointer.evidence_id}"
+            )
+        if item is not None:
+            _validate_pointer(pointer, item, priority, cursors, cutoff_at)
+        else:
+            _validate_pointer_position(pointer, cursors, cutoff_at)
+
+
+def _validate_pointer(
+    pointer: DeferredEvidencePointer,
+    item: EvidenceItem,
+    priority: EvidencePriority,
+    cursors: dict[str, EvidenceCursor],
+    cutoff_at: datetime,
+) -> None:
+    if pointer.ingested_at != item.ingested_at:
+        raise EvidenceSelectionStateError(
+            f"queued ingested_at mismatch: {pointer.source}/{pointer.evidence_id}"
+        )
+    if pointer.semantic_hash != priority.semantic_hash:
+        raise EvidenceSelectionStateError(
+            f"queued semantic_hash mismatch: {pointer.source}/{pointer.evidence_id}"
+        )
+    _validate_pointer_position(pointer, cursors, cutoff_at)
+
+
+def _validate_pointer_position(
+    pointer: DeferredEvidencePointer,
+    cursors: dict[str, EvidenceCursor],
+    cutoff_at: datetime,
+) -> None:
+    if pointer.ingested_at > cutoff_at:
+        raise EvidenceSelectionStateError(
+            f"queued evidence is after cutoff: {pointer.source}/{pointer.evidence_id}"
+        )
+    cursor = cursors.get(pointer.source)
+    if cursor is not None and _position(pointer) <= _position(cursor):
+        raise EvidenceSelectionStateError(
+            f"queued evidence is at or before frontier: {pointer.source}/{pointer.evidence_id}"
+        )
+
+
+def _advance_frontiers(
+    *,
+    cursors: dict[str, EvidenceCursor],
+    pointers: dict[tuple[str, str], DeferredEvidencePointer],
+    retained_keys: set[tuple[str, str]],
+    deferred_keys: set[tuple[str, str]],
+    processed_keys: set[tuple[str, str]],
+) -> tuple[dict[str, EvidenceCursor], dict[str, tuple[DeferredEvidencePointer, ...]]]:
+    by_source: dict[str, list[DeferredEvidencePointer]] = defaultdict(list)
+    for pointer in pointers.values():
+        by_source[pointer.source].append(pointer)
+
+    next_cursors = dict(cursors)
+    next_processed: dict[str, tuple[DeferredEvidencePointer, ...]] = {}
+    for source in sorted(by_source):
+        current = cursors.get(source)
+        gap_seen = False
+        completed_above_gap: list[DeferredEvidencePointer] = []
+        advanced: DeferredEvidencePointer | None = None
+        for pointer in sorted(by_source[source], key=_pointer_position_sort_key):
+            key = (pointer.source, pointer.evidence_id)
+            completed = key in retained_keys or key in processed_keys
+            if key not in deferred_keys and not completed:
+                continue
+            if not gap_seen and key in deferred_keys:
+                gap_seen = True
+                continue
+            if completed and not gap_seen:
+                advanced = pointer
+            elif completed:
+                completed_above_gap.append(pointer)
+        if advanced is not None:
+            next_cursors[source] = EvidenceCursor(
+                ingested_at=advanced.ingested_at,
+                evidence_id=advanced.evidence_id,
+            )
+        elif current is None:
+            next_cursors.pop(source, None)
+        if completed_above_gap:
+            next_processed[source] = tuple(completed_above_gap)
+    return ({source: next_cursors[source] for source in sorted(next_cursors)}, next_processed)
+
+
+def _selection_rank(
+    value: tuple[EvidenceItem, EvidencePriority],
+    *,
+    persisted_deferred_keys: set[tuple[str, str]],
+) -> tuple[int, int, int, float, str, str]:
+    item, priority = value
+    return (
+        0 if priority.mandatory else 1,
+        _PRIORITY_RANK[priority.priority_class],
+        0 if (item.source, item.evidence_id) in persisted_deferred_keys else 1,
+        -item.ingested_at.timestamp(),
+        item.source,
+        item.evidence_id,
+    )
+
+
+def _decision(
+    item: EvidenceItem,
+    priority: EvidencePriority,
+    *,
+    outcome: Literal["retained", "deferred", "rejected"],
+    reasons: tuple[str, ...],
+) -> EvidenceSelectionDecision:
+    return EvidenceSelectionDecision(
+        source=item.source,
+        evidence_id=item.evidence_id,
+        outcome=outcome,
+        estimated_tokens=priority.estimated_tokens,
+        priority_class=priority.priority_class,
+        materiality=priority.materiality,
+        mandatory=priority.mandatory,
+        reasons=reasons,
+    )
+
+
+def _pointer(
+    item: EvidenceItem,
+    priority: EvidencePriority,
+    *,
+    deferred: bool,
+) -> DeferredEvidencePointer:
+    return DeferredEvidencePointer(
+        source=item.source,
+        evidence_id=item.evidence_id,
+        ingested_at=item.ingested_at,
+        semantic_hash=priority.semantic_hash,
+        deferred_priority_class=priority.priority_class if deferred else None,
+        deferral_reasons=(
+            (*priority.reason_codes, "evidence_budget_exhausted") if deferred else ()
+        ),
+    )
+
+
+def _evidence_map_sort_key(
+    value: tuple[tuple[str, str], EvidenceItem],
+) -> tuple[str, datetime, str]:
+    _, item = value
+    return (item.source, item.ingested_at, item.evidence_id)
+
+
+def _pointer_sort_key(pointer: DeferredEvidencePointer) -> tuple[str, datetime, str]:
+    return (pointer.source, pointer.ingested_at, pointer.evidence_id)
+
+
+def _pointer_position_sort_key(pointer: DeferredEvidencePointer) -> tuple[datetime, str]:
+    return (pointer.ingested_at, pointer.evidence_id)
+
+
+def _decision_sort_key(decision: EvidenceSelectionDecision) -> tuple[str, str]:
+    return (decision.source, decision.evidence_id)
+
+
+def _position(value: EvidenceItem | EvidenceCursor | DeferredEvidencePointer) -> tuple[datetime, str]:
+    return (value.ingested_at, value.evidence_id)
+
+
+def _required_text(value: str, field: str) -> str:
+    normalized = str(value).strip()
+    if not normalized:
+        raise ValueError(f"{field} must not be blank")
+    return normalized
+
+
+def _sha256_digest(value: str, *, field: str) -> str:
+    normalized = str(value).strip().lower()
+    if len(normalized) != 64 or any(char not in "0123456789abcdef" for char in normalized):
+        raise ValueError(f"{field} must be a lowercase SHA-256 digest")
+    return normalized
+
+
+def _require_aware_datetime(value: datetime, *, field: str) -> None:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field} must be timezone-aware")

--- a/apps/analysis/evidence_delta/evaluator.py
+++ b/apps/analysis/evidence_delta/evaluator.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 
-from .rules import RuleResult, evaluate_rule, semantic_hash, semantic_identity
+from .rules import (
+    RuleResult,
+    evaluate_rule,
+    material_event_authority_rank,
+    semantic_conflict_hash,
+    semantic_hash,
+    semantic_identity,
+)
 from .schemas import (
     DeltaEvidence,
     EvidenceIdentity,
@@ -47,8 +54,8 @@ def evaluate_evidence_delta(
     normalized_state_id = _required_text(canonical_state_id)
     previous = _validate_previous_hashes(previous_semantic_hashes or {})
     grouped: dict[tuple[str, str], list[DeltaEvidence]] = defaultdict(list)
-    by_identity_hashes: dict[str, set[str]] = defaultdict(set)
-    authoritative_hashes: dict[tuple[str, str], set[str]] = defaultdict(set)
+    by_identity_content_hashes: dict[str, set[str]] = defaultdict(set)
+    authoritative_content_hashes: dict[tuple[str, str], set[str]] = defaultdict(set)
 
     for item in evidence:
         if item.asset != normalized_asset:
@@ -56,26 +63,30 @@ def evaluate_evidence_delta(
                 f"evidence asset mismatch: expected {normalized_asset}, got {item.asset} ({item.evidence_id})"
             )
         key = semantic_identity(item)
-        item_hash = semantic_hash(item)
-        grouped[(key, item_hash)].append(item)
-        by_identity_hashes[key].add(item_hash)
-        authoritative_hashes[(item.source, item.evidence_id)].add(item_hash)
+        content_hash = semantic_conflict_hash(item)
+        grouped[(key, content_hash)].append(item)
+        by_identity_content_hashes[key].add(content_hash)
+        authoritative_content_hashes[(item.source, item.evidence_id)].add(content_hash)
 
     conflicting_semantic_keys = {
-        key for key, hashes in by_identity_hashes.items() if len(hashes) > 1
+        key for key, hashes in by_identity_content_hashes.items() if len(hashes) > 1
     }
     conflicting_authoritative_keys = {
-        key for key, hashes in authoritative_hashes.items() if len(hashes) > 1
+        key for key, hashes in authoritative_content_hashes.items() if len(hashes) > 1
     }
     evaluated: list[EvaluatedEvidence] = []
     semantic_hashes: dict[str, str] = {}
-    for key, item_hash in sorted(grouped):
-        items = grouped[(key, item_hash)]
-        representative = min(items, key=lambda item: (item.evidence_id, item.source))
+    for key, content_hash in sorted(grouped):
+        items = grouped[(key, content_hash)]
+        representative = min(
+            items,
+            key=lambda item: (-material_event_authority_rank(item), item.evidence_id, item.source),
+        )
+        item_hash = semantic_hash(representative)
         has_authoritative_conflict = any(
             (item.source, item.evidence_id) in conflicting_authoritative_keys for item in items
         )
-        if len(by_identity_hashes[key]) == 1 and not has_authoritative_conflict:
+        if len(by_identity_content_hashes[key]) == 1 and not has_authoritative_conflict:
             semantic_hashes[key] = item_hash
         if has_authoritative_conflict:
             result = RuleResult(
@@ -121,6 +132,8 @@ def evaluate_evidence_delta(
                 reasons=sorted(set(result.reasons)),
             )
         )
+
+    evaluated.sort(key=lambda item: (item.evidence_key, item.semantic_hash))
 
     if evaluated:
         action = max(

--- a/apps/analysis/evidence_delta/rules.py
+++ b/apps/analysis/evidence_delta/rules.py
@@ -116,6 +116,37 @@ def semantic_identity(item: DeltaEvidence) -> str:
 def semantic_hash(item: DeltaEvidence) -> str:
     """Hash business meaning, excluding delivery/provenance-only metadata."""
 
+    payload = _semantic_payload(item)
+    if isinstance(item, MaterialEventEvidence):
+        # Keep the clustered claim identity stable while making an authority
+        # progression observable across runs. Collector-specific source labels
+        # remain excluded so equivalent authority stages can be aggregated.
+        payload["authority_progression"] = _material_event_authority_progression(item)
+    return content_hash(payload, exclude_keys=frozenset())
+
+
+def semantic_conflict_hash(item: DeltaEvidence) -> str:
+    """Hash business content used to distinguish genuine same-identity conflicts."""
+
+    return content_hash(_semantic_payload(item), exclude_keys=frozenset())
+
+
+def material_event_authority_rank(item: DeltaEvidence) -> int:
+    """Order equivalent material-event authority stages for deterministic selection."""
+
+    if not isinstance(item, MaterialEventEvidence):
+        return 0
+    return {
+        SourceQuality.UNVERIFIED: 0,
+        SourceQuality.SUPPLEMENTAL: 1,
+        SourceQuality.VALIDATED: 2,
+        SourceQuality.OFFICIAL: 3,
+        SourceQuality.PRIMARY: 3,
+        SourceQuality.EXCHANGE: 3,
+    }[item.source_quality]
+
+
+def _semantic_payload(item: DeltaEvidence) -> dict[str, Any]:
     payload = item.model_dump(
         mode="json",
         exclude={"source", "evidence_id", "observed_at", "source_ref", "metadata"},
@@ -126,7 +157,7 @@ def semantic_hash(item: DeltaEvidence) -> str:
         payload.pop("source_quality", None)
         payload["claim"] = " ".join(item.claim.casefold().split())
         payload["cluster_key"] = item.cluster_key.casefold()
-    return content_hash(payload, exclude_keys=frozenset())
+    return payload
 
 
 def evaluate_rule(item: DeltaEvidence) -> RuleResult:
@@ -198,10 +229,18 @@ def _material_event_rule(item: MaterialEventEvidence) -> RuleResult:
     high_risk = item.risk_level in {"high", "critical"} or item.materiality_score >= 70.0
     if item.confirmation_status is ConfirmationStatus.CONFLICTING:
         return _manual("material_event:conflicting_claims", affected)
+    if item.source_quality is SourceQuality.UNVERIFIED:
+        if high_risk:
+            return _manual("material_event:unverified_high_risk", affected)
+        return _no_op("material_event:unverified_source")
     if high_risk and (
         item.confirmation_status is not ConfirmationStatus.CONFIRMED or not item.recompute_eligible
     ):
         return _manual("material_event:high_risk_unconfirmed", affected)
+    if item.source_quality is SourceQuality.SUPPLEMENTAL:
+        if item.materiality_score >= 40.0:
+            return _context("material_event:supplemental_context_only", affected)
+        return _no_op("material_event:below_materiality_threshold")
     if item.recompute_eligible and item.materiality_score >= 70.0:
         return _transition("material_event:confirmed_material_event", affected, critical=item.risk_level == "critical")
     if item.materiality_score >= 40.0:
@@ -257,3 +296,17 @@ def _manual(reason: str, affected: tuple[str, ...]) -> RuleResult:
 
 def _semantic_key(kind: str, *parts: object) -> str:
     return f"{kind}:{json.dumps(parts, ensure_ascii=False, separators=(',', ':'))}"
+
+
+def _material_event_authority_progression(item: MaterialEventEvidence) -> str:
+    if item.source_quality in {
+        SourceQuality.OFFICIAL,
+        SourceQuality.PRIMARY,
+        SourceQuality.EXCHANGE,
+    }:
+        return "officially_confirmed"
+    if item.source_quality is SourceQuality.SUPPLEMENTAL:
+        return "supplemental"
+    if item.source_quality is SourceQuality.VALIDATED:
+        return "corroborated"
+    return "unverified"

--- a/apps/output/context_bundle.py
+++ b/apps/output/context_bundle.py
@@ -46,7 +46,7 @@ def write_context_bundle(
 ) -> ContextBundleWriteResult:
     validated = _validate_bundle(bundle)
     if validated.schema_version != CONTEXT_BUNDLE_SCHEMA_VERSION or validated.state_scope is None:
-        raise ValueError("context bundle writer only persists scoped v2 bundles")
+        raise ValueError("context bundle writer only persists scoped v3 bundles")
     storage_dir = Path(storage_root).resolve()
     relative = Path(
         "outputs",
@@ -84,6 +84,8 @@ def write_context_bundle(
             "state_scope": validated.state_scope,
             "run_id": validated.run_id,
             "canonical_state_id": validated.canonical_state_id,
+            "evidence_delta_decision_id": validated.evidence_delta_decision["decision_id"],
+            "evidence_delta_action": validated.evidence_delta_decision["recommended_action"],
             "estimated_tokens": validated.budget_trace.estimated_tokens,
         },
     }

--- a/apps/worker/composite_analysis_pipeline.py
+++ b/apps/worker/composite_analysis_pipeline.py
@@ -39,6 +39,7 @@ from apps.worker.composite_state_shadow import (
     LEGACY_CONTEXT_MODE,
     STATE_DELTA_CONTEXT_MODE,
     StateDeltaAnalyzer,
+    build_state_delta_setup_failure_review_item,
     execute_composite_state_shadow,
     finalize_composite_state_shadow,
     prepare_composite_state_shadow,
@@ -111,15 +112,22 @@ def run_composite_analysis_pipeline(
         except Exception as exc:
             logger.exception("State-delta shadow setup failed; continuing legacy output")
             shadow_runtime = None
+            failure_kind = type(exc).__name__
+            review_item = build_state_delta_setup_failure_review_item(
+                run_id=run_id,
+                failure_kind=failure_kind,
+            )
             shadow_trace = {
-                "schema_version": "composite_state_shadow.v2",
+                "schema_version": "composite_state_shadow.v3",
                 "mode": STATE_DELTA_CONTEXT_MODE,
                 "requested_state_scope": _safe_requested_state_scope(state_shadow_input),
                 "status": "shadow_setup_failed",
+                "evidence_delta_action": "manual_review",
                 "model_invocation": "skipped",
                 "shadow_review_status": "needs_review",
                 "transition_diff": [],
-                "reason": f"{type(exc).__name__}:{str(exc)[:200]}",
+                "reason": review_item["reason"],
+                "review_items": [review_item],
             }
     elif context_mode != LEGACY_CONTEXT_MODE:  # pragma: no cover - resolver exhaustiveness
         raise ValueError(f"unsupported context mode: {context_mode}")

--- a/apps/worker/composite_state_shadow.py
+++ b/apps/worker/composite_state_shadow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
@@ -12,6 +13,7 @@ from typing import Any, Callable, Literal
 from pydantic import BaseModel
 
 from apps.analysis.context_bundle import AnalysisContextBundle, assemble_context_bundle
+from apps.analysis.evidence_delta import EvidenceDeltaDecision, RecommendedAction, adapt_figure_fact
 from apps.analysis.figure_facts import project_confirmed_evidence
 from apps.analysis.state import (
     ANALYSIS_STATE_MACHINE_VERSION,
@@ -22,7 +24,11 @@ from apps.analysis.state import (
     parse_analysis_state_document,
     review_transition_candidate_scoped,
 )
-from apps.output.context_bundle import ContextBundleWriteResult, write_context_bundle
+from apps.output.context_bundle import (
+    ContextBundleWriteResult,
+    load_context_bundle,
+    write_context_bundle,
+)
 
 
 LEGACY_CONTEXT_MODE = "legacy_full_context"
@@ -42,6 +48,8 @@ class CompositeStateShadowRuntime:
     session: str
     trade_date: date
     available_evidence_refs: list[dict[str, Any]]
+    run_id: str
+    evidence_delta_decision: EvidenceDeltaDecision
     no_material_delta: bool
     assembly_latency_ms: int
 
@@ -82,14 +90,28 @@ def prepare_composite_state_shadow(
         if not session:
             raise ValueError("shadow session must not be blank")
     confirmed_facts = []
+    delta_facts = []
     for raw_fact in shadow_input.get("figure_facts") or []:
         confirmed = project_confirmed_evidence(raw_fact)
         if confirmed is not None:
             confirmed_facts.append(confirmed.model_dump(mode="json"))
+            delta_facts.append(
+                adapt_figure_fact(
+                    confirmed.model_dump(mode="json"),
+                    observed_at=_datetime_value(shadow_input.get("cutoff_at") or created_at),
+                )
+            )
     cutoff_at = _datetime_value(shadow_input.get("cutoff_at") or created_at)
     assembled_at = _datetime_value(shadow_input.get("assembled_at") or created_at)
     if isinstance(previous_state, AnalysisStateDocumentV1):
         trade_date = cutoff_at.date()
+    recovery = _recovery_inputs(
+        storage_root=storage_root,
+        shadow_input=shadow_input,
+        asset=previous_state.asset,
+        state_scope=state_scope,
+        canonical_state_id=str(shadow_input["canonical_state_id"]),
+    )
     bundle = assemble_context_bundle(
         run_id=run_id,
         asset=previous_state.asset,
@@ -101,6 +123,8 @@ def prepare_composite_state_shadow(
         cutoff_at=cutoff_at,
         assembled_at=assembled_at,
         facts=confirmed_facts,
+        delta_facts=delta_facts,
+        **recovery,
         expected_session=shadow_input.get("expected_session"),
         max_alignment_seconds=int(shadow_input.get("max_alignment_seconds") or 86_400),
         budget_tokens=int(shadow_input.get("budget_tokens") or 15_000),
@@ -118,7 +142,10 @@ def prepare_composite_state_shadow(
         for item in facts_block.payload
         if isinstance(item, dict) and item.get("source_ref")
     )
-    no_material_delta = not delta_block.payload and not facts_block.payload
+    if bundle.evidence_delta_decision is None:  # pragma: no cover - v3 schema contract
+        raise ValueError("shadow context bundle is missing evidence delta decision")
+    decision = EvidenceDeltaDecision.model_validate(bundle.evidence_delta_decision)
+    no_material_delta = decision.recommended_action is RecommendedAction.NO_OP
     return CompositeStateShadowRuntime(
         bundle=bundle,
         artifact=artifact,
@@ -128,6 +155,8 @@ def prepare_composite_state_shadow(
         session=session,
         trade_date=trade_date,
         available_evidence_refs=available_refs,
+        run_id=run_id,
+        evidence_delta_decision=decision,
         no_material_delta=no_material_delta,
         assembly_latency_ms=max(0, round((perf_counter() - started) * 1000)),
     )
@@ -141,7 +170,8 @@ def execute_composite_state_shadow(
     """Run only the shadow candidate path; never materialize or advance canonical state."""
 
     base = _base_trace(runtime)
-    if runtime.no_material_delta:
+    action = runtime.evidence_delta_decision.recommended_action
+    if action is RecommendedAction.NO_OP:
         return {
             **base,
             "status": "no_material_delta",
@@ -149,6 +179,25 @@ def execute_composite_state_shadow(
             "shadow_review_status": "not_required",
             "transition_diff": [],
         }
+    if action is RecommendedAction.UPDATE_CONTEXT_ONLY:
+        return {
+            **base,
+            "status": "context_updated_only",
+            "model_invocation": "skipped",
+            "shadow_review_status": "not_required",
+            "transition_diff": [],
+        }
+    if action is RecommendedAction.MANUAL_REVIEW:
+        return {
+            **base,
+            "status": "manual_review_required",
+            "model_invocation": "skipped",
+            "shadow_review_status": "needs_review",
+            "transition_diff": [],
+            "review_items": [_manual_review_item(runtime)],
+        }
+    if action is not RecommendedAction.RUN_TRANSITION_ANALYSIS:  # pragma: no cover - enum contract
+        raise ValueError(f"unsupported evidence delta action: {action}")
     if analyzer is None:
         return {
             **base,
@@ -232,7 +281,7 @@ def finalize_composite_state_shadow(
 
 def _base_trace(runtime: CompositeStateShadowRuntime) -> dict[str, Any]:
     return {
-        "schema_version": "composite_state_shadow.v2",
+        "schema_version": "composite_state_shadow.v3",
         "mode": STATE_DELTA_CONTEXT_MODE,
         "asset": runtime.bundle.asset,
         "state_scope": runtime.state_scope,
@@ -240,10 +289,137 @@ def _base_trace(runtime: CompositeStateShadowRuntime) -> dict[str, Any]:
         "bundle_id": runtime.bundle.bundle_id,
         "bundle_content_hash": runtime.bundle.content_hash,
         "bundle_path": runtime.artifact.storage_relative_path,
+        "evidence_delta_decision_id": runtime.evidence_delta_decision.decision_id,
+        "evidence_delta_action": runtime.evidence_delta_decision.recommended_action.value,
         "bundle_recovered": not runtime.artifact.written,
         "bundle_estimated_tokens": runtime.bundle.budget_trace.estimated_tokens,
         "assembly_latency_ms": runtime.assembly_latency_ms,
     }
+
+
+_RECOVERY_FIELDS = (
+    "previous_semantic_hashes",
+    "deferred_queue",
+    "processed_above_frontier",
+    "freshness_sla_seconds",
+    "default_freshness_sla_seconds",
+)
+
+
+def _recovery_inputs(
+    *,
+    storage_root: Path,
+    shadow_input: dict[str, Any],
+    asset: str,
+    state_scope: StateScope,
+    canonical_state_id: str,
+) -> dict[str, Any]:
+    previous_bundle_path = shadow_input.get("previous_bundle_path")
+    if previous_bundle_path is None:
+        return {
+            field: shadow_input[field]
+            for field in _RECOVERY_FIELDS
+            if field in shadow_input
+        }
+    ambiguous = [field for field in _RECOVERY_FIELDS if field in shadow_input]
+    if ambiguous:
+        raise ValueError(
+            "previous_bundle_path cannot be combined with explicit recovery fields: "
+            + ", ".join(ambiguous)
+        )
+    previous = load_context_bundle(
+        storage_root=storage_root,
+        storage_relative_path=str(previous_bundle_path),
+    )
+    if previous.schema_version != "analysis_context_bundle.v3":
+        raise ValueError("previous context bundle must use analysis_context_bundle.v3")
+    if (
+        previous.asset != asset
+        or previous.state_scope != state_scope
+        or previous.canonical_state_id != canonical_state_id
+    ):
+        raise ValueError("previous context bundle identity does not match shadow input")
+    if previous.evidence_delta_decision is None:  # pragma: no cover - v3 schema contract
+        raise ValueError("previous context bundle is missing evidence delta decision")
+    decision = EvidenceDeltaDecision.model_validate(previous.evidence_delta_decision)
+    hashes: dict[str, str] = {}
+    for item in decision.evaluated_items:
+        existing = hashes.get(item.evidence_key)
+        if existing is not None and existing != item.semantic_hash:
+            raise ValueError("previous context bundle has ambiguous semantic hashes")
+        hashes[item.evidence_key] = item.semantic_hash
+    return {
+        "previous_semantic_hashes": hashes,
+        "deferred_queue": tuple(previous.deferred_queue),
+        "processed_above_frontier": {
+            source: tuple(pointers)
+            for source, pointers in previous.processed_above_frontier.items()
+        },
+        "freshness_sla_seconds": dict(previous.freshness_sla_seconds),
+        "default_freshness_sla_seconds": previous.default_freshness_sla_seconds,
+    }
+
+
+def build_state_delta_review_item(
+    *,
+    run_id: str,
+    review_id: str,
+    source_step_id: str,
+    reason: str,
+    severity: str = "error",
+    impact_modules: list[str] | None = None,
+    suggested_action: str | None = None,
+    evidence_refs: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build the stable, runner-persistable review payload for shadow failures."""
+
+    return {
+        "review_id": review_id,
+        "run_id": run_id,
+        "source_module": "state_delta_shadow",
+        "source_step_id": source_step_id,
+        "severity": severity,
+        "reason": reason,
+        "impact_modules": impact_modules or ["analysis_state", "state_delta_shadow"],
+        "suggested_action": suggested_action
+        or "Review conflicting or unverified evidence before transition analysis.",
+        "status": "pending",
+        "evidence_refs": evidence_refs or [],
+    }
+
+
+def build_state_delta_setup_failure_review_item(
+    *,
+    run_id: str,
+    failure_kind: str,
+) -> dict[str, Any]:
+    """Build a safe review item without reflecting untrusted shadow input."""
+
+    reason = f"State-delta shadow setup failed: {failure_kind}"
+    reason_digest = hashlib.sha256(reason.encode("utf-8")).hexdigest()[:16]
+    return build_state_delta_review_item(
+        run_id=run_id,
+        review_id=f"state_delta_setup:{run_id}:{reason_digest}",
+        source_step_id="state_delta_shadow_setup",
+        reason=reason,
+        suggested_action="Review the trusted state-delta setup inputs before retrying shadow analysis.",
+    )
+
+
+def _manual_review_item(runtime: CompositeStateShadowRuntime) -> dict[str, Any]:
+    decision = runtime.evidence_delta_decision
+    evidence_refs = [
+        ref.model_dump(mode="json")
+        for item in decision.evaluated_items
+        for ref in item.evidence_refs
+    ]
+    return build_state_delta_review_item(
+        run_id=runtime.run_id,
+        review_id=f"evidence_delta:{decision.decision_id}",
+        source_step_id="evidence_delta_decision",
+        reason="Evidence delta requires manual review: " + "; ".join(decision.trigger_reasons),
+        evidence_refs=evidence_refs,
+    )
 
 
 def _datetime_value(value: Any) -> datetime:

--- a/apps/worker/db_persistence.py
+++ b/apps/worker/db_persistence.py
@@ -245,16 +245,23 @@ def ensure_review_items(
                 }
             )
 
-    for review_item in review_batch:
+    persist_review_items(db, review_batch)
+
+
+def persist_review_items(db: Any, review_items: list[dict[str, Any]]) -> None:
+    """Persist externally assembled review items through the worker DB boundary."""
+    if not review_items:
+        return
+    for review_item in review_items:
         try:
             from database.queries import review as review_queries
 
             _runner_patchable("upsert_review_item", review_queries.upsert_review_item)(db, review_item)
         except Exception:
             logger.exception("Failed to upsert review item %s", review_item.get("review_id"))
-    if review_batch:
+    if review_items:
         db.commit()
-        logger.info("Auto-created %d review items for run %s", len(review_batch), run_id)
+        logger.info("Persisted %d review items", len(review_items))
 
 
 def _file_sha256(path: str | None) -> str | None:

--- a/apps/worker/runner.py
+++ b/apps/worker/runner.py
@@ -50,6 +50,7 @@ from apps.worker.db_persistence import (
     db_persist_analysis_snapshot as _db_persist_analysis_snapshot,
     db_persist_final_result as _db_persist_final_result,
     ensure_review_items as _ensure_review_items,
+    persist_review_items as _persist_review_items,
 )
 from apps.worker.error_policy import (
     classify_error_type as _classify_error_type,
@@ -99,6 +100,7 @@ __all__ = [
     "_db_persist_analysis_snapshot",
     "_db_persist_final_result",
     "_ensure_review_items",
+    "_persist_review_items",
     "_register_composite_output_artifacts",
     "_register_composite_report_registry_entries",
     "_register_run_support_artifacts",
@@ -397,6 +399,12 @@ def run_premarket(
                     snapshot_db_id = _db_persist_agent_outputs(
                         db, analysis_snapshot, composite_outputs["agents"], run_id
                     )
+                    shadow_reviews = (
+                        composite_outputs.get("state_delta_shadow", {}).get("review_items", [])
+                        if isinstance(composite_outputs.get("state_delta_shadow"), dict)
+                        else []
+                    )
+                    _persist_review_items(db, shadow_reviews)
                     agent_loop_decision = composite_outputs.get("agent_loop_decision")
                     publish_allowed = bool(getattr(agent_loop_decision, "publish_allowed", False))
                     if publish_allowed:

--- a/tests/analysis/test_context_bundle.py
+++ b/tests/analysis/test_context_bundle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -10,6 +11,9 @@ from apps.analysis.context_bundle import (
     assemble_context_bundle,
     select_incremental_evidence,
 )
+from apps.analysis.context_bundle.schemas import AnalysisContextBundle, compute_bundle_content_hash
+from apps.analysis.context_bundle.selection import EvidenceSelectionBudgetError
+from apps.analysis.evidence_delta import evaluate_evidence_delta
 
 
 NOW = datetime(2026, 7, 22, 8, tzinfo=UTC)
@@ -24,13 +28,27 @@ def _evidence(
     payload: dict | None = None,
     session: str = "asia",
 ) -> dict:
+    material_payload = {
+        "evidence_type": "material_event",
+        "asset": "XAUUSD",
+        "source_quality": "official",
+        "event_id": evidence_id,
+        "cluster_key": f"cluster:{source}:{evidence_id}",
+        "event_type": "test_event",
+        "claim": evidence_id,
+        "materiality_score": 10,
+        "risk_level": "low",
+        "recompute_eligible": False,
+        "confirmation_status": "confirmed",
+        "metadata": payload or {},
+    }
     return {
         "source": source,
         "evidence_id": evidence_id,
         "business_time": business_time,
         "ingested_at": ingested_at,
         "session": session,
-        "payload": payload or {"value": evidence_id},
+        "payload": material_payload,
         "source_ref": {"snapshot_id": evidence_id},
     }
 
@@ -78,8 +96,13 @@ def test_bundle_is_stable_without_provider_conversation_metadata() -> None:
             "nested": {"thread_id": "thread-1"},
         },
     )
-    clean = dict(with_transport)
-    clean["payload"] = {"value": 4050, "nested": {}}
+    clean = _evidence(
+        "market",
+        "market-2",
+        business_time=NOW,
+        ingested_at=NOW + timedelta(minutes=2),
+        payload={"value": 4050, "nested": {}},
+    )
 
     first = _bundle(evidence=[with_transport])
     replay = _bundle(
@@ -157,7 +180,7 @@ def test_history_bodies_are_omitted_but_lineage_and_summary_remain() -> None:
     )
 
 
-def test_budget_defers_newest_evidence_without_skipping_its_cursor() -> None:
+def test_budget_keeps_newest_evidence_without_advancing_across_oldest_gap() -> None:
     evidence = [
         _evidence(
             "news",
@@ -174,19 +197,17 @@ def test_budget_defers_newest_evidence_without_skipping_its_cursor() -> None:
     assert bundle.budget_trace.within_budget is True
     assert bundle.budget_trace.estimated_tokens <= 1_600
     assert len(retained) < len(evidence)
-    assert bundle.next_evidence_cursors["news"].evidence_id == retained[-1]
+    assert retained[0] == "news-5"
+    assert "news" not in bundle.next_evidence_cursors
+    assert bundle.deferred_queue[0]["evidence_id"] == "news-1"
     assert any(
         item["reason"].startswith("budget_deferred:")
         for item in bundle.budget_trace.trim_reasons
     )
-    deferred = select_incremental_evidence(
-        evidence,
-        cursors={"news": bundle.next_evidence_cursors["news"]},
-        cutoff_at=NOW + timedelta(minutes=10),
-    )
-    assert [item.evidence_id for item in deferred] == [
-        item["evidence_id"] for item in evidence[len(retained) :]
-    ]
+    assert bundle.processed_above_frontier["news"]
+    assert {item["snapshot_id"] for item in bundle.source_refs} == {
+        f"news-{index}" for index in range(1, 6)
+    }
 
 
 def test_budget_fails_closed_when_canonical_state_alone_is_too_large() -> None:
@@ -278,7 +299,7 @@ def test_scope_is_part_of_bundle_hash_and_identity() -> None:
         },
     )
 
-    assert daily.schema_version == "analysis_context_bundle.v2"
+    assert daily.schema_version == "analysis_context_bundle.v3"
     assert daily.state_scope == "daily_close"
     assert intraday.state_scope == "intraday"
     assert intraday.content_hash != daily.content_hash
@@ -288,3 +309,157 @@ def test_scope_is_part_of_bundle_hash_and_identity() -> None:
 def test_bundle_rejects_cross_scope_canonical_state() -> None:
     with pytest.raises(ValueError, match="different state_scope"):
         _bundle(state_scope="intraday")
+
+
+def test_v3_requires_identity_bound_decision_and_normalizes_selection_order() -> None:
+    bundle = _bundle(
+        evidence=[
+            _evidence(
+                "news",
+                "news-2",
+                business_time=NOW,
+                ingested_at=NOW + timedelta(minutes=2),
+            ),
+            _evidence(
+                "market",
+                "market-2",
+                business_time=NOW,
+                ingested_at=NOW + timedelta(minutes=1),
+            ),
+        ]
+    )
+    payload = bundle.model_dump(mode="json")
+    payload["selection_decisions"] = list(reversed(payload["selection_decisions"]))
+    canonical = dict(payload)
+    canonical["selection_decisions"] = sorted(
+        canonical["selection_decisions"],
+        key=lambda item: (item["source"], item["evidence_id"], item["outcome"]),
+    )
+    canonical["content_hash"] = compute_bundle_content_hash(canonical)
+    canonical["bundle_id"] = str(
+        uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"finance-agent:context-bundle:{canonical['content_hash']}",
+        )
+    )
+    payload["content_hash"] = canonical["content_hash"]
+    payload["bundle_id"] = canonical["bundle_id"]
+
+    normalized = AnalysisContextBundle.model_validate(payload)
+    assert normalized.selection_decisions == canonical["selection_decisions"]
+    assert compute_bundle_content_hash(payload) == bundle.content_hash
+    replay = _bundle(evidence=list(reversed([
+        _evidence(
+            "news",
+            "news-2",
+            business_time=NOW,
+            ingested_at=NOW + timedelta(minutes=2),
+        ),
+        _evidence(
+            "market",
+            "market-2",
+            business_time=NOW,
+            ingested_at=NOW + timedelta(minutes=1),
+        ),
+    ])))
+    assert replay.content_hash == bundle.content_hash
+    assert replay.bundle_id == bundle.bundle_id
+
+    missing = bundle.model_dump(mode="json")
+    missing["evidence_delta_decision"] = None
+    missing["content_hash"] = compute_bundle_content_hash(missing)
+    missing["bundle_id"] = str(
+        uuid.uuid5(uuid.NAMESPACE_URL, f"finance-agent:context-bundle:{missing['content_hash']}")
+    )
+    with pytest.raises(ValidationError, match="requires decision"):
+        AnalysisContextBundle.model_validate(missing)
+
+    mismatched = bundle.model_dump(mode="json")
+    other = evaluate_evidence_delta(
+        asset="GC",
+        state_scope="daily_close",
+        canonical_state_id=bundle.canonical_state_id,
+        evidence=[],
+    )
+    mismatched["evidence_delta_decision"] = other.model_dump(mode="json")
+    mismatched["content_hash"] = compute_bundle_content_hash(mismatched)
+    mismatched["bundle_id"] = str(
+        uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"finance-agent:context-bundle:{mismatched['content_hash']}",
+        )
+    )
+    with pytest.raises(ValidationError, match="identity does not match"):
+        AnalysisContextBundle.model_validate(mismatched)
+
+
+def test_v3_rejects_forged_selection_counts_and_non_strict_sla() -> None:
+    bundle = _bundle()
+    forged = bundle.model_dump(mode="json")
+    forged["selection_trace"]["retained_count"] += 1
+    forged["content_hash"] = compute_bundle_content_hash(forged)
+    forged["bundle_id"] = str(
+        uuid.uuid5(uuid.NAMESPACE_URL, f"finance-agent:context-bundle:{forged['content_hash']}")
+    )
+    with pytest.raises(ValidationError, match="trace counts"):
+        AnalysisContextBundle.model_validate(forged)
+
+    boolean_sla = bundle.model_dump(mode="json")
+    boolean_sla["freshness_sla_seconds"] = {"market": True}
+    with pytest.raises(ValidationError):
+        AnalysisContextBundle.model_validate(boolean_sla)
+
+
+def test_manual_review_evidence_is_mandatory_and_budget_failure_is_explicit() -> None:
+    evidence = _evidence(
+        "macro",
+        "macro-conflict",
+        business_time=NOW,
+        ingested_at=NOW + timedelta(minutes=1),
+    )
+    evidence["payload"] = {
+        "evidence_type": "macro_metric",
+        "asset": "XAUUSD",
+        "source_quality": "unverified",
+        "metric": "dxy",
+        "current_value": 101.0,
+        "previous_value": 100.0,
+        "unit": "index",
+        "metadata": {"detail": "x" * 1_500},
+    }
+
+    with pytest.raises(EvidenceSelectionBudgetError, match="mandatory evidence exceeds"):
+        _bundle(evidence=[evidence], facts=[], budget_tokens=500)
+
+
+def test_freshness_and_session_use_pretrim_eligible_evidence() -> None:
+    asia = _evidence(
+        "market",
+        "market-large",
+        business_time=NOW,
+        ingested_at=NOW + timedelta(minutes=1),
+        payload={"detail": "a" * 1_200},
+        session="asia",
+    )
+    us = _evidence(
+        "macro",
+        "macro-large",
+        business_time=NOW + timedelta(hours=2),
+        ingested_at=NOW + timedelta(minutes=2),
+        payload={"detail": "b" * 1_200},
+        session="us",
+    )
+    bundle = _bundle(
+        evidence=[asia, us],
+        facts=[],
+        budget_tokens=850,
+        freshness_sla_seconds={"macro": 60},
+        default_freshness_sla_seconds=60,
+        max_alignment_seconds=60,
+    )
+
+    assert bundle.selection_trace["deferred_count"] > 0
+    assert set(bundle.freshness) == {"macro", "market"}
+    assert bundle.freshness["market"]["sla_policy"] == "default"
+    assert bundle.session["status"] == "mismatch"
+    assert bundle.alignment["status"] == "misaligned"

--- a/tests/analysis/test_context_bundle_selection.py
+++ b/tests/analysis/test_context_bundle_selection.py
@@ -1,0 +1,710 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from apps.analysis.context_bundle.selection import (
+    DeferredEvidencePointer,
+    EvidencePriority,
+    EvidencePriorityClass,
+    EvidenceSelectionBudgetError,
+    EvidenceSelectionStateError,
+    select_material_evidence,
+)
+
+
+NOW = datetime(2026, 7, 22, 8, tzinfo=UTC)
+
+
+def _hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _evidence(
+    source: str,
+    evidence_id: str,
+    *,
+    minute: int,
+) -> dict:
+    observed_at = NOW + timedelta(minutes=minute)
+    return {
+        "source": source,
+        "evidence_id": evidence_id,
+        "business_time": observed_at,
+        "ingested_at": observed_at,
+        "session": "asia",
+        "payload": {"value": evidence_id},
+        "source_ref": {"snapshot_id": evidence_id},
+    }
+
+
+def _priority(
+    source: str,
+    evidence_id: str,
+    *,
+    priority_class: EvidencePriorityClass,
+    tokens: int,
+    mandatory: bool = False,
+    semantic_hash: str | None = None,
+) -> EvidencePriority:
+    return EvidencePriority(
+        source=source,
+        evidence_id=evidence_id,
+        semantic_hash=semantic_hash or _hash(evidence_id),
+        priority_class=priority_class,
+        materiality="critical" if mandatory else "caller_confirmed",
+        mandatory=mandatory,
+        reason_codes=(f"priority:{priority_class.value}",),
+        estimated_tokens=tokens,
+    )
+
+
+def _select(
+    *,
+    evidence: list[dict],
+    priorities: list[EvidencePriority],
+    budget_tokens: int,
+    cursors: dict | None = None,
+    deferred_queue: tuple[DeferredEvidencePointer, ...] = (),
+    processed_above_frontier: dict[str, tuple[DeferredEvidencePointer, ...]] | None = None,
+):
+    return select_material_evidence(
+        evidence=evidence,
+        priorities=priorities,
+        evidence_cursors=cursors or {},
+        cutoff_at=NOW + timedelta(minutes=30),
+        evidence_budget_tokens=budget_tokens,
+        deferred_queue=deferred_queue,
+        processed_above_frontier=processed_above_frontier or {},
+    )
+
+
+def test_critical_evidence_crosses_backlog_without_advancing_past_gap() -> None:
+    evidence = [
+        _evidence("news", "backlog", minute=1),
+        _evidence("news", "critical", minute=2),
+    ]
+    priorities = [
+        _priority(
+            "news",
+            "backlog",
+            priority_class=EvidencePriorityClass.BACKLOG,
+            tokens=8,
+        ),
+        _priority(
+            "news",
+            "critical",
+            priority_class=EvidencePriorityClass.CONFIRMED_INVALIDATION,
+            tokens=2,
+        ),
+    ]
+    cursor = {"news": {"ingested_at": NOW, "evidence_id": "seed"}}
+
+    result = _select(
+        evidence=evidence,
+        priorities=priorities,
+        budget_tokens=2,
+        cursors=cursor,
+    )
+
+    assert result.retained_evidence_ids == ("critical",)
+    assert [item.evidence_id for item in result.deferred_queue] == ["backlog"]
+    assert result.next_evidence_cursors["news"].evidence_id == "seed"
+    assert [
+        item.evidence_id for item in result.processed_above_frontier["news"]
+    ] == ["critical"]
+
+
+def test_processed_above_frontier_does_not_consume_budget_or_trigger_again() -> None:
+    first = _select(
+        evidence=[
+            _evidence("news", "backlog", minute=1),
+            _evidence("news", "critical", minute=2),
+        ],
+        priorities=[
+            _priority(
+                "news",
+                "backlog",
+                priority_class=EvidencePriorityClass.BACKLOG,
+                tokens=8,
+            ),
+            _priority(
+                "news",
+                "critical",
+                priority_class=EvidencePriorityClass.CONFIRMED_INVALIDATION,
+                tokens=2,
+            ),
+        ],
+        budget_tokens=2,
+        cursors={"news": {"ingested_at": NOW, "evidence_id": "seed"}},
+    )
+
+    replay = _select(
+        evidence=[
+            _evidence("news", "critical", minute=2),
+            _evidence("news", "backlog", minute=1),
+        ],
+        priorities=[
+            _priority(
+                "news",
+                "critical",
+                priority_class=EvidencePriorityClass.CONFIRMED_INVALIDATION,
+                tokens=2,
+            ),
+            _priority(
+                "news",
+                "backlog",
+                priority_class=EvidencePriorityClass.BACKLOG,
+                tokens=8,
+            ),
+        ],
+        budget_tokens=1,
+        cursors={"news": {"ingested_at": NOW, "evidence_id": "seed"}},
+        deferred_queue=first.deferred_queue,
+        processed_above_frontier=first.processed_above_frontier,
+    )
+
+    assert replay.retained_evidence_ids == ()
+    assert replay.trace.retained_tokens == 0
+    assert any(
+        item.evidence_id == "critical"
+        and item.outcome == "rejected"
+        and "already_processed_above_frontier" in item.reasons
+        for item in replay.decisions
+    )
+
+
+def test_filling_gap_absorbs_processed_items_and_advances_frontier() -> None:
+    evidence = [
+        _evidence("news", "backlog", minute=1),
+        _evidence("news", "critical", minute=2),
+    ]
+    priorities = [
+        _priority(
+            "news",
+            "backlog",
+            priority_class=EvidencePriorityClass.BACKLOG,
+            tokens=8,
+        ),
+        _priority(
+            "news",
+            "critical",
+            priority_class=EvidencePriorityClass.CONFIRMED_INVALIDATION,
+            tokens=2,
+        ),
+    ]
+    cursor = {"news": {"ingested_at": NOW, "evidence_id": "seed"}}
+    first = _select(
+        evidence=evidence,
+        priorities=priorities,
+        budget_tokens=2,
+        cursors=cursor,
+    )
+
+    resolved = _select(
+        evidence=evidence,
+        priorities=priorities,
+        budget_tokens=8,
+        cursors=cursor,
+        deferred_queue=first.deferred_queue,
+        processed_above_frontier=first.processed_above_frontier,
+    )
+
+    assert resolved.retained_evidence_ids == ("backlog",)
+    assert resolved.next_evidence_cursors["news"].evidence_id == "critical"
+    assert resolved.deferred_queue == ()
+    assert resolved.processed_above_frontier == {}
+
+
+def test_frontiers_are_isolated_per_source() -> None:
+    result = _select(
+        evidence=[
+            _evidence("news", "news-backlog", minute=1),
+            _evidence("news", "news-critical", minute=2),
+            _evidence("market", "market-current", minute=3),
+        ],
+        priorities=[
+            _priority(
+                "news",
+                "news-backlog",
+                priority_class=EvidencePriorityClass.BACKLOG,
+                tokens=9,
+            ),
+            _priority(
+                "news",
+                "news-critical",
+                priority_class=EvidencePriorityClass.CONFIRMED_INVALIDATION,
+                tokens=1,
+            ),
+            _priority(
+                "market",
+                "market-current",
+                priority_class=EvidencePriorityClass.ORDINARY_CURRENT,
+                tokens=1,
+            ),
+        ],
+        budget_tokens=2,
+        cursors={
+            "news": {"ingested_at": NOW, "evidence_id": "news-seed"},
+            "market": {"ingested_at": NOW, "evidence_id": "market-seed"},
+        },
+    )
+
+    assert result.next_evidence_cursors["news"].evidence_id == "news-seed"
+    assert result.next_evidence_cursors["market"].evidence_id == "market-current"
+    assert [
+        item.evidence_id for item in result.processed_above_frontier["news"]
+    ] == ["news-critical"]
+    assert "market" not in result.processed_above_frontier
+
+
+def test_same_timestamp_uses_evidence_id_as_stable_frontier_order() -> None:
+    evidence = [
+        _evidence("news", "b", minute=1),
+        _evidence("news", "a", minute=1),
+    ]
+    priorities = [
+        _priority(
+            "news",
+            "b",
+            priority_class=EvidencePriorityClass.ORDINARY_CURRENT,
+            tokens=1,
+        ),
+        _priority(
+            "news",
+            "a",
+            priority_class=EvidencePriorityClass.ORDINARY_CURRENT,
+            tokens=1,
+        ),
+    ]
+
+    result = _select(evidence=evidence, priorities=priorities, budget_tokens=1)
+
+    assert result.retained_evidence_ids == ("a",)
+    assert [item.evidence_id for item in result.deferred_queue] == ["b"]
+    assert result.next_evidence_cursors["news"].evidence_id == "a"
+
+
+def test_evidence_after_cutoff_is_rejected_and_never_queued() -> None:
+    result = select_material_evidence(
+        evidence=[_evidence("news", "future", minute=31)],
+        priorities=[
+            _priority(
+                "news",
+                "future",
+                priority_class=EvidencePriorityClass.CONFIRMED_INVALIDATION,
+                tokens=1,
+            )
+        ],
+        evidence_cursors={},
+        cutoff_at=NOW + timedelta(minutes=30),
+        evidence_budget_tokens=10,
+    )
+
+    assert result.retained_evidence_ids == ()
+    assert result.deferred_queue == ()
+    assert result.processed_above_frontier == {}
+    assert result.next_evidence_cursors == {}
+    assert result.decisions[0].reasons == ("after_cutoff",)
+
+
+def test_mandatory_evidence_over_budget_fails_closed() -> None:
+    with pytest.raises(EvidenceSelectionBudgetError) as exc_info:
+        _select(
+            evidence=[_evidence("macro", "must-keep", minute=1)],
+            priorities=[
+                _priority(
+                    "macro",
+                    "must-keep",
+                    priority_class=EvidencePriorityClass.MANDATORY_CRITICAL,
+                    tokens=5,
+                    mandatory=True,
+                )
+            ],
+            budget_tokens=4,
+        )
+
+    assert exc_info.value.required_tokens == 5
+    assert exc_info.value.budget_tokens == 4
+    assert exc_info.value.mandatory_evidence_ids == ("must-keep",)
+    assert [
+        (item.source, item.evidence_id)
+        for item in exc_info.value.mandatory_evidence_keys
+    ] == [("macro", "must-keep")]
+
+
+def test_deferred_queue_hash_conflict_fails_before_frontier_advances() -> None:
+    cursor = {"news": {"ingested_at": NOW, "evidence_id": "seed"}}
+    corrupted = DeferredEvidencePointer(
+        source="news",
+        evidence_id="queued",
+        ingested_at=NOW + timedelta(minutes=1),
+        semantic_hash=_hash("old-content"),
+    )
+
+    with pytest.raises(EvidenceSelectionStateError, match="semantic_hash"):
+        _select(
+            evidence=[_evidence("news", "queued", minute=1)],
+            priorities=[
+                _priority(
+                    "news",
+                    "queued",
+                    priority_class=EvidencePriorityClass.BACKLOG,
+                    tokens=1,
+                    semantic_hash=_hash("changed-content"),
+                )
+            ],
+            budget_tokens=1,
+            cursors=cursor,
+            deferred_queue=(corrupted,),
+        )
+
+    assert cursor["news"]["evidence_id"] == "seed"
+
+
+def test_processed_pointer_hash_conflict_fails_even_without_replayed_body() -> None:
+    processed = DeferredEvidencePointer(
+        source="news",
+        evidence_id="already-used",
+        ingested_at=NOW + timedelta(minutes=2),
+        semantic_hash=_hash("original"),
+    )
+
+    with pytest.raises(EvidenceSelectionStateError, match="processed semantic_hash"):
+        _select(
+            evidence=[_evidence("news", "gap", minute=1)],
+            priorities=[
+                _priority(
+                    "news",
+                    "gap",
+                    priority_class=EvidencePriorityClass.BACKLOG,
+                    tokens=1,
+                ),
+                _priority(
+                    "news",
+                    "already-used",
+                    priority_class=EvidencePriorityClass.CONFIRMED_INVALIDATION,
+                    tokens=1,
+                    semantic_hash=_hash("mutated"),
+                ),
+            ],
+            budget_tokens=1,
+            processed_above_frontier={"news": (processed,)},
+        )
+
+
+def test_persisted_deferred_wins_same_class_to_prevent_starvation() -> None:
+    old = _evidence("news", "old", minute=1)
+    old_priority = _priority(
+        "news",
+        "old",
+        priority_class=EvidencePriorityClass.ORDINARY_CURRENT,
+        tokens=1,
+    )
+    first = _select(
+        evidence=[old],
+        priorities=[old_priority],
+        budget_tokens=0,
+    )
+
+    assert first.deferred_queue[0].deferred_priority_class is EvidencePriorityClass.ORDINARY_CURRENT
+    assert "evidence_budget_exhausted" in first.deferred_queue[0].deferral_reasons
+
+    second = _select(
+        evidence=[_evidence("news", "new", minute=2), old],
+        priorities=[
+            _priority(
+                "news",
+                "new",
+                priority_class=EvidencePriorityClass.ORDINARY_CURRENT,
+                tokens=1,
+            ),
+            old_priority,
+        ],
+        budget_tokens=1,
+        deferred_queue=first.deferred_queue,
+    )
+
+    assert second.retained_evidence_ids == ("old",)
+    assert [item.evidence_id for item in second.deferred_queue] == ["new"]
+    assert second.next_evidence_cursors["news"].evidence_id == "old"
+
+
+def test_higher_priority_new_evidence_can_still_cross_persisted_gap() -> None:
+    old = _evidence("news", "old", minute=1)
+    old_priority = _priority(
+        "news",
+        "old",
+        priority_class=EvidencePriorityClass.BACKLOG,
+        tokens=1,
+    )
+    first = _select(evidence=[old], priorities=[old_priority], budget_tokens=0)
+
+    second = _select(
+        evidence=[old, _evidence("news", "critical", minute=2)],
+        priorities=[
+            old_priority,
+            _priority(
+                "news",
+                "critical",
+                priority_class=EvidencePriorityClass.CONFIRMED_INVALIDATION,
+                tokens=1,
+            ),
+        ],
+        budget_tokens=1,
+        deferred_queue=first.deferred_queue,
+    )
+
+    assert second.retained_evidence_ids == ("critical",)
+    assert [item.evidence_id for item in second.deferred_queue] == ["old"]
+    assert [
+        item.evidence_id for item in second.processed_above_frontier["news"]
+    ] == ["critical"]
+
+
+def test_deferred_priority_snapshot_does_not_block_next_round_reclassification() -> None:
+    item = _evidence("news", "reclassified", minute=1)
+    first = _select(
+        evidence=[item],
+        priorities=[
+            _priority(
+                "news",
+                "reclassified",
+                priority_class=EvidencePriorityClass.BACKLOG,
+                tokens=1,
+            )
+        ],
+        budget_tokens=0,
+    )
+
+    second = _select(
+        evidence=[item],
+        priorities=[
+            _priority(
+                "news",
+                "reclassified",
+                priority_class=EvidencePriorityClass.CONFIRMED_KEY_LEVEL,
+                tokens=1,
+            )
+        ],
+        budget_tokens=1,
+        deferred_queue=first.deferred_queue,
+    )
+
+    assert first.deferred_queue[0].deferred_priority_class is EvidencePriorityClass.BACKLOG
+    assert second.retained_evidence_ids == ("reclassified",)
+
+
+@pytest.mark.parametrize(
+    ("priority_class", "mandatory"),
+    [
+        (EvidencePriorityClass.MANDATORY_CRITICAL, False),
+        (EvidencePriorityClass.CONFIRMED_INVALIDATION, True),
+    ],
+)
+def test_mandatory_flag_and_priority_class_must_agree(
+    priority_class: EvidencePriorityClass,
+    mandatory: bool,
+) -> None:
+    with pytest.raises(ValidationError, match="mandatory must be true exactly"):
+        _priority(
+            "macro",
+            "invalid-mandatory",
+            priority_class=priority_class,
+            tokens=1,
+            mandatory=mandatory,
+        )
+
+
+def test_unrelated_extra_priority_fails_closed() -> None:
+    with pytest.raises(EvidenceSelectionStateError, match="no current or processed evidence"):
+        _select(
+            evidence=[_evidence("news", "current", minute=1)],
+            priorities=[
+                _priority(
+                    "news",
+                    "current",
+                    priority_class=EvidencePriorityClass.ORDINARY_CURRENT,
+                    tokens=1,
+                ),
+                _priority(
+                    "news",
+                    "unrelated",
+                    priority_class=EvidencePriorityClass.BACKLOG,
+                    tokens=1,
+                ),
+            ],
+            budget_tokens=1,
+        )
+
+
+def test_selection_is_deterministic_across_input_order() -> None:
+    evidence = [
+        _evidence("news", "ordinary", minute=1),
+        _evidence("market", "regime", minute=2),
+        _evidence("macro", "invalidation", minute=3),
+    ]
+    priorities = [
+        _priority(
+            "news",
+            "ordinary",
+            priority_class=EvidencePriorityClass.ORDINARY_CURRENT,
+            tokens=1,
+        ),
+        _priority(
+            "market",
+            "regime",
+            priority_class=EvidencePriorityClass.MARKET_OPTIONS_REGIME,
+            tokens=1,
+        ),
+        _priority(
+            "macro",
+            "invalidation",
+            priority_class=EvidencePriorityClass.CONFIRMED_INVALIDATION,
+            tokens=1,
+        ),
+    ]
+
+    first = _select(evidence=evidence, priorities=priorities, budget_tokens=2)
+    second = _select(
+        evidence=list(reversed(evidence)),
+        priorities=list(reversed(priorities)),
+        budget_tokens=2,
+    )
+
+    assert first.model_dump(mode="json") == second.model_dump(mode="json")
+
+
+def test_same_evidence_id_from_different_sources_keeps_source_aware_identity() -> None:
+    result = _select(
+        evidence=[
+            _evidence("news", "shared-id", minute=1),
+            _evidence("market", "shared-id", minute=2),
+        ],
+        priorities=[
+            _priority(
+                "news",
+                "shared-id",
+                priority_class=EvidencePriorityClass.ORDINARY_CURRENT,
+                tokens=1,
+                semantic_hash=_hash("news/shared-id"),
+            ),
+            _priority(
+                "market",
+                "shared-id",
+                priority_class=EvidencePriorityClass.ORDINARY_CURRENT,
+                tokens=1,
+                semantic_hash=_hash("market/shared-id"),
+            ),
+        ],
+        budget_tokens=2,
+    )
+
+    assert result.retained_evidence_ids == ("shared-id", "shared-id")
+    assert {
+        (item.source, item.evidence_id) for item in result.retained_evidence_keys
+    } == {("news", "shared-id"), ("market", "shared-id")}
+
+
+def test_missing_priority_fails_closed_instead_of_assuming_low_priority() -> None:
+    with pytest.raises(EvidenceSelectionStateError, match="missing evidence priority"):
+        _select(
+            evidence=[_evidence("news", "unclassified", minute=1)],
+            priorities=[],
+            budget_tokens=1,
+        )
+
+
+def test_identical_duplicates_are_deduplicated_but_evidence_conflicts_fail() -> None:
+    item = _evidence("news", "duplicate", minute=1)
+    priority = _priority(
+        "news",
+        "duplicate",
+        priority_class=EvidencePriorityClass.ORDINARY_CURRENT,
+        tokens=1,
+    )
+    deduplicated = _select(
+        evidence=[item, dict(item)],
+        priorities=[priority, priority.model_copy()],
+        budget_tokens=1,
+    )
+
+    assert deduplicated.retained_evidence_ids == ("duplicate",)
+
+    conflicting_item = _evidence("news", "duplicate", minute=2)
+    with pytest.raises(EvidenceSelectionStateError, match="conflicting duplicate evidence"):
+        _select(
+            evidence=[item, conflicting_item],
+            priorities=[priority],
+            budget_tokens=1,
+        )
+
+
+def test_conflicting_duplicate_priority_hash_or_class_fails_closed() -> None:
+    first = _priority(
+        "news",
+        "duplicate",
+        priority_class=EvidencePriorityClass.ORDINARY_CURRENT,
+        tokens=1,
+        semantic_hash=_hash("first"),
+    )
+    conflicting = first.model_copy(update={"semantic_hash": _hash("second")})
+
+    with pytest.raises(EvidenceSelectionStateError, match="conflicting duplicate evidence priority"):
+        _select(
+            evidence=[_evidence("news", "duplicate", minute=1)],
+            priorities=[first, conflicting],
+            budget_tokens=1,
+        )
+
+    conflicting_class = first.model_copy(
+        update={"priority_class": EvidencePriorityClass.CONFIRMED_INVALIDATION}
+    )
+    with pytest.raises(EvidenceSelectionStateError, match="conflicting duplicate evidence priority"):
+        _select(
+            evidence=[_evidence("news", "duplicate", minute=1)],
+            priorities=[first, conflicting_class],
+            budget_tokens=1,
+        )
+
+
+def test_low_value_backlog_is_deferred_before_higher_priority_evidence() -> None:
+    result = _select(
+        evidence=[
+            _evidence("news", "backlog", minute=3),
+            _evidence("options", "regime", minute=1),
+            _evidence("market", "key-level", minute=2),
+        ],
+        priorities=[
+            _priority(
+                "news",
+                "backlog",
+                priority_class=EvidencePriorityClass.BACKLOG,
+                tokens=1,
+            ),
+            _priority(
+                "options",
+                "regime",
+                priority_class=EvidencePriorityClass.MARKET_OPTIONS_REGIME,
+                tokens=1,
+            ),
+            _priority(
+                "market",
+                "key-level",
+                priority_class=EvidencePriorityClass.CONFIRMED_KEY_LEVEL,
+                tokens=1,
+            ),
+        ],
+        budget_tokens=2,
+    )
+
+    assert result.retained_evidence_ids == ("key-level", "regime")
+    assert [item.evidence_id for item in result.deferred_queue] == ["backlog"]
+    retained = {
+        item.evidence_id: item for item in result.decisions if item.outcome == "retained"
+    }
+    assert retained["key-level"].reasons == ("priority:confirmed_key_level",)
+    assert retained["regime"].reasons == ("priority:market_options_regime",)

--- a/tests/analysis/test_evidence_delta_evaluator.py
+++ b/tests/analysis/test_evidence_delta_evaluator.py
@@ -102,19 +102,21 @@ def _event(
     score: float = 85.0,
     eligible: bool = True,
     confirmation: ConfirmationStatus = ConfirmationStatus.CONFIRMED,
+    source_quality: SourceQuality = SourceQuality.OFFICIAL,
+    risk_level: str = "high",
 ) -> MaterialEventEvidence:
     return MaterialEventEvidence(
         source=source,
         evidence_id=evidence_id,
         asset="XAUUSD",
         observed_at=NOW,
-        source_quality=SourceQuality.OFFICIAL,
+        source_quality=source_quality,
         event_id=evidence_id,
         cluster_key="fomc-policy-change",
         event_type="fomc_statement",
         claim=claim,
         materiality_score=score,
-        risk_level="high",
+        risk_level=risk_level,
         recompute_eligible=eligible,
         confirmation_status=confirmation,
     )
@@ -175,7 +177,7 @@ def test_input_order_does_not_change_decision_identity() -> None:
 def test_duplicate_news_from_different_sources_is_clustered_with_source_aware_refs() -> None:
     first = _event(source="federal_reserve", evidence_id="official-1")
     second = _event(source="reuters", evidence_id="wire-9")
-    second = second.model_copy(update={"source_quality": SourceQuality.VALIDATED})
+    second = second.model_copy(update={"source_quality": SourceQuality.PRIMARY})
 
     decision = _evaluate(second, first)
 
@@ -190,7 +192,7 @@ def test_duplicate_news_from_different_sources_is_clustered_with_source_aware_re
 def test_same_evidence_id_from_different_sources_is_not_collapsed() -> None:
     first = _event(source="federal_reserve", evidence_id="shared-id")
     second = _event(source="reuters", evidence_id="shared-id")
-    second = second.model_copy(update={"source_quality": SourceQuality.VALIDATED})
+    second = second.model_copy(update={"source_quality": SourceQuality.PRIMARY})
 
     item = _evaluate(first, second).evaluated_items[0]
 
@@ -284,6 +286,145 @@ def test_confirmed_material_event_triggers_and_unconfirmed_high_risk_stays_manua
         _evaluate(_event(eligible=False, confirmation=ConfirmationStatus.UNCONFIRMED)).recommended_action
         is RecommendedAction.MANUAL_REVIEW
     )
+
+
+@pytest.mark.parametrize(
+    "source_quality",
+    [
+        SourceQuality.OFFICIAL,
+        SourceQuality.PRIMARY,
+        SourceQuality.VALIDATED,
+        SourceQuality.EXCHANGE,
+    ],
+)
+def test_confirmed_material_event_requires_trusted_source_for_transition(
+    source_quality: SourceQuality,
+) -> None:
+    assert _evaluate(_event(source_quality=source_quality)).recommended_action is (
+        RecommendedAction.RUN_TRANSITION_ANALYSIS
+    )
+
+
+def test_confirmed_supplemental_material_event_is_context_only() -> None:
+    decision = _evaluate(_event(source_quality=SourceQuality.SUPPLEMENTAL))
+
+    assert decision.recommended_action is RecommendedAction.UPDATE_CONTEXT_ONLY
+    assert decision.trigger_reasons == ["material_event:supplemental_context_only"]
+
+
+@pytest.mark.parametrize(
+    ("score", "risk_level", "expected"),
+    [
+        (85.0, "low", RecommendedAction.MANUAL_REVIEW),
+        (30.0, "high", RecommendedAction.MANUAL_REVIEW),
+        (30.0, "low", RecommendedAction.NO_OP),
+    ],
+)
+def test_unverified_material_event_fails_closed_only_when_high_risk(
+    score: float, risk_level: str, expected: RecommendedAction
+) -> None:
+    assert _evaluate(
+        _event(
+            score=score,
+            risk_level=risk_level,
+            source_quality=SourceQuality.UNVERIFIED,
+        )
+    ).recommended_action is expected
+
+
+def test_material_event_authority_progression_changes_hash_without_changing_identity() -> None:
+    unverified = _event(source_quality=SourceQuality.UNVERIFIED)
+    official = _event(source_quality=SourceQuality.OFFICIAL, evidence_id="event-2")
+    official_other_collector = _event(
+        source="white_house",
+        evidence_id="event-3",
+        source_quality=SourceQuality.PRIMARY,
+    )
+
+    assert semantic_identity(unverified) == semantic_identity(official)
+    assert semantic_hash(unverified) != semantic_hash(official)
+    assert semantic_hash(official) == semantic_hash(official_other_collector)
+
+    decision = _evaluate(
+        official,
+        previous_semantic_hashes={semantic_identity(unverified): semantic_hash(unverified)},
+    )
+
+    assert decision.recommended_action is RecommendedAction.RUN_TRANSITION_ANALYSIS
+    assert decision.evaluated_items[0].outcome == "transition_trigger"
+
+
+def test_material_event_supplemental_to_validated_progression_is_not_duplicate() -> None:
+    supplemental = _event(source_quality=SourceQuality.SUPPLEMENTAL)
+    validated = _event(
+        evidence_id="event-2",
+        source_quality=SourceQuality.VALIDATED,
+    )
+
+    assert semantic_identity(supplemental) == semantic_identity(validated)
+    assert semantic_hash(supplemental) != semantic_hash(validated)
+
+    decision = _evaluate(
+        validated,
+        previous_semantic_hashes={
+            semantic_identity(supplemental): semantic_hash(supplemental),
+        },
+    )
+
+    assert decision.recommended_action is RecommendedAction.RUN_TRANSITION_ANALYSIS
+    assert decision.evaluated_items[0].outcome == "transition_trigger"
+
+
+def test_same_batch_supplemental_and_validated_event_aggregates_at_validated_stage() -> None:
+    supplemental = _event(
+        source="wire",
+        evidence_id="supplemental-1",
+        source_quality=SourceQuality.SUPPLEMENTAL,
+    )
+    validated = _event(
+        source="validated_feed",
+        evidence_id="validated-1",
+        source_quality=SourceQuality.VALIDATED,
+    )
+
+    decision = _evaluate(supplemental, validated)
+
+    assert len(decision.evaluated_items) == 1
+    assert decision.recommended_action is RecommendedAction.RUN_TRANSITION_ANALYSIS
+    assert [(ref.source, ref.evidence_id) for ref in decision.evaluated_items[0].evidence_refs] == [
+        ("validated_feed", "validated-1"),
+        ("wire", "supplemental-1"),
+    ]
+    assert decision.evaluated_items[0].semantic_hash == semantic_hash(validated)
+
+
+def test_same_batch_validated_and_official_event_aggregates_at_official_stage() -> None:
+    validated = _event(
+        source="validated_feed",
+        evidence_id="validated-1",
+        source_quality=SourceQuality.VALIDATED,
+    )
+    official = _event(
+        source="federal_reserve",
+        evidence_id="official-1",
+        source_quality=SourceQuality.OFFICIAL,
+    )
+
+    decision = _evaluate(validated, official)
+
+    assert len(decision.evaluated_items) == 1
+    assert decision.recommended_action is RecommendedAction.RUN_TRANSITION_ANALYSIS
+    assert decision.evaluated_items[0].semantic_hash == semantic_hash(official)
+
+
+def test_same_material_event_cluster_with_different_claims_requires_manual_review() -> None:
+    decision = _evaluate(
+        _event(claim="Federal Reserve changes its policy stance"),
+        _event(evidence_id="event-2", claim="Federal Reserve holds its policy stance"),
+    )
+
+    assert decision.recommended_action is RecommendedAction.MANUAL_REVIEW
+    assert all(item.reasons == ["semantic_identity:conflicting_payload"] for item in decision.evaluated_items)
 
 
 def test_same_semantic_identity_with_conflicting_payloads_fails_closed() -> None:

--- a/tests/api/test_analysis_memory_api.py
+++ b/tests/api/test_analysis_memory_api.py
@@ -559,7 +559,20 @@ def test_context_bundle_metadata_is_validated_paginated_and_payload_free(
                 "evidence_id": "market-71",
                 "business_time": NOW,
                 "ingested_at": NOW,
-                "payload": {"price": 4100},
+                # Minimal typed payload conforming to the published #76 EvidenceDelta
+                # contract (validated key_level_event) so the v3 bundle can evaluate
+                # and retain it.
+                "payload": {
+                    "evidence_type": "key_level_event",
+                    "asset": "XAUUSD",
+                    "source_quality": "validated",
+                    "level_id": "support-4000",
+                    "level_role": "support",
+                    "level_value": 4000,
+                    "observed_value": 4100,
+                    "event": "confirmed_break",
+                    "confirmation_status": "confirmed",
+                },
                 "source_ref": {"source": "market", "snapshot_id": "market-71"},
             }
         ],
@@ -733,6 +746,18 @@ def test_legacy_bundle_is_only_observable_as_daily_close(
     payload = bundle.model_dump(mode="json")
     payload["schema_version"] = "analysis_context_bundle.v1"
     payload.pop("state_scope")
+    # v1 legacy bundles must not carry v3-only selection fields, so drop them
+    # before hashing/writing so the loader accepts the downcast payload.
+    for field in (
+        "evidence_delta_decision",
+        "deferred_queue",
+        "processed_above_frontier",
+        "selection_decisions",
+        "selection_trace",
+        "freshness_sla_seconds",
+        "default_freshness_sla_seconds",
+    ):
+        payload.pop(field, None)
     payload["content_hash"] = compute_bundle_content_hash(payload)
     payload["bundle_id"] = str(
         uuid.uuid5(

--- a/tests/architecture/test_analysis_memory_ci_guards.py
+++ b/tests/architecture/test_analysis_memory_ci_guards.py
@@ -11,6 +11,7 @@ def test_ci_runs_analysis_memory_focused_and_postgres_suites() -> None:
     focused_suites = {
         "tests/database/test_analysis_state_core.py",
         "tests/analysis/test_context_bundle.py",
+        "tests/analysis/test_context_bundle_selection.py",
         "tests/analysis/test_evidence_delta_evaluator.py",
         "tests/analysis/test_state_materializer.py",
         "tests/analysis/test_figure_facts.py",

--- a/tests/output/test_context_bundle_artifacts.py
+++ b/tests/output/test_context_bundle_artifacts.py
@@ -20,6 +20,15 @@ from apps.output.context_bundle import (
 
 
 NOW = datetime(2026, 7, 22, 8, tzinfo=UTC)
+V3_FIELDS = {
+    "evidence_delta_decision",
+    "deferred_queue",
+    "processed_above_frontier",
+    "selection_decisions",
+    "selection_trace",
+    "freshness_sla_seconds",
+    "default_freshness_sla_seconds",
+}
 
 
 def _bundle(state_scope="daily_close"):
@@ -39,7 +48,15 @@ def _bundle(state_scope="daily_close"):
                 "evidence_id": "market-2",
                 "business_time": NOW,
                 "ingested_at": NOW + timedelta(minutes=1),
-                "payload": {"price": 4050},
+                "payload": {
+                    "evidence_type": "macro_metric",
+                    "asset": "XAUUSD",
+                    "source_quality": "official",
+                    "metric": "dxy",
+                    "current_value": 99.8,
+                    "previous_value": 100.0,
+                    "unit": "index",
+                },
                 "source_ref": {"snapshot_id": "market-2"},
             }
         ],
@@ -102,6 +119,8 @@ def test_loader_reads_legacy_v1_as_daily_close_but_writer_rejects_it(tmp_path) -
     payload = _bundle().model_dump(mode="json")
     payload["schema_version"] = "analysis_context_bundle.v1"
     payload.pop("state_scope")
+    for field in V3_FIELDS:
+        payload.pop(field)
     payload["content_hash"] = compute_bundle_content_hash(payload)
     payload["bundle_id"] = str(
         uuid.uuid5(
@@ -128,8 +147,59 @@ def test_loader_reads_legacy_v1_as_daily_close_but_writer_rejects_it(tmp_path) -
 
     assert loaded.schema_version == "analysis_context_bundle.v1"
     assert loaded.state_scope is None
-    with pytest.raises(ValueError, match="only persists scoped v2"):
+    with pytest.raises(ValueError, match="only persists scoped v3"):
         write_context_bundle(storage_root=tmp_path, bundle=loaded)
+
+
+def test_loader_preserves_scoped_v2_identity_but_writer_rejects_it(tmp_path) -> None:
+    payload = _bundle().model_dump(mode="json")
+    payload["schema_version"] = "analysis_context_bundle.v2"
+    for field in V3_FIELDS:
+        payload.pop(field)
+    payload["content_hash"] = compute_bundle_content_hash(payload)
+    payload["bundle_id"] = str(
+        uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"finance-agent:context-bundle:{payload['content_hash']}",
+        )
+    )
+    path = (
+        tmp_path
+        / "outputs"
+        / "context_bundles"
+        / "XAUUSD"
+        / "daily_close"
+        / "run-67"
+        / f"{payload['bundle_id']}.json"
+    )
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = load_context_bundle(
+        storage_root=tmp_path,
+        storage_relative_path=path.relative_to(tmp_path).as_posix(),
+    )
+
+    assert loaded.schema_version == "analysis_context_bundle.v2"
+    assert loaded.content_hash == payload["content_hash"]
+    assert loaded.bundle_id == payload["bundle_id"]
+    with pytest.raises(ValueError, match="only persists scoped v3"):
+        write_context_bundle(storage_root=tmp_path, bundle=loaded)
+
+
+def test_v2_rejects_unhashed_v3_selection_payload() -> None:
+    payload = _bundle().model_dump(mode="json")
+    payload["schema_version"] = "analysis_context_bundle.v2"
+    payload["content_hash"] = compute_bundle_content_hash(payload)
+    payload["bundle_id"] = str(
+        uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            f"finance-agent:context-bundle:{payload['content_hash']}",
+        )
+    )
+
+    with pytest.raises(ValidationError, match="must not carry v3 selection fields"):
+        AnalysisContextBundle.model_validate(payload)
 
 
 def test_writer_path_isolated_by_scope_for_same_asset_and_run(tmp_path) -> None:

--- a/tests/worker/test_composite_state_shadow.py
+++ b/tests/worker/test_composite_state_shadow.py
@@ -37,8 +37,22 @@ def _state() -> dict:
 
 
 def _evidence(*, provider_metadata: bool = False) -> dict:
-    payload = {"price": 4050}
+    # Minimal typed payload conforming to the published #76 EvidenceDelta contract
+    # (validated key_level_event) so the v3 bundle can evaluate and retain it.
+    payload = {
+        "evidence_type": "key_level_event",
+        "asset": "XAUUSD",
+        "source_quality": "validated",
+        "level_id": "support-4000",
+        "level_role": "support",
+        "level_value": 4000,
+        "observed_value": 4050,
+        "event": "confirmed_break",
+        "confirmation_status": "confirmed",
+    }
     if provider_metadata:
+        # Transport metadata must be stripped by the assembler so it never
+        # influences bundle identity or content hash.
         payload.update({"provider": "jojocode", "conversation_id": "thread-1"})
     return {
         "source": "market",

--- a/tests/worker/test_composite_state_shadow.py
+++ b/tests/worker/test_composite_state_shadow.py
@@ -4,14 +4,20 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 from apps.analysis.figure_facts import FigureFact
+from apps.worker.db_persistence import persist_review_items
 from apps.worker.composite_state_shadow import (
+    build_state_delta_setup_failure_review_item,
     execute_composite_state_shadow,
     finalize_composite_state_shadow,
     prepare_composite_state_shadow,
     resolve_analysis_context_mode,
 )
+from database.models.analysis import AnalysisBase
+from database.queries.review import get_review_item
 
 
 NOW = datetime(2026, 7, 22, 8, tzinfo=UTC)
@@ -50,6 +56,7 @@ def _evidence(*, provider_metadata: bool = False) -> dict:
         "event": "confirmed_break",
         "confirmation_status": "confirmed",
     }
+
     if provider_metadata:
         # Transport metadata must be stripped by the assembler so it never
         # influences bundle identity or content hash.
@@ -61,6 +68,25 @@ def _evidence(*, provider_metadata: bool = False) -> dict:
         "ingested_at": NOW + timedelta(minutes=2),
         "session": "asia",
         "payload": payload,
+        "source_ref": REF,
+    }
+
+
+def _macro_evidence(*, current: float, source_quality: str = "validated") -> dict:
+    return {
+        "source": "macro",
+        "evidence_id": f"dxy-{current}",
+        "business_time": NOW + timedelta(minutes=1),
+        "ingested_at": NOW + timedelta(minutes=2),
+        "payload": {
+            "evidence_type": "macro_metric",
+            "asset": "XAUUSD",
+            "source_quality": source_quality,
+            "metric": "dxy",
+            "current_value": current,
+            "previous_value": 100.0,
+            "unit": "index",
+        },
         "source_ref": REF,
     }
 
@@ -165,7 +191,7 @@ def test_shadow_candidate_is_reviewed_and_all_consumers_share_bundle(tmp_path) -
 
     assert trace["status"] == "candidate_accepted_shadow_only"
     assert trace["shadow_review_status"] == "accepted"
-    assert trace["schema_version"] == "composite_state_shadow.v2"
+    assert trace["schema_version"] == "composite_state_shadow.v3"
     assert trace["state_scope"] == "daily_close"
     assert "/daily_close/" in trace["bundle_path"]
     assert trace["transition_diff"][0]["action"] == "strengthen"
@@ -192,6 +218,256 @@ def test_shadow_analyzer_failure_is_contained_as_needs_review(tmp_path) -> None:
     assert trace["status"] == "candidate_rejected"
     assert trace["shadow_review_status"] == "needs_review"
     assert trace["reason"].startswith("RuntimeError:")
+
+
+@pytest.mark.parametrize(
+    ("evidence", "expected_action", "expected_calls"),
+    [
+        ([], "no_op", 0),
+        ([_macro_evidence(current=100.3)], "update_context_only", 0),
+        ([_evidence()], "run_transition_analysis", 1),
+        ([_macro_evidence(current=101.0, source_quality="unverified")], "manual_review", 0),
+    ],
+)
+def test_evidence_delta_action_is_the_only_analyzer_gate(
+    tmp_path, evidence, expected_action, expected_calls
+) -> None:
+    runtime = prepare_composite_state_shadow(
+        storage_root=tmp_path,
+        run_id="run-decision-gate",
+        created_at=NOW,
+        shadow_input=_shadow_input(evidence=evidence),
+    )
+    calls = 0
+
+    def analyzer(bundle):
+        nonlocal calls
+        calls += 1
+        return _candidate(bundle)
+
+    trace = execute_composite_state_shadow(runtime=runtime, analyzer=analyzer)
+
+    assert runtime.evidence_delta_decision.recommended_action.value == expected_action
+    assert trace["evidence_delta_action"] == expected_action
+    assert calls == expected_calls
+    if expected_action == "manual_review":
+        review = trace["review_items"][0]
+        assert review["review_id"] == f"evidence_delta:{trace['evidence_delta_decision_id']}"
+        assert review["run_id"] == "run-decision-gate"
+        assert review["source_module"] == "state_delta_shadow"
+        assert review["source_step_id"] == "evidence_delta_decision"
+        assert review["status"] == "pending"
+
+
+def test_duplicate_evidence_skips_analyzer_from_recovered_semantic_hash(tmp_path) -> None:
+    evidence = _macro_evidence(current=100.3)
+    first = prepare_composite_state_shadow(
+        storage_root=tmp_path,
+        run_id="run-before-duplicate",
+        created_at=NOW,
+        shadow_input=_shadow_input(evidence=[evidence]),
+    )
+    replay_input = _shadow_input(evidence=[evidence])
+    replay_input["previous_semantic_hashes"] = dict(
+        first.evidence_delta_decision.semantic_hashes
+    )
+    replay = prepare_composite_state_shadow(
+        storage_root=tmp_path,
+        run_id="run-duplicate",
+        created_at=NOW,
+        shadow_input=replay_input,
+    )
+    calls = 0
+
+    def analyzer(_bundle):
+        nonlocal calls
+        calls += 1
+        raise AssertionError("duplicate evidence must not invoke analyzer")
+
+    trace = execute_composite_state_shadow(runtime=replay, analyzer=analyzer)
+
+    assert replay.evidence_delta_decision.recommended_action.value == "no_op"
+    assert trace["status"] == "no_material_delta"
+    assert calls == 0
+
+
+def test_accepted_figure_fact_enters_facts_and_evidence_delta_decision(tmp_path) -> None:
+    fact = FigureFact.build(
+        figure_id="fig-accepted",
+        report_id="225145",
+        page_no=1,
+        bbox=[0, 0, 10, 10],
+        asset="XAUUSD",
+        observations=["关键支撑 4000"],
+        numeric_values=[],
+        derived_claims=[],
+        interpretation_limits=[],
+        source_ref={
+            "report_id": "225145",
+            "figure_id": "fig-accepted",
+            "page_no": 1,
+            "bbox": [0, 0, 10, 10],
+        },
+        quality_status="accepted",
+        image_content_hash="b" * 64,
+        created_by_run_id="run-figure",
+    )
+    shadow_input = _shadow_input()
+    shadow_input["figure_facts"] = [fact]
+
+    runtime = prepare_composite_state_shadow(
+        storage_root=tmp_path,
+        run_id="run-accepted-figure",
+        created_at=NOW,
+        shadow_input=shadow_input,
+    )
+
+    facts_block = next(block for block in runtime.bundle.blocks if block.name == "facts")
+    assert facts_block.payload[0]["figure_fact_id"] == fact.figure_fact_id
+    assert [item.evidence_type for item in runtime.evidence_delta_decision.evaluated_items] == [
+        "figure_fact"
+    ]
+    assert runtime.evidence_delta_decision.recommended_action.value == "update_context_only"
+
+
+def test_explicit_prior_bundle_recovers_delta_and_selection_state(tmp_path) -> None:
+    first_input = _shadow_input(evidence=[_macro_evidence(current=100.3)])
+    first_input.update(
+        {
+            "freshness_sla_seconds": {"macro": 123},
+            "default_freshness_sla_seconds": 456,
+        }
+    )
+    first = prepare_composite_state_shadow(
+        storage_root=tmp_path,
+        run_id="run-prior",
+        created_at=NOW,
+        shadow_input=first_input,
+    )
+    next_input = _shadow_input(evidence=[_macro_evidence(current=100.3)])
+    next_input["previous_bundle_path"] = first.artifact.storage_relative_path
+
+    replay = prepare_composite_state_shadow(
+        storage_root=tmp_path,
+        run_id="run-replay",
+        created_at=NOW + timedelta(hours=1),
+        shadow_input=next_input,
+    )
+
+    assert replay.bundle.freshness_sla_seconds == {"macro": 123}
+    assert replay.bundle.default_freshness_sla_seconds == 456
+    assert replay.evidence_delta_decision.recommended_action.value == "no_op"
+    assert replay.bundle.deferred_queue == first.bundle.deferred_queue
+    assert replay.bundle.processed_above_frontier == first.bundle.processed_above_frontier
+
+
+@pytest.mark.parametrize("field, value", [("asset", "EURUSD"), ("state_scope", "intraday")])
+def test_prior_bundle_identity_mismatch_fails_closed(tmp_path, field, value) -> None:
+    first = prepare_composite_state_shadow(
+        storage_root=tmp_path,
+        run_id="run-prior",
+        created_at=NOW,
+        shadow_input=_shadow_input(evidence=[_macro_evidence(current=100.3)]),
+    )
+    replay_input = _shadow_input(evidence=[_macro_evidence(current=100.3)])
+    replay_input["previous_bundle_path"] = first.artifact.storage_relative_path
+    if field == "asset":
+        replay_input["canonical_state"] = {**_state(), "asset": value}
+    else:
+        replay_input[field] = value
+
+    with pytest.raises(ValueError, match="previous context bundle identity|daily_close"):
+        prepare_composite_state_shadow(
+            storage_root=tmp_path,
+            run_id="run-replay",
+            created_at=NOW,
+            shadow_input=replay_input,
+        )
+
+
+def test_prior_bundle_hash_and_ambiguous_recovery_fail_closed(tmp_path) -> None:
+    first = prepare_composite_state_shadow(
+        storage_root=tmp_path,
+        run_id="run-prior",
+        created_at=NOW,
+        shadow_input=_shadow_input(evidence=[_macro_evidence(current=100.3)]),
+    )
+    artifact = tmp_path / first.artifact.storage_relative_path
+    artifact.write_text(artifact.read_text(encoding="utf-8").replace("XAUUSD", "XAUUSZ", 1), encoding="utf-8")
+    replay_input = _shadow_input(evidence=[_macro_evidence(current=100.3)])
+    replay_input["previous_bundle_path"] = first.artifact.storage_relative_path
+    with pytest.raises(Exception, match="context bundle"):
+        prepare_composite_state_shadow(
+            storage_root=tmp_path,
+            run_id="run-replay",
+            created_at=NOW,
+            shadow_input=replay_input,
+        )
+
+    replay_input.pop("previous_bundle_path")
+    replay_input["previous_semantic_hashes"] = {}
+    replay_input["previous_bundle_path"] = first.artifact.storage_relative_path
+    with pytest.raises(ValueError, match="cannot be combined"):
+        prepare_composite_state_shadow(
+            storage_root=tmp_path,
+            run_id="run-ambiguous",
+            created_at=NOW,
+            shadow_input=replay_input,
+        )
+
+
+def test_manual_review_trace_persists_through_worker_boundary(tmp_path) -> None:
+    runtime = prepare_composite_state_shadow(
+        storage_root=tmp_path,
+        run_id="run-review-persistence",
+        created_at=NOW,
+        shadow_input=_shadow_input(
+            evidence=[_macro_evidence(current=101.0, source_quality="unverified")]
+        ),
+    )
+    review = execute_composite_state_shadow(runtime=runtime, analyzer=None)["review_items"][0]
+    engine = create_engine(f"sqlite:///{tmp_path / 'review-items.db'}")
+    AnalysisBase.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+    try:
+        persist_review_items(db, [review])
+        persisted = get_review_item(db, review["review_id"])
+        assert persisted is not None
+        assert persisted.run_id == "run-review-persistence"
+        assert persisted.source_module == "state_delta_shadow"
+        assert persisted.source_step_id == "evidence_delta_decision"
+        assert persisted.status == "pending"
+        assert persisted.evidence_refs == review["evidence_refs"]
+    finally:
+        db.close()
+
+
+def test_setup_failure_review_item_is_stable_and_persistable(tmp_path) -> None:
+    review = build_state_delta_setup_failure_review_item(
+        run_id="run-setup-failure",
+        failure_kind="ValueError",
+    )
+    replay = build_state_delta_setup_failure_review_item(
+        run_id="run-setup-failure",
+        failure_kind="ValueError",
+    )
+
+    assert replay["review_id"] == review["review_id"]
+    assert review["source_step_id"] == "state_delta_shadow_setup"
+    assert review["evidence_refs"] == []
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'setup-review-items.db'}")
+    AnalysisBase.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+    try:
+        persist_review_items(db, [review])
+        persisted = get_review_item(db, review["review_id"])
+        assert persisted is not None
+        assert persisted.run_id == "run-setup-failure"
+        assert persisted.source_step_id == "state_delta_shadow_setup"
+    finally:
+        db.close()
+        engine.dispose()
 
 
 def test_unaccepted_figure_fact_cannot_create_material_delta(tmp_path) -> None:

--- a/tests/worker/test_premarket_composite_output_integration.py
+++ b/tests/worker/test_premarket_composite_output_integration.py
@@ -181,7 +181,20 @@ def test_composite_state_delta_shadow_shares_one_bundle_without_canonical_write(
                 "evidence_id": "market-shadow-2",
                 "business_time": (_CREATED_AT - timedelta(minutes=2)).isoformat(),
                 "ingested_at": (_CREATED_AT - timedelta(minutes=1)).isoformat(),
-                "payload": {"price": 3350},
+                # Minimal typed payload conforming to the published #76 EvidenceDelta
+                # contract (validated key_level_event) so the v3 bundle can evaluate
+                # and retain it for the shadow analyzer.
+                "payload": {
+                    "evidence_type": "key_level_event",
+                    "asset": "XAUUSD",
+                    "source_quality": "validated",
+                    "level_id": "support-3300",
+                    "level_role": "support",
+                    "level_value": 3300,
+                    "observed_value": 3350,
+                    "event": "confirmed_break",
+                    "confirmation_status": "confirmed",
+                },
                 "source_ref": evidence_ref,
             }
         ],

--- a/tests/worker/test_premarket_composite_output_integration.py
+++ b/tests/worker/test_premarket_composite_output_integration.py
@@ -262,6 +262,77 @@ def test_composite_state_delta_shadow_shares_one_bundle_without_canonical_write(
     assert (tmp_path / shadow["bundle_path"]).is_file()
 
 
+def test_composite_manual_review_keeps_review_item_and_skips_transition_analyzer(
+    tmp_path: Path,
+) -> None:
+    from apps.worker.runner import _run_composite_analysis_pipeline
+
+    run_id = "run-state-delta-manual-review"
+    calls = 0
+    shadow_input = {
+        "state_scope": "daily_close",
+        "canonical_state_id": "state-shadow-root",
+        "canonical_state": {
+            "asset": "XAUUSD",
+            "as_of": (_CREATED_AT - timedelta(hours=1)).isoformat(),
+            "market_stage": "direction_decision",
+            "core_thesis": "等待宏观确认",
+            "net_bias": "mixed_bullish",
+            "dominant_drivers": [],
+            "key_levels": [{"price": 3300, "role": "support"}],
+            "scenario_states": [],
+            "unresolved_items": [],
+            "invalidation_conditions": [],
+            "evidence_cursors": {},
+            "input_snapshot_ids": {"market": "market-shadow-1"},
+            "source_refs": [{"snapshot_id": "market-shadow-1"}],
+        },
+        "evidence": [
+            {
+                "source": "unverified_macro",
+                "evidence_id": "dxy-unverified-material",
+                "business_time": (_CREATED_AT - timedelta(minutes=2)).isoformat(),
+                "ingested_at": (_CREATED_AT - timedelta(minutes=1)).isoformat(),
+                "payload": {
+                    "evidence_type": "macro_metric",
+                    "asset": "XAUUSD",
+                    "source_quality": "unverified",
+                    "metric": "dxy",
+                    "current_value": 101.0,
+                    "previous_value": 100.0,
+                    "unit": "index",
+                },
+                "source_ref": {"snapshot_id": "macro-shadow-unverified"},
+            }
+        ],
+        "evidence_cursors": {},
+        "cutoff_at": _CREATED_AT.isoformat(),
+        "assembled_at": _CREATED_AT.isoformat(),
+    }
+
+    def analyzer(_bundle):
+        nonlocal calls
+        calls += 1
+        raise AssertionError("manual review must skip transition analyzer")
+
+    _summaries, outputs = _run_composite_analysis_pipeline(
+        storage_root=tmp_path,
+        snapshot=_make_rich_snapshot(run_id=run_id),
+        run_id=run_id,
+        created_at=_CREATED_AT,
+        analysis_context_mode="state_delta_context",
+        state_shadow_input=shadow_input,
+        state_delta_analyzer=analyzer,
+    )
+
+    shadow = outputs["state_delta_shadow"]
+    assert calls == 0
+    assert shadow["schema_version"] == "composite_state_shadow.v3"
+    assert shadow["status"] == "manual_review_required"
+    assert shadow["evidence_delta_action"] == "manual_review"
+    assert shadow["review_items"][0]["run_id"] == run_id
+
+
 def test_composite_shadow_setup_failure_does_not_break_legacy_outputs(tmp_path: Path) -> None:
     from apps.worker.runner import _run_composite_analysis_pipeline
 
@@ -277,9 +348,36 @@ def test_composite_shadow_setup_failure_does_not_break_legacy_outputs(tmp_path: 
     assert summaries["final_report"]["status"] == "success"
     assert outputs["report_result"]["paths"]
     assert outputs["state_delta_shadow"]["status"] == "shadow_setup_failed"
+    assert outputs["state_delta_shadow"]["schema_version"] == "composite_state_shadow.v3"
+    assert outputs["state_delta_shadow"]["evidence_delta_action"] == "manual_review"
     assert outputs["state_delta_shadow"]["requested_state_scope"] is None
     assert "must-not-enter-trace" not in str(outputs["state_delta_shadow"])
     assert outputs["state_delta_shadow"]["production_canonical_write_allowed"] is False
+    review = outputs["state_delta_shadow"]["review_items"][0]
+    assert review == {
+        "review_id": "state_delta_setup:run-shadow-setup-failure:"
+        "78a572444077af19",
+        "run_id": "run-shadow-setup-failure",
+        "source_module": "state_delta_shadow",
+        "source_step_id": "state_delta_shadow_setup",
+        "severity": "error",
+        "reason": "State-delta shadow setup failed: ValueError",
+        "impact_modules": ["analysis_state", "state_delta_shadow"],
+        "suggested_action": "Review the trusted state-delta setup inputs before retrying shadow analysis.",
+        "status": "pending",
+        "evidence_refs": [],
+    }
+    assert "must-not-enter-trace" not in str(review)
+
+    _, replay_outputs = _run_composite_analysis_pipeline(
+        storage_root=tmp_path,
+        snapshot=_make_rich_snapshot(run_id="run-shadow-setup-failure"),
+        run_id="run-shadow-setup-failure",
+        created_at=_CREATED_AT,
+        analysis_context_mode="state_delta_context",
+        state_shadow_input={"state_scope": {"untrusted": "must-not-enter-trace"}},
+    )
+    assert replay_outputs["state_delta_shadow"]["review_items"][0]["review_id"] == review["review_id"]
 
 
 def test_composite_source_health_uses_completed_snapshot_over_preliminary_news_health() -> None:


### PR DESCRIPTION
## Summary
- add deterministic materiality-aware evidence selection with mandatory critical retention, deferred queue, and contiguous cursor frontier tracking
- integrate ContextBundle v3 with EvidenceDelta decisions, pre-trim freshness/session/alignment, source-specific SLA, scoped identity, and v1/v2 read compatibility
- align existing success fixtures with the typed evidence contract while retaining fail-closed invalid-input coverage
- register the selector regression suite in required Analysis Memory CI

## Verification
- full affected Analysis Memory and worker regression: 196 passed
- Trae CLI focused selector, bundle, evidence delta, output, API, worker, and architecture suites: passed
- Ruff, CI YAML parse, git diff --check: passed

Closes #77