### PR TITLE
feat: add canonical daily context contract

### DIFF
--- a/apps/analysis/jin10/agent_analysis.py
+++ b/apps/analysis/jin10/agent_analysis.py
@@ -3,11 +3,21 @@ from __future__ import annotations
 import json
 import os
 import re
+from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
 from apps.analysis.jin10.agent_prompt_profiles import typed_report_prompt_spec
-from apps.analysis.jin10.daily_context import compact_context_for_prompt, compact_context_metadata
+from apps.analysis.context_bundle.schemas import AnalysisContextBundle
+from apps.analysis.jin10.daily_context import (
+    LEGACY_FULL_CONTEXT,
+    STATE_DELTA_CONTEXT,
+    StateDeltaContextError,
+    compact_context_for_prompt,
+    compact_context_metadata,
+    normalize_analysis_context_mode,
+    project_context_bundle_for_prompt,
+)
 from apps.analysis.jin10.multimodal import ImageLoader, build_multimodal_user_content
 from apps.analysis.jin10.prompt_budget import (
     PromptBudgetExceeded,
@@ -46,6 +56,8 @@ def build_agent_analysis_prompt(
     *,
     previous_daily_analysis: dict[str, Any] | None = None,
     analysis_context: dict[str, Any] | None = None,
+    context_mode: str = LEGACY_FULL_CONTEXT,
+    analysis_context_bundle: AnalysisContextBundle | dict[str, Any] | None = None,
     market_odds_evidence: dict[str, Any] | None = None,
 ) -> str:
     """Build the report-specific prompt plus the canonical JSON contract."""
@@ -55,6 +67,8 @@ def build_agent_analysis_prompt(
         daily_report,
         previous_daily_analysis=previous_daily_analysis,
         analysis_context=analysis_context,
+        context_mode=context_mode,
+        analysis_context_bundle=analysis_context_bundle,
         market_odds_evidence=market_odds_evidence,
     )
     return prompt
@@ -66,6 +80,8 @@ def build_agent_analysis_prompt_with_trace(
     *,
     previous_daily_analysis: dict[str, Any] | None = None,
     analysis_context: dict[str, Any] | None = None,
+    context_mode: str = LEGACY_FULL_CONTEXT,
+    analysis_context_bundle: AnalysisContextBundle | dict[str, Any] | None = None,
     market_odds_evidence: dict[str, Any] | None = None,
 ) -> tuple[str, dict[str, Any]]:
     """Build a bounded prompt and its deterministic per-block budget trace."""
@@ -76,6 +92,8 @@ def build_agent_analysis_prompt_with_trace(
         daily_report,
         previous_daily_analysis=previous_daily_analysis,
         analysis_context=analysis_context,
+        context_mode=context_mode,
+        analysis_context_bundle=analysis_context_bundle,
         market_odds_evidence=market_odds_evidence,
         _trim_reasons=trim_reasons,
     )
@@ -91,12 +109,32 @@ def _build_agent_analysis_prompt_body(
     *,
     previous_daily_analysis: dict[str, Any] | None = None,
     analysis_context: dict[str, Any] | None = None,
+    context_mode: str = LEGACY_FULL_CONTEXT,
+    analysis_context_bundle: AnalysisContextBundle | dict[str, Any] | None = None,
     market_odds_evidence: dict[str, Any] | None = None,
     _trim_reasons: dict[str, list[str]] | None = None,
 ) -> str:
     """Build the future LLM prompt for Jin10 raw-report post analysis."""
 
     trim_reasons = _trim_reasons if _trim_reasons is not None else {}
+    resolved_context_mode = normalize_analysis_context_mode(context_mode)
+    prompt_profile = _agent_analysis_prompt_profile(raw_report=raw_report, daily_report=daily_report)
+    if resolved_context_mode == STATE_DELTA_CONTEXT:
+        if prompt_profile != "default_daily":
+            raise StateDeltaContextError(
+                "state_delta_context is only supported by the default_daily prompt profile"
+            )
+        state_delta_context = project_context_bundle_for_prompt(analysis_context_bundle)
+        action = (state_delta_context["evidence_delta_decision"] or {}).get("recommended_action")
+        if action != "run_transition_analysis":
+            raise StateDeltaContextError(
+                "state_delta_context requires run_transition_analysis action: " + str(action or "invalid")
+            )
+        return _build_state_delta_daily_prompt(
+            state_delta_context=state_delta_context,
+            trim_reasons=trim_reasons,
+        )
+
     daily_block = (
         _compact_daily_summary(daily_report, trim_reasons=trim_reasons)
         if daily_report
@@ -201,7 +239,6 @@ def _build_agent_analysis_prompt_body(
             chart_mode_note=chart_mode_note,
             market_odds_evidence=market_odds_evidence,
         )
-    prompt_profile = _agent_analysis_prompt_profile(raw_report=raw_report, daily_report=daily_report)
     if prompt_profile != "default_daily":
         return _build_typed_report_analysis_prompt(
             prompt_profile=prompt_profile,
@@ -359,6 +396,53 @@ chart_render_mode: {chart_render_mode}
 - 如果提供了 `analysis_baseline`，开头必须先概括该基准来自周报还是前一日最终综合分析报告，再说明当日证据对它执行了哪种变化动作；前序与当日价位冲突时优先解释时间尺度和数据日期，不得静默覆盖。
 - 传导链、黄金路径、白银路径可以由模型自行组织，不必机械套模板。
 - 不要出现“当前会话形成的核心判断脉络”“当前会话形成的关键位体系”这类会话内元表述。
+
+请按下方结构化输出契约返回分析结果。"""
+
+
+def _build_state_delta_daily_prompt(
+    *,
+    state_delta_context: dict[str, Any],
+    trim_reasons: dict[str, list[str]],
+) -> str:
+    """Build the explicit Bundle-backed daily prompt without legacy memory."""
+
+    trim_reasons.setdefault("analysis_memory_bundle_v3", []).append(
+        "projected_from_validated_context_bundle_v3"
+    )
+    trim_reasons.setdefault("instructions", []).append(
+        "state_delta_context_excludes_legacy_report_memory"
+    )
+    context_block = _prompt_json(state_delta_context)
+    bundle_meta = state_delta_context["bundle"]
+    return f"""你是一名专业的宏观市场与贵金属分析 Agent，默认使用简体中文。
+
+任务：基于唯一的 AnalysisContextBundle v3，对 canonical AnalysisState 执行当日增量分析。只消费 Bundle 已保留的 delta evidence 和 accepted facts；不得寻找、消费或假设任何 Bundle 之外的报告正文、图表、历史分析或当前运行材料。
+
+本次分析身份：
+- canonical_state_id: {bundle_meta["canonical_state_id"]}
+- state_scope: {bundle_meta["state_scope"]}
+- bundle_id: {bundle_meta["bundle_id"]}
+- content_hash: {bundle_meta["content_hash"]}
+
+硬性规则：
+1. 不主动联网，不引入输入材料之外的实时行情或历史数据。
+2. canonical_state 是唯一分析记忆；只允许用 retained_delta_evidence 和 accepted_facts 强化、维持、削弱、失效或待确认其中的判断。
+3. `evidence_delta_decision.recommended_action` 是本次更新动作权限；若为 no_op 或 update_context_only，不得虚构状态变化；若为 manual_review，只能输出待人工确认结论。
+4. selection trace 中 deferred/rejected 的 Evidence 不在本次可用证据集内，不得引用或推断其内容。
+5. accepted_facts 之外的图表事实不得进入确认层；Bundle 未保留的图表或报告内容不得引用。
+6. 必须区分 retained evidence、accepted fact、Agent 推论和尚未确认部分；不得把 Bundle 外观点或事实包装成已确认信息。
+7. 关键位只能来自 canonical_state、retained delta evidence 或 accepted facts，并明确来源与时效。
+8. 不给确定性预测；每条路径必须包含触发、失效和风险。
+9. 期权成交量不能替代 OI，COT 不能确认日内突破；实际利率、名义利率、美元与期限利差缺失时必须逐项标记未确认。
+10. 最大痛点只能作为动态参考锚；远期模型目标不得直接进入短线交易路径。
+11. 一句话结论先说明 canonical 判断、本次 material delta 和 EvidenceDelta action，再说明仍缺哪些确认。
+12. 最终响应只返回末尾 JSON schema 对象，不输出 Markdown、YAML 或额外说明。
+
+推荐分析结构语义：一句话结论；最新判断变化；行情回顾；黄金传导链；短中长期判断；确认矩阵；关键位；三条路径；分角色等待/失效条件；最终综合判断。
+
+=== analysis_memory_bundle_v3 ===
+{context_block}
 
 请按下方结构化输出契约返回分析结果。"""
 
@@ -1753,12 +1837,60 @@ def load_previous_jin10_agent_analysis(
 # ── LLM-powered analysis ──────────────────────────────────────────
 
 
+def _state_delta_lineage(projection: dict[str, Any]) -> dict[str, Any]:
+    """Return the stable Bundle lineage carried by state-delta audit records."""
+
+    bundle = projection["bundle"]
+    decision = projection["evidence_delta_decision"] or {}
+    return {
+        "context_bundle_id": bundle["bundle_id"],
+        "context_bundle_hash": bundle["content_hash"],
+        "canonical_state_id": bundle["canonical_state_id"],
+        "state_scope": bundle["state_scope"],
+        "retained_evidence_ids": projection["retained_evidence_ids"],
+        "retained_evidence_refs": projection["retained_evidence_refs"],
+        "evidence_delta_decision_id": decision.get("decision_id"),
+        "evidence_delta_action": decision.get("recommended_action"),
+    }
+
+
+def _state_delta_scaffold(raw: dict[str, Any], projection: dict[str, Any]) -> dict[str, Any]:
+    """Minimal deterministic envelope permitted before a state-delta model call."""
+
+    bundle = projection["bundle"]
+    return {
+        "document_id": str(raw.get("document_id") or ""),
+        "trade_date": str(raw.get("trade_date") or ""),
+        "run_id": str(raw.get("run_id") or raw.get("article_id") or bundle["run_id"]),
+        "article_id": str(raw.get("article_id") or ""),
+        "asset": bundle["asset"],
+        "family": "analysis_context_bundle",
+    }
+
+
+def _state_delta_source_refs(projection: dict[str, Any]) -> tuple[list[str], list[dict[str, Any]]]:
+    bundle = projection["bundle"]
+    descriptor = {
+        "artifact_id": bundle["bundle_id"],
+        "artifact_type": "analysis_context_bundle",
+        "content_hash": bundle["content_hash"],
+        "canonical_state_id": bundle["canonical_state_id"],
+        "state_scope": bundle["state_scope"],
+    }
+    return (
+        [f"analysis_context_bundle:{bundle['bundle_id']}"],
+        [descriptor, *[dict(item) for item in projection["retained_evidence_refs"]]],
+    )
+
+
 def build_jin10_agent_analysis_report_with_llm(
     raw_report: Jin10RawArticleReport | dict[str, Any],
     daily_report: Jin10DailyAnalysisReport | dict[str, Any] | None = None,
     *,
     figure_image_loader: ImageLoader | None = None,
     analysis_context: dict[str, Any] | None = None,
+    context_mode: str = LEGACY_FULL_CONTEXT,
+    analysis_context_bundle: AnalysisContextBundle | dict[str, Any] | None = None,
     market_odds_evidence: dict[str, Any] | None = None,
 ) -> Jin10AgentAnalysisReport:
     """Build Jin10 analysis from a validated JSON response, with explicit fallback."""
@@ -1766,11 +1898,51 @@ def build_jin10_agent_analysis_report_with_llm(
 
     raw = _to_dict(raw_report)
     daily = _to_dict(daily_report) if daily_report is not None else {}
-    fallback = build_jin10_agent_analysis_report(raw_report, daily_report)
     prompt_version = agent_analysis_prompt_version(raw, daily)
     llm_config = _agent_llm_config()
     prompt_profile = _agent_analysis_prompt_profile(raw_report=raw, daily_report=daily)
-    effective_context = analysis_context if prompt_profile == "default_daily" else None
+    resolved_context_mode = normalize_analysis_context_mode(context_mode)
+    state_delta_projection = None
+    if resolved_context_mode == STATE_DELTA_CONTEXT:
+        if prompt_profile != "default_daily":
+            raise StateDeltaContextError(
+                "state_delta_context is only supported by the default_daily prompt profile"
+            )
+        state_delta_projection = project_context_bundle_for_prompt(analysis_context_bundle)
+        state_delta_lineage = _state_delta_lineage(state_delta_projection)
+        if state_delta_lineage["evidence_delta_action"] != "run_transition_analysis":
+            raise StateDeltaContextError(
+                "state_delta_context requires run_transition_analysis action: "
+                + str(state_delta_lineage["evidence_delta_action"] or "invalid")
+            )
+        fallback = build_jin10_agent_analysis_report(
+            _state_delta_scaffold(raw, state_delta_projection),
+            {},
+        )
+        bundle_artifacts, bundle_refs = _state_delta_source_refs(state_delta_projection)
+        fallback.source_artifact_refs = bundle_artifacts
+        fallback.source_refs = bundle_refs
+        fallback.provenance = ["分析记忆来自单一、不可变的 AnalysisContextBundle v3。"]
+        fallback.evidence_basis = {
+            "analysis_memory": {
+                **state_delta_lineage,
+                "accepted_fact_ids": [
+                    str(item.get("figure_fact_id"))
+                    for item in state_delta_projection["accepted_facts"]
+                    if item.get("figure_fact_id")
+                ],
+            }
+        }
+        fallback.generated_from = {
+            "source": "jin10_agent_analysis_state_delta_scaffold",
+            "context_mode": STATE_DELTA_CONTEXT,
+            "analysis_context_bundle": dict(state_delta_projection["bundle"]),
+            **state_delta_lineage,
+        }
+        effective_context = None
+    else:
+        fallback = build_jin10_agent_analysis_report(raw_report, daily_report)
+        effective_context = analysis_context if prompt_profile == "default_daily" else None
     if effective_context:
         context_metadata = compact_context_metadata(effective_context)
         prompt_context = compact_context_for_prompt(effective_context)
@@ -1810,23 +1982,29 @@ def build_jin10_agent_analysis_report_with_llm(
             raw,
             daily,
             analysis_context=effective_context,
+            context_mode=resolved_context_mode,
+            analysis_context_bundle=analysis_context_bundle,
             market_odds_evidence=market_odds_evidence,
         )
     except PromptBudgetExceeded as exc:
+        if state_delta_projection is not None:
+            raise
         fallback.generated_from["source"] = "jin10_agent_analysis_fallback_prompt_budget_exceeded"
         fallback.generated_from["prompt_version"] = prompt_version
         fallback.generated_from["prompt_profile"] = prompt_profile
         fallback.generated_from["model"] = llm_config["model"]
         fallback.generated_from["provider"] = llm_config["provider"]
         fallback.generated_from["prompt_budget"] = exc.trace
+        fallback.generated_from["context_mode"] = resolved_context_mode
         fallback.generated_from["degraded"] = True
         fallback.generated_from["degraded_reason"] = "prompt_budget_exceeded"
         fallback.generated_from["structured_output_validated"] = False
         return fallback
+    prompt_payload_hash = sha256(prompt.encode("utf-8")).hexdigest()
     multimodal_plan = build_multimodal_user_content(
         prompt,
-        raw,
-        image_loader=figure_image_loader,
+        {} if state_delta_projection is not None else raw,
+        image_loader=None if state_delta_projection is not None else figure_image_loader,
         max_images=llm_config["max_images"],
     )
 
@@ -1853,9 +2031,32 @@ def build_jin10_agent_analysis_report_with_llm(
                 "snapshot_id": f"jin10:{fallback.trade_date}:{fallback.run_id}:agent_analysis",
                 "trade_date": fallback.trade_date,
                 "report_id": str(fallback.run_id or fallback.article_id),
+                "context_mode": resolved_context_mode,
+                **(_state_delta_lineage(state_delta_projection) if state_delta_projection else {}),
                 "input_snapshot_ids": {
-                    "raw_report": fallback.source_artifact_refs,
-                    "daily_context": (effective_context or {}).get("input_snapshot_ids") if effective_context else {},
+                    **(
+                        {}
+                        if state_delta_projection
+                        else {"raw_report": fallback.source_artifact_refs}
+                    ),
+                    **(
+                        {"daily_context": (effective_context or {}).get("input_snapshot_ids") or {}}
+                        if effective_context
+                        else {}
+                    ),
+                    **(
+                        {
+                            "analysis_context_bundle": {
+                                "bundle_id": state_delta_projection["bundle"]["bundle_id"],
+                                "content_hash": state_delta_projection["bundle"]["content_hash"],
+                                "canonical_state_id": state_delta_projection["bundle"][
+                                    "canonical_state_id"
+                                ],
+                            }
+                        }
+                        if state_delta_projection
+                        else {}
+                    ),
                 },
             },
         )
@@ -1875,10 +2076,11 @@ def build_jin10_agent_analysis_report_with_llm(
             source_artifact_refs=fallback.source_artifact_refs,
             one_line_conclusion=llm_fields["one_line_conclusion"],
             provenance=fallback.provenance,
-            evidence_basis={
-                **fallback.evidence_basis,
-                **llm_fields["evidence_basis"],
-            },
+            evidence_basis=(
+                fallback.evidence_basis
+                if state_delta_projection is not None
+                else {**fallback.evidence_basis, **llm_fields["evidence_basis"]}
+            ),
             market_stage=llm_fields["market_stage"],
             logic_chain=llm_fields["logic_chain"],
             key_variables=llm_fields["key_variables"],
@@ -1908,12 +2110,30 @@ def build_jin10_agent_analysis_report_with_llm(
                 "degraded": degraded,
                 "degraded_reason": ";".join(multimodal_plan.degraded_reasons) if degraded else None,
                 "figure_results": figure_results,
-                "raw_report_family": fallback.generated_from.get("raw_report_family") or raw.get("family"),
-                "daily_report_family": fallback.generated_from.get("daily_report_family") or daily.get("family"),
+                "raw_report_family": (
+                    fallback.generated_from.get("raw_report_family") or raw.get("family")
+                    if state_delta_projection is None
+                    else None
+                ),
+                "daily_report_family": (
+                    fallback.generated_from.get("daily_report_family") or daily.get("family")
+                    if state_delta_projection is None
+                    else None
+                ),
                 "prompt_version": prompt_version,
                 "prompt_profile": prompt_profile,
+                "context_mode": resolved_context_mode,
+                **(_state_delta_lineage(state_delta_projection) if state_delta_projection else {}),
+                "analysis_context_bundle": (
+                    state_delta_projection["bundle"] if state_delta_projection else None
+                ),
+                "prompt_payload_hash": prompt_payload_hash,
                 "prompt_budget": prompt_budget,
-                "daily_context": compact_context_metadata(effective_context),
+                **(
+                    {"daily_context": compact_context_metadata(effective_context)}
+                    if effective_context
+                    else {}
+                ),
                 "prompt_ready": True,
                 "structured_output_validated": True,
                 "llm_structured_output": llm_fields,
@@ -1921,10 +2141,19 @@ def build_jin10_agent_analysis_report_with_llm(
             },
         )
     except Exception as exc:
+        if state_delta_projection is not None:
+            raise StateDeltaContextError(
+                "state_delta_context model failure: " + type(exc).__name__
+            ) from exc
         # Fallback to deterministic analysis
         fallback.generated_from["source"] = "jin10_agent_analysis_fallback_after_llm_error"
         fallback.generated_from["prompt_version"] = prompt_version
         fallback.generated_from["prompt_profile"] = _agent_analysis_prompt_profile(raw_report=raw, daily_report=daily)
+        fallback.generated_from["context_mode"] = resolved_context_mode
+        fallback.generated_from["analysis_context_bundle"] = (
+            state_delta_projection["bundle"] if state_delta_projection else None
+        )
+        fallback.generated_from["prompt_payload_hash"] = prompt_payload_hash
         fallback.generated_from["prompt_budget"] = prompt_budget
         fallback.generated_from["model"] = llm_config["model"]
         fallback.generated_from["provider"] = llm_config["provider"]

--- a/apps/analysis/jin10/daily_context.py
+++ b/apps/analysis/jin10/daily_context.py
@@ -5,6 +5,11 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
+from apps.analysis.context_bundle.schemas import (
+    CONTEXT_BUNDLE_SCHEMA_VERSION,
+    AnalysisContextBundle,
+)
+
 
 KEY_MACRO_SYMBOLS = (
     "US10Y",
@@ -17,6 +22,114 @@ KEY_MACRO_SYMBOLS = (
     "RESERVES",
     "SOFR",
 )
+
+LEGACY_FULL_CONTEXT = "legacy_full_context"
+STATE_DELTA_CONTEXT = "state_delta_context"
+SUPPORTED_ANALYSIS_CONTEXT_MODES = frozenset(
+    {LEGACY_FULL_CONTEXT, STATE_DELTA_CONTEXT}
+)
+
+
+class StateDeltaContextError(ValueError):
+    """Raised when the explicit state-delta prompt input is absent or invalid."""
+
+
+def normalize_analysis_context_mode(value: str | None) -> str:
+    mode = str(value or LEGACY_FULL_CONTEXT).strip()
+    if mode not in SUPPORTED_ANALYSIS_CONTEXT_MODES:
+        raise StateDeltaContextError(f"unsupported analysis context mode: {mode}")
+    return mode
+
+
+def project_context_bundle_for_prompt(
+    bundle: AnalysisContextBundle | dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Project one validated v3 Bundle into provider-independent prompt memory.
+
+    The projection keeps Bundle lineage and decision/selection state intact but
+    intentionally contains no legacy report body or implicit latest lookup.
+    """
+
+    if bundle is None:
+        raise StateDeltaContextError(
+            "state_delta_context requires an explicit AnalysisContextBundle v3"
+        )
+    try:
+        # Revalidate a JSON dump even for typed inputs: Pydantic model_copy and
+        # nested mutable payloads must not bypass the persisted hash contract.
+        payload = bundle.model_dump(mode="json") if isinstance(bundle, AnalysisContextBundle) else bundle
+        validated = AnalysisContextBundle.model_validate(payload)
+    except Exception as exc:
+        raise StateDeltaContextError(
+            f"invalid AnalysisContextBundle: {type(exc).__name__}"
+        ) from exc
+    if validated.schema_version != CONTEXT_BUNDLE_SCHEMA_VERSION:
+        raise StateDeltaContextError(
+            "state_delta_context only accepts AnalysisContextBundle v3"
+        )
+
+    blocks = {block.name: block for block in validated.blocks}
+    if len(validated.blocks) != 3 or set(blocks) != {
+        "canonical_state",
+        "delta_evidence",
+        "facts",
+    }:
+        raise StateDeltaContextError(
+            "AnalysisContextBundle v3 must contain canonical_state, delta_evidence and facts"
+        )
+    delta_block = blocks["delta_evidence"]
+    canonical_state = blocks["canonical_state"].payload
+    if not isinstance(canonical_state, dict):
+        raise StateDeltaContextError("canonical_state block payload must be an object")
+    if (
+        canonical_state.get("asset") != validated.asset
+        or canonical_state.get("state_scope") != validated.state_scope
+    ):
+        raise StateDeltaContextError(
+            "canonical_state block identity does not match AnalysisContextBundle"
+        )
+    retained_refs = [
+        {
+            "source": str(item.get("source") or ""),
+            "evidence_id": str(item.get("evidence_id") or ""),
+        }
+        for item in delta_block.payload
+        if isinstance(item, dict)
+    ]
+    accepted_facts = [
+        dict(item)
+        for item in blocks["facts"].payload
+        if isinstance(item, dict) and item.get("quality_status") == "accepted"
+    ]
+    return {
+        "schema_version": "jin10-state-delta-prompt-context.v1",
+        "context_mode": STATE_DELTA_CONTEXT,
+        "bundle": {
+            "bundle_id": validated.bundle_id,
+            "content_hash": validated.content_hash,
+            "canonical_state_id": validated.canonical_state_id,
+            "state_scope": validated.state_scope,
+            "asset": validated.asset,
+            "run_id": validated.run_id,
+            "cutoff_at": validated.cutoff_at.isoformat(),
+        },
+        "canonical_state": canonical_state,
+        "retained_delta_evidence": delta_block.payload,
+        "retained_evidence_ids": list(delta_block.retained_evidence_ids),
+        "retained_evidence_refs": retained_refs,
+        "accepted_facts": accepted_facts,
+        "evidence_delta_decision": validated.evidence_delta_decision,
+        "selection_trace": validated.selection_trace,
+        "selection_decisions": validated.selection_decisions,
+        "deferred_queue": validated.deferred_queue,
+        "processed_above_frontier": validated.processed_above_frontier,
+        "freshness": validated.freshness,
+        "freshness_sla_seconds": validated.freshness_sla_seconds,
+        "default_freshness_sla_seconds": validated.default_freshness_sla_seconds,
+        "session": validated.session,
+        "alignment": validated.alignment,
+        "bundle_budget_trace": validated.budget_trace.model_dump(mode="json"),
+    }
 
 
 def build_daily_analysis_context(

--- a/tests/analysis/test_jin10_agent_analysis.py
+++ b/tests/analysis/test_jin10_agent_analysis.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
 import json
+import uuid
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
+
+from apps.analysis.context_bundle import assemble_context_bundle
+from apps.analysis.context_bundle.schemas import (
+    _canonical_bytes,
+    _estimate_tokens,
+    compute_bundle_content_hash,
+)
+from apps.analysis.evidence_delta import FigureFactEvidence
 from apps.analysis.jin10.agent_analysis import (
     MISSING,
     _parse_llm_output_to_fields,
@@ -14,6 +25,10 @@ from apps.analysis.jin10.agent_analysis import (
     build_jin10_agent_analysis_report_with_llm,
     parse_agent_analysis_markdown,
     sanitize_agent_analysis_markdown,
+)
+from apps.analysis.jin10.daily_context import (
+    StateDeltaContextError,
+    project_context_bundle_for_prompt,
 )
 from apps.analysis.jin10.daily_report import build_daily_report_analysis_snapshot
 from apps.analysis.jin10.raw_article import build_jin10_raw_article_report, build_raw_article_context
@@ -69,6 +84,75 @@ def _agent_report():
     raw_report = build_jin10_raw_article_report(document)
     daily_report = build_jin10_daily_analysis_report(snapshot)
     return raw_report, daily_report, build_jin10_agent_analysis_report(raw_report, daily_report)
+
+
+def _state_delta_bundle(
+    *,
+    canonical_state: dict | None = None,
+    materiality_score: float = 75,
+    risk_level: str = "high",
+    recompute_eligible: bool = False,
+    include_accepted_fact: bool = True,
+):
+    now = datetime(2026, 7, 22, 8, tzinfo=UTC)
+    fact = FigureFactEvidence(
+        source="figure_fact",
+        evidence_id="figure-fact-1",
+        asset="XAUUSD",
+        observed_at=now,
+        source_quality="validated",
+        source_ref={"artifact_id": "figure-fact-1"},
+        figure_fact_id="figure-fact-1",
+        figure_id="figure-1",
+        report_id="jin10-225144",
+        figure_content_hash="a" * 64,
+        quality_status="accepted",
+        has_direct_evidence=True,
+    )
+    return assemble_context_bundle(
+        run_id="run-state-delta-1",
+        asset="XAUUSD",
+        state_scope="daily_close",
+        canonical_state_id="state-daily-close-1",
+        canonical_state=canonical_state
+        or {
+            "asset": "XAUUSD",
+            "state_scope": "daily_close",
+            "core_thesis": "黄金处于等待实际利率确认的弱修复阶段",
+            "key_levels": [4000, 4126],
+        },
+        evidence=[
+            {
+                "source": "market",
+                "evidence_id": "market-delta-1",
+                "business_time": now,
+                "ingested_at": now + timedelta(minutes=1),
+                "session": "asia",
+                "payload": {
+                    "evidence_type": "material_event",
+                    "asset": "XAUUSD",
+                    "source_quality": "official",
+                    "event_id": "market-delta-1",
+                    "cluster_key": "market-delta-1",
+                    "event_type": "macro_release",
+                    "claim": "实际利率回落但尚未突破确认阈值",
+                    "materiality_score": materiality_score,
+                    "risk_level": risk_level,
+                    "recompute_eligible": recompute_eligible,
+                    "confirmation_status": "confirmed",
+                },
+                "source_ref": {"snapshot_id": "market-delta-1"},
+            }
+        ],
+        evidence_cursors={},
+        cutoff_at=now + timedelta(minutes=2),
+        assembled_at=now + timedelta(minutes=3),
+        facts=[fact.model_dump(mode="json")] if include_accepted_fact else [],
+        delta_facts=[fact] if include_accepted_fact else [],
+        freshness_sla_seconds={"market": 60},
+        default_freshness_sla_seconds=120,
+        expected_session="asia",
+    )
 
 
 def _llm_payload(report) -> dict:
@@ -288,6 +372,117 @@ def test_build_agent_analysis_prompt_marks_compacted_fallback_chart_mode() -> No
 
     assert "chart_render_mode: fallback_compact" in prompt
     assert "当前图表为页图 fallback：仅代表归档页面截图" in prompt
+
+
+def test_state_delta_prompt_uses_only_validated_bundle_memory() -> None:
+    raw_report, daily_report, _ = _agent_report()
+    bundle = _state_delta_bundle(recompute_eligible=True)
+    legacy_context = {
+        "analysis_baseline": {"one_line_conclusion": "不得进入 state delta prompt 的历史日报"},
+        "weekly_anchor": {"one_line_conclusion": "不得进入 state delta prompt 的完整周报"},
+    }
+
+    prompt, trace = build_agent_analysis_prompt_with_trace(
+        raw_report.to_dict(),
+        daily_report.to_dict(),
+        previous_daily_analysis={"final_summary": "不得静默回退的前日报告"},
+        analysis_context=legacy_context,
+        context_mode="state_delta_context",
+        analysis_context_bundle=bundle,
+    )
+
+    assert "=== analysis_memory_bundle_v3 ===" in prompt
+    assert bundle.bundle_id in prompt
+    assert bundle.content_hash in prompt
+    assert bundle.canonical_state_id in prompt
+    assert '"state_scope":"daily_close"' in prompt
+    assert '"retained_evidence_ids":["market-delta-1"]' in prompt
+    assert '"recommended_action":"run_transition_analysis"' in prompt
+    assert '"figure_fact_id":"figure-fact-1"' in prompt
+    assert '"deferred_queue"' in prompt
+    assert '"processed_above_frontier"' in prompt
+    assert '"freshness_sla_seconds":{"market":60}' in prompt
+    assert raw_report.title not in prompt
+    assert raw_report.article_markdown not in prompt
+    assert "不得进入 state delta prompt 的历史日报" not in prompt
+    assert "不得进入 state delta prompt 的完整周报" not in prompt
+    assert "不得静默回退的前日报告" not in prompt
+    assert "=== analysis_baseline ===" not in prompt
+    assert trace["within_budget"] is True
+    assert trace["total"]["estimated_tokens"] <= 15_000
+
+
+def test_state_delta_projection_requires_valid_v3_bundle_and_retains_recovery_state() -> None:
+    bundle = _state_delta_bundle()
+    projection = project_context_bundle_for_prompt(bundle.model_dump(mode="json"))
+
+    assert projection["evidence_delta_decision"] == bundle.evidence_delta_decision
+    assert projection["deferred_queue"] == []
+    assert projection["processed_above_frontier"] == {}
+    assert projection["freshness_sla_seconds"] == bundle.freshness_sla_seconds
+    assert projection["default_freshness_sla_seconds"] == bundle.default_freshness_sla_seconds
+
+    invalid = bundle.model_dump(mode="json")
+    invalid["content_hash"] = "0" * 64
+    with pytest.raises(StateDeltaContextError, match="invalid AnalysisContextBundle"):
+        project_context_bundle_for_prompt(invalid)
+
+    wrong_id = bundle.model_copy(update={"bundle_id": "00000000-0000-0000-0000-000000000000"})
+    with pytest.raises(StateDeltaContextError, match="invalid AnalysisContextBundle"):
+        project_context_bundle_for_prompt(wrong_id)
+
+    typed_tamper = bundle.model_copy(deep=True)
+    typed_tamper.blocks[0].payload["asset"] = "XAGUSD"
+    with pytest.raises(StateDeltaContextError, match="invalid AnalysisContextBundle"):
+        project_context_bundle_for_prompt(typed_tamper)
+
+    for field, value in (("asset", "XAGUSD"), ("state_scope", "weekly_fundamental")):
+        payload = bundle.model_dump(mode="json")
+        canonical = next(item for item in payload["blocks"] if item["name"] == "canonical_state")
+        canonical["payload"][field] = value
+        encoded = _canonical_bytes(canonical["payload"])
+        canonical["utf8_bytes"] = len(encoded)
+        canonical["estimated_tokens"] = _estimate_tokens(encoded)
+        trace_block = next(item for item in payload["budget_trace"]["blocks"] if item["name"] == "canonical_state")
+        trace_block["utf8_bytes"] = canonical["utf8_bytes"]
+        trace_block["estimated_tokens"] = canonical["estimated_tokens"]
+        payload["budget_trace"]["total_utf8_bytes"] = sum(
+            item["utf8_bytes"] for item in payload["blocks"]
+        )
+        payload["budget_trace"]["estimated_tokens"] = sum(
+            item["estimated_tokens"] for item in payload["blocks"]
+        )
+        payload["content_hash"] = compute_bundle_content_hash(payload)
+        payload["bundle_id"] = str(
+            uuid.uuid5(uuid.NAMESPACE_URL, f"finance-agent:context-bundle:{payload['content_hash']}")
+        )
+        with pytest.raises(StateDeltaContextError, match="canonical_state block identity"):
+            project_context_bundle_for_prompt(payload)
+
+
+def test_state_delta_rejects_non_default_profile_before_profile_early_return() -> None:
+    raw_report = {"title": "市场赔率数据表", "article_markdown": "Bundle 外正文"}
+    daily_report = {"report_type": "market_observation"}
+
+    with pytest.raises(StateDeltaContextError, match="only supported"):
+        build_agent_analysis_prompt(
+            raw_report,
+            daily_report,
+            context_mode="state_delta_context",
+            analysis_context_bundle=_state_delta_bundle(),
+        )
+
+
+def test_state_delta_prompt_rejects_non_transition_decision() -> None:
+    raw_report, daily_report, _ = _agent_report()
+
+    with pytest.raises(StateDeltaContextError, match="manual_review"):
+        build_agent_analysis_prompt(
+            raw_report.to_dict(),
+            daily_report.to_dict(),
+            context_mode="state_delta_context",
+            analysis_context_bundle=_state_delta_bundle(),
+        )
 
 
 def test_build_agent_analysis_prompt_uses_market_observation_framework() -> None:
@@ -762,6 +957,186 @@ def test_llm_agent_analysis_prompt_budget_failure_skips_external_call(monkeypatc
     assert result.generated_from["degraded"] is True
     assert result.generated_from["degraded_reason"] == "prompt_budget_exceeded"
     assert result.generated_from["prompt_budget"] == trace
+
+
+def test_llm_state_delta_budget_and_model_failures_raise_without_raw_fallback(monkeypatch) -> None:
+    raw_report, daily_report, _ = _agent_report()
+    bundle = _state_delta_bundle(recompute_eligible=True)
+    trace = build_prompt_budget_trace("超限", budget_tokens=0)
+
+    def fail_prompt(*args, **kwargs):
+        raise PromptBudgetExceeded(trace)
+
+    monkeypatch.setattr(
+        "apps.analysis.jin10.agent_analysis.build_agent_analysis_prompt_with_trace",
+        fail_prompt,
+    )
+    with pytest.raises(PromptBudgetExceeded):
+        build_jin10_agent_analysis_report_with_llm(
+            raw_report,
+            daily_report,
+            context_mode="state_delta_context",
+            analysis_context_bundle=bundle,
+        )
+
+    monkeypatch.undo()
+    monkeypatch.setenv("FINANCE_AGENT_FORCE_LIVE_LLM", "1")
+    monkeypatch.setattr("apps.llm.gateway.chat_sync", lambda **kwargs: (_ for _ in ()).throw(RuntimeError()))
+    with pytest.raises(StateDeltaContextError, match="model failure: RuntimeError"):
+        build_jin10_agent_analysis_report_with_llm(
+            raw_report,
+            daily_report,
+            context_mode="state_delta_context",
+            analysis_context_bundle=bundle,
+        )
+
+
+def test_llm_state_delta_missing_bundle_fails_before_images_and_external_call(monkeypatch) -> None:
+    raw_report, daily_report, _ = _agent_report()
+    calls = {"image": 0, "chat": 0}
+
+    def image_loader(chart):
+        calls["image"] += 1
+        raise AssertionError("invalid state delta context must stop before image loading")
+
+    def fake_chat_sync(**kwargs):
+        calls["chat"] += 1
+        raise AssertionError("invalid state delta context must stop before external call")
+
+    monkeypatch.setenv("FINANCE_AGENT_FORCE_LIVE_LLM", "1")
+    monkeypatch.setattr("apps.llm.gateway.chat_sync", fake_chat_sync)
+
+    with pytest.raises(StateDeltaContextError, match="requires an explicit"):
+        build_jin10_agent_analysis_report_with_llm(
+            raw_report,
+            daily_report,
+            figure_image_loader=image_loader,
+            context_mode="state_delta_context",
+        )
+    assert calls == {"image": 0, "chat": 0}
+
+
+def test_llm_state_delta_audit_binds_bundle_lineage(monkeypatch) -> None:
+    raw_report, daily_report, deterministic = _agent_report()
+    bundle = _state_delta_bundle(recompute_eligible=True)
+    captured = {}
+
+    class Response:
+        content = json.dumps(_llm_payload(deterministic), ensure_ascii=False)
+        model = "state-delta-model"
+        provider = "cockpit"
+        latency_ms = 8
+        usage = {}
+        audit_id = "audit-state-delta"
+
+    def fake_chat_sync(**kwargs):
+        captured.update(kwargs)
+        return Response()
+
+    monkeypatch.setenv("FINANCE_AGENT_FORCE_LIVE_LLM", "1")
+    monkeypatch.setattr("apps.llm.gateway.chat_sync", fake_chat_sync)
+
+    result = build_jin10_agent_analysis_report_with_llm(
+        raw_report,
+        daily_report,
+        context_mode="state_delta_context",
+        analysis_context_bundle=bundle,
+    )
+
+    audit = captured["audit_context"]
+    assert audit["context_mode"] == "state_delta_context"
+    assert audit["context_bundle_id"] == bundle.bundle_id
+    assert audit["context_bundle_hash"] == bundle.content_hash
+    assert audit["canonical_state_id"] == bundle.canonical_state_id
+    assert audit["state_scope"] == "daily_close"
+    assert audit["retained_evidence_ids"] == ["market-delta-1"]
+    assert audit["retained_evidence_refs"] == [
+        {"source": "market", "evidence_id": "market-delta-1"}
+    ]
+    assert audit["evidence_delta_decision_id"] == bundle.evidence_delta_decision["decision_id"]
+    assert audit["input_snapshot_ids"] == {
+        "analysis_context_bundle": {
+            "bundle_id": bundle.bundle_id,
+            "content_hash": bundle.content_hash,
+            "canonical_state_id": bundle.canonical_state_id,
+        }
+    }
+    assert result.generated_from["analysis_context_bundle"]["bundle_id"] == bundle.bundle_id
+    assert len(result.generated_from["prompt_payload_hash"]) == 64
+    assert result.source_artifact_refs == [f"analysis_context_bundle:{bundle.bundle_id}"]
+    assert result.source_refs[0]["artifact_id"] == bundle.bundle_id
+    assert all("jin10" not in str(item) for item in result.source_artifact_refs)
+    assert all(item.get("source") != "jin10_external" for item in result.source_refs)
+    assert set(result.evidence_basis) == {"analysis_memory"}
+
+
+@pytest.mark.parametrize(
+    ("bundle_kwargs", "expected_action", "expected_calls"),
+    [
+        (
+            {"materiality_score": 10, "risk_level": "low", "include_accepted_fact": False},
+            "no_op",
+            {"image": 0, "chat": 0},
+        ),
+        ({"materiality_score": 50, "risk_level": "low"}, "update_context_only", {"image": 0, "chat": 0}),
+        ({}, "manual_review", {"image": 0, "chat": 0}),
+        ({"recompute_eligible": True}, "run_transition_analysis", {"image": 0, "chat": 1}),
+    ],
+)
+def test_llm_state_delta_routes_every_decision_before_images_and_provider(
+    monkeypatch,
+    bundle_kwargs,
+    expected_action,
+    expected_calls,
+) -> None:
+    raw_report, daily_report, deterministic = _agent_report()
+    calls = {"image": 0, "chat": 0}
+
+    class Response:
+        content = json.dumps(_llm_payload(deterministic), ensure_ascii=False)
+        model = "state-delta-model"
+        provider = "cockpit"
+        latency_ms = 8
+        usage = {}
+        audit_id = "audit-state-delta"
+
+    def image_loader(chart):
+        calls["image"] += 1
+        raise AssertionError("state_delta_context must not load raw-report images")
+
+    def fake_chat_sync(**kwargs):
+        calls["chat"] += 1
+        return Response()
+
+    monkeypatch.setenv("FINANCE_AGENT_FORCE_LIVE_LLM", "1")
+    monkeypatch.setattr("apps.llm.gateway.chat_sync", fake_chat_sync)
+    bundle = _state_delta_bundle(**bundle_kwargs)
+
+    if expected_action == "run_transition_analysis":
+        result = build_jin10_agent_analysis_report_with_llm(
+            raw_report,
+            daily_report,
+            figure_image_loader=image_loader,
+            context_mode="state_delta_context",
+            analysis_context_bundle=bundle,
+        )
+        assert calls == expected_calls
+        assert result.generated_from["evidence_delta_action"] == expected_action
+        assert result.generated_from["evidence_delta_decision_id"] == bundle.evidence_delta_decision["decision_id"]
+        assert result.generated_from["retained_evidence_refs"] == [
+            {"source": "market", "evidence_id": "market-delta-1"}
+        ]
+        assert result.generated_from["submitted_image_count"] == 0
+    else:
+        with pytest.raises(StateDeltaContextError, match=expected_action):
+            build_jin10_agent_analysis_report_with_llm(
+                raw_report,
+                daily_report,
+                figure_image_loader=image_loader,
+                context_mode="state_delta_context",
+                analysis_context_bundle=bundle,
+            )
+        assert calls == expected_calls
 
 
 def test_sanitize_agent_analysis_markdown_removes_agent_storage_section_and_yaml_block() -> None:


### PR DESCRIPTION
## What changed

- add an explicit `state_delta_context` mode for Jin10 daily analysis
- validate and project one immutable `AnalysisContextBundle v3` into canonical state, retained Evidence, accepted facts, EvidenceDeltaDecision, selection/recovery state, freshness and budget trace
- make `EvidenceDeltaDecision` the model-call authority: only `run_transition_analysis` may invoke the provider
- fail closed for invalid Bundle identity/hash, non-runnable actions, prompt-budget overflow and provider/output failures
- remove weekly/previous report bodies, raw report content, unaccepted charts and provider conversation state from the state-delta prompt and lineage
- preserve the existing legacy context path as the default until explicit canary wiring is delivered

## Why

Daily analysis still treated prior report bodies as memory. This change introduces the bounded Bundle-backed prompt contract required for canonical AnalysisState takeover without silently falling back to legacy continuity.

Production registry selection and scheduler/worker/Dagster caller wiring remain intentionally out of scope for this PR and belong to #79/#80.

## Validation

- `148 passed` across Jin10 analysis, daily context, ContextBundle schema/artifacts, coordinator, snapshot builder, prompt budget, final renderer and architecture guards
- Ruff passed for all changed Python files
- staged diff and secret/storage scope checks passed
- final high-risk contract review found no remaining P0/P1/P2 findings

Closes #78
