### PR TITLE
feat: enforce shared context bundle runtime

### DIFF
--- a/apps/analysis/agents/cme_options.py
+++ b/apps/analysis/agents/cme_options.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from apps.analysis.agents.schemas import AgentBias, AgentOutput, AgentStatus, DataCategory
+
+if TYPE_CHECKING:
+    from apps.analysis.context_bundle import ConsumerProjection
 
 _AGENT_NAME = "cme_options_agent"
 _MODULE = "options"
@@ -21,7 +25,19 @@ _WATCHLIST = [
 ]
 
 
-def analyze_cme_options(snapshot: dict[str, Any], *, created_at: datetime | None = None) -> AgentOutput:
+def analyze_cme_options(
+    snapshot: dict[str, Any],
+    *,
+    created_at: datetime | None = None,
+    context_projection: "ConsumerProjection | Mapping[str, Any] | None" = None,
+) -> AgentOutput:
+    from apps.analysis.context_bundle import validate_consumer_projection
+
+    projection = validate_consumer_projection(context_projection, "options") if context_projection is not None else None
+    return _bind_context_projection(_analyze_cme_options(snapshot, created_at=created_at), projection)
+
+
+def _analyze_cme_options(snapshot: dict[str, Any], *, created_at: datetime | None = None) -> AgentOutput:
     """Analyze already-computed CME options snapshot data without mutating inputs or reading files."""
 
     created_at = created_at or datetime.now(timezone.utc)
@@ -51,7 +67,11 @@ def analyze_cme_options(snapshot: dict[str, Any], *, created_at: datetime | None
     options = snapshot.get("options")
 
     if not isinstance(options, dict) or options.get("status") != "available":
-        reason = "options section is missing" if not isinstance(options, dict) else f"options status is {options.get('status')!r}"
+        reason = (
+            "options section is missing"
+            if not isinstance(options, dict)
+            else f"options status is {options.get('status')!r}"
+        )
         return AgentOutput(
             version=_VERSION,
             agent_name=_AGENT_NAME,
@@ -102,7 +122,9 @@ def analyze_cme_options(snapshot: dict[str, Any], *, created_at: datetime | None
         if strike is not None:
             finding += f" near {strike:g}"
         else:
-            invalid_conditions.append("Top wall score has no numeric strike/level; precise wall price was not invented.")
+            invalid_conditions.append(
+                "Top wall score has no numeric strike/level; precise wall price was not invented."
+            )
         if wall_score is not None:
             finding += f" with score {wall_score:.2f}"
             confidence += min(wall_score * 0.10, 0.10)
@@ -177,7 +199,9 @@ def analyze_cme_options(snapshot: dict[str, Any], *, created_at: datetime | None
         status=status,
         created_at=created_at,
         data_category=DataCategory.SYSTEM_INFERENCE,
-        evidence_items=_options_evidence_items(options=options, bias=bias, confidence=confidence, source_refs=source_refs),
+        evidence_items=_options_evidence_items(
+            options=options, bias=bias, confidence=confidence, source_refs=source_refs
+        ),
         input_payload={
             "bullish_drivers": bullish_drivers,
             "bearish_drivers": bearish_drivers,
@@ -359,7 +383,9 @@ def _add_block_pnt(options: dict[str, Any], key_findings: list[str]) -> None:
     if strike is not None:
         key_findings.append(f"Block/PNT activity appears near {strike:g} with block {block:g} and PNT {pnt:g}.")
     else:
-        key_findings.append(f"Block/PNT activity is present with block {block:g} and PNT {pnt:g}, but no exact level is available.")
+        key_findings.append(
+            f"Block/PNT activity is present with block {block:g} and PNT {pnt:g}, but no exact level is available."
+        )
 
 
 def _add_expiration_summary(options: dict[str, Any], key_findings: list[str]) -> None:
@@ -473,9 +499,14 @@ def _summary(
             first = expiry_structures[0]
             second = expiry_structures[1]
             same_structure = first["structure_label"] == second["structure_label"]
-            same_side = first["position_vs_gamma_zero"] == second["position_vs_gamma_zero"] and first["position_vs_gamma_zero"] != "unknown"
+            same_side = (
+                first["position_vs_gamma_zero"] == second["position_vs_gamma_zero"]
+                and first["position_vs_gamma_zero"] != "unknown"
+            )
             if same_structure and same_side:
-                relation = {"below": "均低于", "above": "均高于", "near": "均贴近"}.get(first["position_vs_gamma_zero"], "均围绕")
+                relation = {"below": "均低于", "above": "均高于", "near": "均贴近"}.get(
+                    first["position_vs_gamma_zero"], "均围绕"
+                )
                 phrases.append(
                     f"{first['expiry']} / {second['expiry']} {relation}各自零轴，且{first['structure_label']}"
                 )
@@ -572,9 +603,7 @@ def _add_calibration_findings(
                 near = _text(sig_dict.get("near_month", ""))
                 next_m = _text(sig_dict.get("next_month", ""))
                 conf = sig_dict.get("roll_confidence", 0)
-                key_findings.append(
-                    f"Expiry roll {activity} ({near} → {next_m}, confidence {conf:.2f})."
-                )
+                key_findings.append(f"Expiry roll {activity} ({near} → {next_m}, confidence {conf:.2f}).")
 
     # Calibration warnings
     warnings = cal.get("calibration_warnings")
@@ -683,7 +712,10 @@ def _structure_confidence_bonus(expiry_structures: list[dict[str, Any]]) -> floa
         first, second = expiry_structures[0], expiry_structures[1]
         if first["structure_label"] == second["structure_label"]:
             bonus += 0.04
-        if first["position_vs_gamma_zero"] == second["position_vs_gamma_zero"] and first["position_vs_gamma_zero"] != "unknown":
+        if (
+            first["position_vs_gamma_zero"] == second["position_vs_gamma_zero"]
+            and first["position_vs_gamma_zero"] != "unknown"
+        ):
             bonus += 0.03
     if all(item["gamma_zero"] is not None for item in expiry_structures[:2]):
         bonus += 0.03
@@ -709,3 +741,13 @@ def _support_resistance_levels(options: dict[str, Any]) -> tuple[float | None, f
     support = _first_with_number(sr.get("support"), ("strike", "price", "level"))
     resistance = _first_with_number(sr.get("resistance"), ("strike", "price", "level"))
     return support, resistance
+
+
+def _bind_context_projection(output: AgentOutput, projection: "ConsumerProjection | None") -> AgentOutput:
+    if projection is None:
+        return output
+    from apps.analysis.context_bundle import consume_projection_for_agent_output
+
+    return AgentOutput.model_validate(
+        consume_projection_for_agent_output(projection, output, expected_consumer="options")
+    )

--- a/apps/analysis/agents/coordinator.py
+++ b/apps/analysis/agents/coordinator.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import ValidationError
 
 from apps.analysis.agents.schemas import AgentBias, AgentOutput, AgentStatus, DataCategory
+
+if TYPE_CHECKING:
+    from apps.analysis.context_bundle import ConsumerProjection
 from apps.analysis.confidence import compute_confidence_kernel
 
 _AGENT_NAME = "coordinator_agent"
@@ -52,6 +56,40 @@ def coordinate_agent_outputs(
     news_output: AgentOutput | dict[str, Any] | None = None,
     market_odds_output: AgentOutput | dict[str, Any] | None = None,
     created_at: datetime | None = None,
+    context_projection: "ConsumerProjection | Mapping[str, Any] | None" = None,
+) -> AgentOutput:
+    from apps.analysis.context_bundle import validate_consumer_projection
+
+    projection = (
+        validate_consumer_projection(context_projection, "coordinator") if context_projection is not None else None
+    )
+    return _bind_context_projection(
+        _coordinate_agent_outputs(
+            snapshot,
+            macro_output=macro_output,
+            options_output=options_output,
+            risk_output=risk_output,
+            technical_output=technical_output,
+            positioning_output=positioning_output,
+            news_output=news_output,
+            market_odds_output=market_odds_output,
+            created_at=created_at,
+        ),
+        projection,
+    )
+
+
+def _coordinate_agent_outputs(
+    snapshot: dict[str, Any],
+    *,
+    macro_output: AgentOutput | dict[str, Any] | None,
+    options_output: AgentOutput | dict[str, Any] | None,
+    risk_output: AgentOutput | dict[str, Any] | None,
+    technical_output: AgentOutput | dict[str, Any] | None = None,
+    positioning_output: AgentOutput | dict[str, Any] | None = None,
+    news_output: AgentOutput | dict[str, Any] | None = None,
+    market_odds_output: AgentOutput | dict[str, Any] | None = None,
+    created_at: datetime | None = None,
 ) -> AgentOutput:
     """Coordinate already-computed pseudo-agent outputs into one read-only AgentOutput."""
 
@@ -84,7 +122,9 @@ def coordinate_agent_outputs(
     positioning = _coerce_output(positioning_output)
     news = _coerce_output(news_output)
     market_odds = _coerce_output(market_odds_output)
-    prior_outputs = [output for output in (macro, options, risk, technical, positioning, news, market_odds) if output is not None]
+    prior_outputs = [
+        output for output in (macro, options, risk, technical, positioning, news, market_odds) if output is not None
+    ]
 
     input_snapshot_ids = _input_snapshot_ids(snapshot, prior_outputs)
     source_refs = _source_refs(snapshot, prior_outputs)
@@ -112,24 +152,18 @@ def coordinate_agent_outputs(
     # ── Market odds conflict check with macro/options direction ──────
     if market_odds is not None and market_odds.bias in _DIRECTIONAL_BIASES:
         if macro is not None and macro.bias in _DIRECTIONAL_BIASES and macro.bias != market_odds.bias:
-            risk_points.append(
-                f"宏观/市场赔率方向冲突：宏观 {macro.bias.value}，市场赔率 {market_odds.bias.value}。"
-            )
+            risk_points.append(f"宏观/市场赔率方向冲突：宏观 {macro.bias.value}，市场赔率 {market_odds.bias.value}。")
             invalid_conditions.append(
                 f"宏观/市场赔率偏向冲突 — {macro.bias.value} vs {market_odds.bias.value}；建议交叉验证。"
             )
         if options is not None and options.bias in _DIRECTIONAL_BIASES and options.bias != market_odds.bias:
-            risk_points.append(
-                f"期权/市场赔率方向冲突：期权 {options.bias.value}，市场赔率 {market_odds.bias.value}。"
-            )
+            risk_points.append(f"期权/市场赔率方向冲突：期权 {options.bias.value}，市场赔率 {market_odds.bias.value}。")
 
     bias = _combined_bias(macro, options, risk, risk_points)
     if macro is not None and options is not None:
         if macro.bias in _DIRECTIONAL_BIASES and options.bias in _DIRECTIONAL_BIASES and macro.bias != options.bias:
             status = AgentStatus.PARTIAL
-            invalid_conditions.append(
-                f"宏观/期权方向冲突：宏观 {macro.bias.value}，期权 {options.bias.value}。"
-            )
+            invalid_conditions.append(f"宏观/期权方向冲突：宏观 {macro.bias.value}，期权 {options.bias.value}。")
 
     if unavailable_modules:
         status = AgentStatus.PARTIAL
@@ -282,7 +316,14 @@ def _gold_analysis_context_payload(snapshot: dict[str, Any]) -> dict[str, Any]:
         "baseline_kind": data.get("baseline_kind"),
         "baseline": {
             key: baseline.get(key)
-            for key in ("source_kind", "trade_date", "article_id", "quality_status", "publication_status", "publish_allowed")
+            for key in (
+                "source_kind",
+                "trade_date",
+                "article_id",
+                "quality_status",
+                "publication_status",
+                "publish_allowed",
+            )
             if baseline.get(key) is not None
         },
         "oil_report_summary": {
@@ -375,7 +416,9 @@ def _extend_prefixed(target: list[str], prefix: str, notes: list[str]) -> None:
             target.append(prefix + str(note))
 
 
-def _combined_bias(macro: AgentOutput | None, options: AgentOutput | None, risk: AgentOutput | None, risk_points: list[str]) -> AgentBias:
+def _combined_bias(
+    macro: AgentOutput | None, options: AgentOutput | None, risk: AgentOutput | None, risk_points: list[str]
+) -> AgentBias:
     if risk is not None and risk.bias in {AgentBias.MIXED, AgentBias.NEUTRAL, AgentBias.UNAVAILABLE}:
         return risk.bias
     if risk is not None and risk.bias in _DIRECTIONAL_BIASES:
@@ -466,3 +509,13 @@ def _summary(bias: AgentBias, status: AgentStatus, confidence: float) -> str:
 
 def _clamp(value: float, lower: float, upper: float) -> float:
     return max(lower, min(upper, round(value, 2)))
+
+
+def _bind_context_projection(output: AgentOutput, projection: "ConsumerProjection | None") -> AgentOutput:
+    if projection is None:
+        return output
+    from apps.analysis.context_bundle import consume_projection_for_agent_output
+
+    return AgentOutput.model_validate(
+        consume_projection_for_agent_output(projection, output, expected_consumer="coordinator")
+    )

--- a/apps/analysis/agents/fact_review.py
+++ b/apps/analysis/agents/fact_review.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from collections import Counter
+from collections.abc import Mapping
 from datetime import date, datetime
-from typing import Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable
 
 from sqlalchemy import select
 from sqlalchemy.exc import OperationalError, ProgrammingError
@@ -23,6 +24,9 @@ _SKIP_AGENT_NAMES = {"fact_review_agent", "synthesis_agent", "coordinator", "coo
 _UNAVAILABLE_SOURCE_STATUSES = {"unavailable", "failed", "error"}
 _REVIEW_QUEUE_VERDICTS = {"unsupported", "contradicted"}
 _STRUCTURED_CONTRADICTION_FIELDS = ("subject", "metric", "predicate", "horizon", "scope", "observation_time")
+
+if TYPE_CHECKING:
+    from apps.analysis.context_bundle import ConsumerProjection
 
 
 def build_fact_review_prompt_template() -> str:
@@ -167,9 +171,15 @@ def build_runtime_fact_review_agent_output(
     *,
     snapshot_id: str,
     created_at: datetime,
+    context_projection: "ConsumerProjection | Mapping[str, Any] | None" = None,
 ) -> RuntimeAgentOutput:
     """Review in-memory domain outputs without fabricating persistence identifiers."""
 
+    from apps.analysis.context_bundle import validate_consumer_projection
+
+    projection = (
+        validate_consumer_projection(context_projection, "fact_review") if context_projection is not None else None
+    )
     review_targets = [row for row in agent_outputs if row.agent_name not in _SKIP_AGENT_NAMES]
     if not review_targets:
         raise ValueError("fact_review_agent requires at least one upstream agent output")
@@ -217,37 +227,48 @@ def build_runtime_fact_review_agent_output(
     source_refs = _dedupe_dicts(ref for row in review_targets for ref in row.source_refs)
     evidence_refs = _dedupe_dicts(ref for row in review_targets for ref in row.evidence_refs)
     input_snapshot_ids = {row.agent_name: row.snapshot_id for row in review_targets}
-    return RuntimeAgentOutput(
-        version="1.0",
-        agent_name="fact_review_agent",
-        module="fact_review",
-        snapshot_id=f"{snapshot_id}:fact_review",
-        input_snapshot_ids=input_snapshot_ids,
-        bias=AgentBias.MIXED if fact_review_status == "conflicted" else AgentBias.NEUTRAL,
-        confidence=_review_confidence(counts, len(claim_reviews)),
-        key_findings=_build_key_findings(counts, review_targets),
-        risk_points=_build_risk_points(claim_reviews),
-        watchlist=[row.agent_name for row in review_targets],
-        invalid_conditions=_build_invalid_conditions(counts),
-        summary=_build_summary_text(counts),
-        source_refs=source_refs,
-        evidence_refs=evidence_refs,
-        status=AgentStatus(_agent_status(fact_review_status)),
-        created_at=created_at,
-        data_quality=[f"fact_review:{fact_review_status}"],
-        input_payload={
-            "generated_by": "rule",
-            "prompt_version": _PROMPT_VERSION,
-            "fact_review_status": fact_review_status,
-            "claim_review_status": (
-                "contradicted" if counts["contradicted"] else "unsupported" if counts["unsupported"] else "supported"
-            ),
-            "reviewed_agent_outputs": reviewed_agent_outputs,
-            "verdict_counts": counts,
-            "claim_reviews": claim_reviews,
-            "unsupported_claim_ids": [item["claim_id"] for item in claim_reviews if item["verdict"] == "unsupported"],
-            "conflicted_claim_ids": [item["claim_id"] for item in claim_reviews if item["verdict"] == "contradicted"],
-        },
+    return _bind_context_projection(
+        RuntimeAgentOutput(
+            version="1.0",
+            agent_name="fact_review_agent",
+            module="fact_review",
+            snapshot_id=f"{snapshot_id}:fact_review",
+            input_snapshot_ids=input_snapshot_ids,
+            bias=AgentBias.MIXED if fact_review_status == "conflicted" else AgentBias.NEUTRAL,
+            confidence=_review_confidence(counts, len(claim_reviews)),
+            key_findings=_build_key_findings(counts, review_targets),
+            risk_points=_build_risk_points(claim_reviews),
+            watchlist=[row.agent_name for row in review_targets],
+            invalid_conditions=_build_invalid_conditions(counts),
+            summary=_build_summary_text(counts),
+            source_refs=source_refs,
+            evidence_refs=evidence_refs,
+            status=AgentStatus(_agent_status(fact_review_status)),
+            created_at=created_at,
+            data_quality=[f"fact_review:{fact_review_status}"],
+            input_payload={
+                "generated_by": "rule",
+                "prompt_version": _PROMPT_VERSION,
+                "fact_review_status": fact_review_status,
+                "claim_review_status": (
+                    "contradicted"
+                    if counts["contradicted"]
+                    else "unsupported"
+                    if counts["unsupported"]
+                    else "supported"
+                ),
+                "reviewed_agent_outputs": reviewed_agent_outputs,
+                "verdict_counts": counts,
+                "claim_reviews": claim_reviews,
+                "unsupported_claim_ids": [
+                    item["claim_id"] for item in claim_reviews if item["verdict"] == "unsupported"
+                ],
+                "conflicted_claim_ids": [
+                    item["claim_id"] for item in claim_reviews if item["verdict"] == "contradicted"
+                ],
+            },
+        ),
+        projection,
     )
 
 
@@ -424,7 +445,9 @@ def _review_claim(
     review_targets: list[PersistedAgentOutput] | list[RuntimeAgentOutput],
 ) -> tuple[str, str, list[dict[str, Any]]]:
     claim_id = str(claim.get("claim_id") or f"{row.agent_name}:claim")
-    source_refs = claim.get("source_refs") if isinstance(claim.get("source_refs"), list) else list(row.source_refs or [])
+    source_refs = (
+        claim.get("source_refs") if isinstance(claim.get("source_refs"), list) else list(row.source_refs or [])
+    )
     evidence_refs = claim.get("evidence_refs") if isinstance(claim.get("evidence_refs"), list) else []
 
     if row.status in _UNAVAILABLE_SOURCE_STATUSES or _all_sources_unavailable(source_refs):
@@ -517,11 +540,7 @@ def _all_sources_unavailable(source_refs: list[dict[str, Any]]) -> bool:
     otherwise usable evidence from the same claim.
     """
 
-    statuses = [
-        str(ref.get("status") or "").strip().lower()
-        for ref in source_refs
-        if isinstance(ref, dict)
-    ]
+    statuses = [str(ref.get("status") or "").strip().lower() for ref in source_refs if isinstance(ref, dict)]
     return bool(statuses) and all(status in _UNAVAILABLE_SOURCE_STATUSES for status in statuses)
 
 
@@ -560,9 +579,7 @@ def _build_key_findings(
     if counts["contradicted"]:
         findings.append(f"发现 {counts['contradicted']} 条结构化事实矛盾 claim。")
     if counts["unsupported"] or counts["insufficient_evidence"]:
-        findings.append(
-            f"发现 {counts['unsupported'] + counts['insufficient_evidence']} 条需人工补证的 claim。"
-        )
+        findings.append(f"发现 {counts['unsupported'] + counts['insufficient_evidence']} 条需人工补证的 claim。")
     return findings
 
 
@@ -629,3 +646,20 @@ def _iso_date(value: date | str) -> str:
     if isinstance(value, date):
         return value.isoformat()
     return str(value)
+
+
+def _bind_context_projection(
+    output: RuntimeAgentOutput,
+    projection: "ConsumerProjection | None",
+) -> RuntimeAgentOutput:
+    if projection is None:
+        return output
+    from apps.analysis.context_bundle import consume_projection_for_agent_output
+
+    return RuntimeAgentOutput.model_validate(
+        consume_projection_for_agent_output(
+            projection,
+            output,
+            expected_consumer="fact_review",
+        )
+    )

--- a/apps/analysis/agents/macro_liquidity.py
+++ b/apps/analysis/agents/macro_liquidity.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Mapping
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from apps.analysis.agents.schemas import AgentBias, AgentOutput, AgentStatus, DataCategory
 from apps.analysis.agents.macro_liquidity_prompt import build_macro_liquidity_prompt_template
@@ -35,19 +36,33 @@ _LIQUIDITY_GROUPS = {
     "IORB": ("IORB",),
 }
 
+if TYPE_CHECKING:
+    from apps.analysis.context_bundle import ConsumerProjection
 
-def analyze_macro_liquidity(snapshot: dict[str, Any], *, created_at: datetime | None = None) -> AgentOutput:
+
+def analyze_macro_liquidity(
+    snapshot: dict[str, Any],
+    *,
+    created_at: datetime | None = None,
+    context_projection: "ConsumerProjection | Mapping[str, Any] | None" = None,
+) -> AgentOutput:
     """Analyze already-loaded macro liquidity snapshot data without mutating inputs."""
 
+    from apps.analysis.context_bundle import validate_consumer_projection
+
+    projection = validate_consumer_projection(context_projection, "macro") if context_projection is not None else None
     created_at = created_at or datetime.now(timezone.utc)
     if not isinstance(snapshot, dict):
-        return _build_unavailable_output(
-            snapshot_id="unknown",
-            input_snapshot_ids={},
-            source_refs=[],
-            created_at=created_at,
-            invalid_reason="非字典输入被拒绝；文件/路径读取不在范围内。",
-            risk_point="宏观流动性输入必须是已加载的快照字典。",
+        return _bind_context_projection(
+            _build_unavailable_output(
+                snapshot_id="unknown",
+                input_snapshot_ids={},
+                source_refs=[],
+                created_at=created_at,
+                invalid_reason="非字典输入被拒绝；文件/路径读取不在范围内。",
+                risk_point="宏观流动性输入必须是已加载的快照字典。",
+            ),
+            projection,
         )
 
     snapshot_id = str(snapshot.get("snapshot_id") or "unknown")
@@ -56,14 +71,19 @@ def analyze_macro_liquidity(snapshot: dict[str, Any], *, created_at: datetime | 
     macro = snapshot.get("macro")
 
     if not isinstance(macro, dict) or macro.get("status") != "available":
-        reason = "macro section is missing" if not isinstance(macro, dict) else f"macro status is {macro.get('status')!r}"
-        return _build_unavailable_output(
-            snapshot_id=snapshot_id,
-            input_snapshot_ids=input_snapshot_ids,
-            source_refs=source_refs,
-            created_at=created_at,
-            invalid_reason=reason,
-            risk_point="宏观流动性输入不可用。",
+        reason = (
+            "macro section is missing" if not isinstance(macro, dict) else f"macro status is {macro.get('status')!r}"
+        )
+        return _bind_context_projection(
+            _build_unavailable_output(
+                snapshot_id=snapshot_id,
+                input_snapshot_ids=input_snapshot_ids,
+                source_refs=source_refs,
+                created_at=created_at,
+                invalid_reason=reason,
+                risk_point="宏观流动性输入不可用。",
+            ),
+            projection,
         )
 
     data = _macro_data(snapshot)
@@ -78,14 +98,19 @@ def analyze_macro_liquidity(snapshot: dict[str, Any], *, created_at: datetime | 
         indicators=indicators,
         data=data,
     )
-    llm_result = invoke_macro_liquidity_llm(snapshot, deterministic_output=deterministic)
-    return _merge_macro_liquidity_output(snapshot, deterministic, llm_result)
+    llm_result = invoke_macro_liquidity_llm(
+        snapshot,
+        deterministic_output=deterministic,
+        context_projection=projection,
+    )
+    return _bind_context_projection(_merge_macro_liquidity_output(snapshot, deterministic, llm_result), projection)
 
 
 def invoke_macro_liquidity_llm(
     snapshot: dict[str, Any],
     *,
     deterministic_output: AgentOutput | None = None,
+    context_projection: "ConsumerProjection | None" = None,
 ) -> dict[str, Any]:
     from apps.llm.gateway import chat_sync
 
@@ -100,7 +125,11 @@ def invoke_macro_liquidity_llm(
             "skipped": True,
         }
 
-    prompt = build_macro_liquidity_prompt(snapshot, deterministic_output=deterministic_output)
+    prompt = build_macro_liquidity_prompt(
+        snapshot,
+        deterministic_output=deterministic_output,
+        context_projection=context_projection,
+    )
     provider = os.getenv("MACRO_LIQUIDITY_LLM_PROVIDER", _DEFAULT_LLM_PROVIDER)
     model = os.getenv("MACRO_LIQUIDITY_LLM_MODEL", os.getenv("LLM_COCKPIT_MODEL", _DEFAULT_LLM_MODEL))
     reasoning_effort = os.getenv(
@@ -123,7 +152,11 @@ def invoke_macro_liquidity_llm(
             "run_id": snapshot.get("run_id"),
             "snapshot_id": snapshot.get("snapshot_id"),
             "trade_date": snapshot.get("trade_date"),
-            "input_payload": build_macro_liquidity_structured_payload(snapshot, deterministic_output=deterministic_output),
+            "input_payload": build_macro_liquidity_structured_payload(
+                snapshot,
+                deterministic_output=deterministic_output,
+                context_projection=context_projection,
+            ),
         },
     )
     return {
@@ -143,8 +176,13 @@ def build_macro_liquidity_prompt(
     snapshot: dict[str, Any],
     *,
     deterministic_output: AgentOutput | None = None,
+    context_projection: "ConsumerProjection | None" = None,
 ) -> str:
-    payload = build_macro_liquidity_structured_payload(snapshot, deterministic_output=deterministic_output)
+    payload = build_macro_liquidity_structured_payload(
+        snapshot,
+        deterministic_output=deterministic_output,
+        context_projection=context_projection,
+    )
     return (
         f"{build_macro_liquidity_prompt_template()}\n\n"
         "=== 结构化输入 ===\n"
@@ -156,6 +194,7 @@ def build_macro_liquidity_structured_payload(
     snapshot: dict[str, Any],
     *,
     deterministic_output: AgentOutput | None = None,
+    context_projection: "ConsumerProjection | None" = None,
 ) -> dict[str, Any]:
     deterministic_output = deterministic_output or _build_deterministic_output(
         snapshot_id=str(snapshot.get("snapshot_id") or "unknown"),
@@ -169,7 +208,7 @@ def build_macro_liquidity_structured_payload(
     macro = snapshot.get("macro") if isinstance(snapshot.get("macro"), dict) else {}
     data = macro.get("data") if isinstance(macro.get("data"), dict) else {}
     indicators = data.get("indicators") if isinstance(data.get("indicators"), dict) else {}
-    return {
+    payload = {
         "report_type": "macro_liquidity",
         "snapshot_id": str(snapshot.get("snapshot_id") or "unknown"),
         "trade_date": _trade_date(snapshot),
@@ -218,11 +257,18 @@ def build_macro_liquidity_structured_payload(
         "existing_frame": {
             "real_yield": _indicator_snapshot(indicators, _REAL_YIELD_KEYS),
             "dxy": _indicator_snapshot(indicators, _DXY_KEYS),
-            "liquidity": {
-                name: _indicator_snapshot(indicators, keys) for name, keys in _LIQUIDITY_GROUPS.items()
-            },
+            "liquidity": {name: _indicator_snapshot(indicators, keys) for name, keys in _LIQUIDITY_GROUPS.items()},
         },
     }
+    if context_projection is not None:
+        payload["context_bundle_summary"] = _context_projection_summary(context_projection)
+        from apps.analysis.context_bundle import consumer_projection_payload
+
+        payload["context_bundle_projection"] = consumer_projection_payload(
+            context_projection,
+            expected_consumer="macro",
+        )
+    return payload
 
 
 def _system_data_gaps(indicators: dict[str, Any], source_refs: list[dict[str, Any]]) -> list[dict[str, str]]:
@@ -235,17 +281,21 @@ def _system_data_gaps(indicators: dict[str, Any], source_refs: list[dict[str, An
 
     dxy = _indicator_snapshot(indicators, _DXY_KEYS)
     if dxy is None:
-        gaps.append({
-            "item": "DXY",
-            "current_status": "missing_from_system_snapshot",
-            "optimization": "接入 TradingView DXY 最新值、1周变化、1月变化，CNBC 仅作兜底。",
-        })
+        gaps.append(
+            {
+                "item": "DXY",
+                "current_status": "missing_from_system_snapshot",
+                "optimization": "接入 TradingView DXY 最新值、1周变化、1月变化，CNBC 仅作兜底。",
+            }
+        )
     elif "tradingview" not in refs_text:
-        gaps.append({
-            "item": "DXY TradingView weekly/monthly",
-            "current_status": "system_snapshot_has_dxy_but_not_confirmed_tradingview_source",
-            "optimization": "修复 TradingView source_ref 与周/月变化映射。",
-        })
+        gaps.append(
+            {
+                "item": "DXY TradingView weekly/monthly",
+                "current_status": "system_snapshot_has_dxy_but_not_confirmed_tradingview_source",
+                "optimization": "修复 TradingView source_ref 与周/月变化映射。",
+            }
+        )
 
     required = [
         ("ETF / GLD flows", ("etf", "gld"), "接入 WGC / GLD 持仓或可信 ETF flow 数据源。"),
@@ -256,11 +306,13 @@ def _system_data_gaps(indicators: dict[str, Any], source_refs: list[dict[str, An
     ]
     for item, needles, optimization in required:
         if not any(needle in refs_text for needle in needles):
-            gaps.append({
-                "item": item,
-                "current_status": "not_in_system_source_refs",
-                "optimization": optimization,
-            })
+            gaps.append(
+                {
+                    "item": item,
+                    "current_status": "not_in_system_source_refs",
+                    "optimization": optimization,
+                }
+            )
     return gaps
 
 
@@ -331,6 +383,41 @@ def _build_unavailable_output(
         regime_drivers=None,
         data_category=DataCategory.CONFIRMED_DATA,
     )
+
+
+def _bind_context_projection(
+    output: AgentOutput,
+    projection: "ConsumerProjection | None",
+) -> AgentOutput:
+    if projection is None:
+        return output
+    from apps.analysis.context_bundle import consume_projection_for_agent_output
+
+    return AgentOutput.model_validate(
+        consume_projection_for_agent_output(
+            projection,
+            output,
+            expected_consumer="macro",
+        )
+    )
+
+
+def _context_projection_summary(projection: "ConsumerProjection") -> dict[str, Any]:
+    return {
+        "decision_id": projection.decision_id,
+        "decision_action": projection.decision.recommended_action.value,
+        "state_scope": projection.identity_payload.state_scope,
+        "retained_evidence_count": len(projection.retained_evidence),
+        "retained_refs": list(projection.retained_source_refs),
+        "accepted_fact_count": len(projection.accepted_facts),
+        "accepted_fact_refs": [
+            {
+                "source": item.get("source"),
+                "figure_fact_id": item.get("figure_fact_id"),
+            }
+            for item in projection.accepted_facts
+        ],
+    }
 
 
 def _input_snapshot_ids(snapshot: dict[str, Any]) -> dict[str, Any]:
@@ -498,13 +585,19 @@ def _build_deterministic_output(
         real_change = _first_change(indicators, _REAL_YIELD_KEYS)
         real_value = real_value if real_value is not None else _first_value(indicators, _REAL_YIELD_KEYS)
         if real_change is not None:
-            key_findings.append("10Y real-yield change is using supplementary TIPS/direct field because US10Y-T10YIE change is incomplete.")
+            key_findings.append(
+                "10Y real-yield change is using supplementary TIPS/direct field because US10Y-T10YIE change is incomplete."
+            )
         else:
             status = AgentStatus.PARTIAL
             confidence -= 0.12
-            invalid_conditions.append("10Y real-yield signal is missing; checked real-yield fields, nominal yield and T10YIE.")
+            invalid_conditions.append(
+                "10Y real-yield signal is missing; checked real-yield fields, nominal yield and T10YIE."
+            )
     else:
-        key_findings.append(f"10Y real-yield main口径 uses US10Y - T10YIE; weekly/directional change is {real_change:.2f}.")
+        key_findings.append(
+            f"10Y real-yield main口径 uses US10Y - T10YIE; weekly/directional change is {real_change:.2f}."
+        )
     if real_change is not None:
         if real_change < 0:
             score += 1
@@ -534,7 +627,9 @@ def _build_deterministic_output(
         elif dxy_value is not None:
             key_findings.append(f"DXY level is available ({dxy_value:.2f}) but directional change is missing.")
 
-    present_liquidity = [name for name, keys in _LIQUIDITY_GROUPS.items() if _first_indicator(indicators, keys) is not None]
+    present_liquidity = [
+        name for name, keys in _LIQUIDITY_GROUPS.items() if _first_indicator(indicators, keys) is not None
+    ]
     if len(present_liquidity) < len(_LIQUIDITY_GROUPS):
         missing = [name for name in _LIQUIDITY_GROUPS if name not in present_liquidity]
         status = AgentStatus.PARTIAL

--- a/apps/analysis/agents/market_odds.py
+++ b/apps/analysis/agents/market_odds.py
@@ -14,8 +14,12 @@ as unavailable but do not block output generation.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from apps.analysis.context_bundle import ConsumerProjection
 
 from apps.analysis.agents.schemas import AgentBias, AgentOutput, AgentStatus, DataCategory
 
@@ -25,8 +29,20 @@ _VERSION = "1.0"
 
 
 def analyze_market_odds(
-    snapshot: dict[str, Any], *, created_at: datetime | None = None
+    snapshot: dict[str, Any],
+    *,
+    created_at: datetime | None = None,
+    context_projection: "ConsumerProjection | Mapping[str, Any] | None" = None,
 ) -> AgentOutput:
+    from apps.analysis.context_bundle import validate_consumer_projection
+
+    projection = (
+        validate_consumer_projection(context_projection, "market_odds") if context_projection is not None else None
+    )
+    return _bind_context_projection(_analyze_market_odds(snapshot, created_at=created_at), projection)
+
+
+def _analyze_market_odds(snapshot: dict[str, Any], *, created_at: datetime | None = None) -> AgentOutput:
     """Analyze the market_odds section of an already-loaded analysis snapshot.
 
     The agent is purely deterministic and read-only:
@@ -103,7 +119,9 @@ def analyze_market_odds(
                 f"signal={signal}, reliability={reliability:.2f}, divergence={divergence:.2f}."
             )
             if prob > 0.6 and signal == "bullish":
-                key_findings.append(f"Elevated bullish market probability for {event_name} — potential upside catalyst.")
+                key_findings.append(
+                    f"Elevated bullish market probability for {event_name} — potential upside catalyst."
+                )
             elif prob > 0.6 and signal == "bearish":
                 risk_points.append(f"Elevated bearish market probability for {event_name} — potential downside risk.")
         else:
@@ -112,7 +130,9 @@ def analyze_market_odds(
         if reliability < 0.3:
             risk_points.append(f"Low reliability ({reliability:.2f}) for event '{event_name}' — treat with caution.")
         if divergence > 0.5:
-            risk_points.append(f"High source divergence ({divergence:.2f}) for event '{event_name}' — conflicting signals.")
+            risk_points.append(
+                f"High source divergence ({divergence:.2f}) for event '{event_name}' — conflicting signals."
+            )
 
         if interpretation:
             key_findings.append(interpretation[:200])
@@ -120,9 +140,7 @@ def analyze_market_odds(
     # ── Missing sources ─────────────────────────────────────────────
     missing_sources = _detect_missing_sources(events)
     if missing_sources:
-        invalid_conditions.append(
-            f"Unavailable probability sources: {', '.join(missing_sources)}."
-        )
+        invalid_conditions.append(f"Unavailable probability sources: {', '.join(missing_sources)}.")
         risk_points.append(
             f"Market odds are based on CME only — {', '.join(missing_sources)} data missing, reducing reliability."
         )
@@ -130,9 +148,7 @@ def analyze_market_odds(
     # ── Placeholder events noted ────────────────────────────────────
     for event in unavailable_events:
         event_name = event.get("event_name", event.get("event_id", "unknown"))
-        invalid_conditions.append(
-            f"Market odds event '{event_name}' is unavailable — source data not yet integrated."
-        )
+        invalid_conditions.append(f"Market odds event '{event_name}' is unavailable — source data not yet integrated.")
 
     # ── Aggregate bias determination ────────────────────────────────
     if not available_events:
@@ -237,9 +253,7 @@ def _detect_missing_sources(events: list[dict[str, Any]]) -> list[str]:
     return sorted(missing)
 
 
-def _calculate_confidence(
-    events: list[dict[str, Any]], mo_status: str, bias: AgentBias
-) -> float:
+def _calculate_confidence(events: list[dict[str, Any]], mo_status: str, bias: AgentBias) -> float:
     """Calculate agent confidence from market odds data quality."""
     if not events:
         return 0.0
@@ -252,8 +266,7 @@ def _calculate_confidence(
 
     # Base: average reliability of available events
     reliabilities = [
-        e.get("reliability_score", 0.0) for e in available
-        if isinstance(e.get("reliability_score"), (int, float))
+        e.get("reliability_score", 0.0) for e in available if isinstance(e.get("reliability_score"), (int, float))
     ]
     confidence = sum(reliabilities) / len(reliabilities) if reliabilities else 0.3
 
@@ -267,7 +280,8 @@ def _calculate_confidence(
 
     # Penalty for high divergence
     high_div_count = sum(
-        1 for e in available
+        1
+        for e in available
         if isinstance(e.get("divergence_score"), (int, float)) and float(e["divergence_score"]) > 0.5
     )
     confidence -= 0.05 * high_div_count
@@ -307,3 +321,13 @@ def _summary(bias: AgentBias, mo_status: str, confidence: float) -> str:
 
 def _clamp(value: float, lower: float, upper: float) -> float:
     return max(lower, min(upper, round(value, 2)))
+
+
+def _bind_context_projection(output: AgentOutput, projection: "ConsumerProjection | None") -> AgentOutput:
+    if projection is None:
+        return output
+    from apps.analysis.context_bundle import consume_projection_for_agent_output
+
+    return AgentOutput.model_validate(
+        consume_projection_for_agent_output(projection, output, expected_consumer="market_odds")
+    )

--- a/apps/analysis/agents/news.py
+++ b/apps/analysis/agents/news.py
@@ -8,10 +8,14 @@ BIAS IS ALWAYS NEUTRAL — news provides risk signals, not price direction.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from apps.analysis.agents.schemas import AgentBias, AgentOutput, AgentStatus, DataCategory
+
+if TYPE_CHECKING:
+    from apps.analysis.context_bundle import ConsumerProjection
 
 _AGENT_NAME = "news_agent"
 _MODULE = "news"
@@ -19,8 +23,18 @@ _VERSION = "1.0"
 
 
 def analyze_news(
-    snapshot: dict[str, Any], *, created_at: datetime | None = None
+    snapshot: dict[str, Any],
+    *,
+    created_at: datetime | None = None,
+    context_projection: "ConsumerProjection | Mapping[str, Any] | None" = None,
 ) -> AgentOutput:
+    from apps.analysis.context_bundle import validate_consumer_projection
+
+    projection = validate_consumer_projection(context_projection, "news") if context_projection is not None else None
+    return _bind_context_projection(_analyze_news(snapshot, created_at=created_at), projection)
+
+
+def _analyze_news(snapshot: dict[str, Any], *, created_at: datetime | None = None) -> AgentOutput:
     """Analyze the news section of an already-loaded analysis snapshot."""
 
     created_at = created_at or datetime.now(timezone.utc)
@@ -33,11 +47,7 @@ def analyze_news(
     news = snapshot.get("news")
 
     if not isinstance(news, dict) or news.get("status") != "available":
-        reason = (
-            "news section is missing"
-            if not isinstance(news, dict)
-            else f"news status is {news.get('status')!r}"
-        )
+        reason = "news section is missing" if not isinstance(news, dict) else f"news status is {news.get('status')!r}"
         return AgentOutput(
             version=_VERSION,
             agent_name=_AGENT_NAME,
@@ -81,25 +91,15 @@ def analyze_news(
     high_star = int(data.get("high_star_count_7d", 0))
 
     if risk_level == "HIGH":
-        key_findings.append(
-            f"News risk level: HIGH ({high_star} high-impact events in recent 7d)."
-        )
-        risk_points.append(
-            "Recent macro events are high-impact; elevated headline-driven volatility risk."
-        )
+        key_findings.append(f"News risk level: HIGH ({high_star} high-impact events in recent 7d).")
+        risk_points.append("Recent macro events are high-impact; elevated headline-driven volatility risk.")
         confidence = 0.72
     elif risk_level == "MEDIUM":
-        key_findings.append(
-            f"News risk level: MEDIUM ({high_star} high-impact events in recent 7d)."
-        )
-        risk_points.append(
-            "Moderate macro event risk; some headline-driven volatility possible."
-        )
+        key_findings.append(f"News risk level: MEDIUM ({high_star} high-impact events in recent 7d).")
+        risk_points.append("Moderate macro event risk; some headline-driven volatility possible.")
         confidence = 0.62
     else:
-        key_findings.append(
-            "News risk level: LOW (no high-impact events in recent 7 days)."
-        )
+        key_findings.append("News risk level: LOW (no high-impact events in recent 7 days).")
         confidence = 0.55
 
     # ── Recent events ──────────────────────────────────────────────────
@@ -126,30 +126,22 @@ def analyze_news(
     flashes = data.get("recent_flashes")
     if isinstance(flashes, list) and flashes:
         flash_count = len(flashes)
-        key_findings.append(
-            f"{flash_count} flash headlines collected (deduplicated)."
-        )
+        key_findings.append(f"{flash_count} flash headlines collected (deduplicated).")
 
         # Detect keyword hits via URL (flash content is in raw payload)
         keywords = {"美联储", "FOMC", "利率", "CPI", "非农", "PCE"}
         hit_count = sum(
-            1 for f in flashes
-            if isinstance(f, dict)
-            and any(kw in str(f.get("url", "")) for kw in keywords)
+            1 for f in flashes if isinstance(f, dict) and any(kw in str(f.get("url", "")) for kw in keywords)
         )
         if hit_count >= 3:
-            risk_points.append(
-                f"{hit_count} flash headlines mention key macro topics — elevated news flow."
-            )
+            risk_points.append(f"{hit_count} flash headlines mention key macro topics — elevated news flow.")
         confidence = min(confidence + 0.02 * min(hit_count, 3), 0.80)
     else:
         invalid_conditions.append("No flash headlines available; news signal may be stale.")
         confidence -= 0.08
 
     # ── Data quality ───────────────────────────────────────────────────
-    if (not isinstance(events, list) or not events) and (
-        not isinstance(flashes, list) or not flashes
-    ):
+    if (not isinstance(events, list) or not events) and (not isinstance(flashes, list) or not flashes):
         status = AgentStatus.PARTIAL
         confidence -= 0.12
         invalid_conditions.append("Both calendar events and flash headlines are empty.")
@@ -299,9 +291,13 @@ def _analyze_daily_market_brief(
     if candidate_events or unconfirmed_risks:
         invalid_conditions.append("Single-source or unofficial events must remain watchlist until verified.")
     if external_market_odds:
-        invalid_conditions.append("External market odds cannot independently set direction, macro regime, confidence, or readiness.")
+        invalid_conditions.append(
+            "External market odds cannot independently set direction, macro regime, confidence, or readiness."
+        )
     if etf_claims:
-        invalid_conditions.append("Jin10 ETF holdings are single-source supplemental observations and require source-tier labeling.")
+        invalid_conditions.append(
+            "Jin10 ETF holdings are single-source supplemental observations and require source-tier labeling."
+        )
 
     confidence = 0.58
     if confirmed_events:
@@ -395,13 +391,10 @@ def _etf_holdings_claims(context: dict[str, Any]) -> list[dict[str, Any]]:
                 "observation_time": reported_on,
                 "value": float(holdings),
                 "change": change,
-                "source_refs": [
-                    ref for ref in source_refs
-                    if ref.get("asset") in {None, asset}
-                ],
-                "evidence_refs": [
-                    {"type": "etf_holdings_feature", "artifact_path": artifact_path}
-                ] if artifact_path else [],
+                "source_refs": [ref for ref in source_refs if ref.get("asset") in {None, asset}],
+                "evidence_refs": [{"type": "etf_holdings_feature", "artifact_path": artifact_path}]
+                if artifact_path
+                else [],
             }
         )
     return claims
@@ -444,3 +437,11 @@ def _summary(risk_level: str, status: AgentStatus, confidence: float) -> str:
 
 def _clamp(value: float, lower: float, upper: float) -> float:
     return max(lower, min(upper, round(value, 2)))
+
+
+def _bind_context_projection(output: AgentOutput, projection: "ConsumerProjection | None") -> AgentOutput:
+    if projection is None:
+        return output
+    from apps.analysis.context_bundle import consume_projection_for_agent_output
+
+    return AgentOutput.model_validate(consume_projection_for_agent_output(projection, output, expected_consumer="news"))

--- a/apps/analysis/agents/positioning.py
+++ b/apps/analysis/agents/positioning.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from apps.analysis.agents.schemas import AgentBias, AgentOutput, AgentStatus, DataCategory
+
+if TYPE_CHECKING:
+    from apps.analysis.context_bundle import ConsumerProjection
 
 _AGENT_NAME = "positioning_agent"
 _MODULE = "positioning"
@@ -23,7 +27,21 @@ _WATCHLIST = [
 ]
 
 
-def analyze_positioning(snapshot: dict[str, Any], *, created_at: datetime | None = None) -> AgentOutput:
+def analyze_positioning(
+    snapshot: dict[str, Any],
+    *,
+    created_at: datetime | None = None,
+    context_projection: "ConsumerProjection | Mapping[str, Any] | None" = None,
+) -> AgentOutput:
+    from apps.analysis.context_bundle import validate_consumer_projection
+
+    projection = (
+        validate_consumer_projection(context_projection, "positioning") if context_projection is not None else None
+    )
+    return _bind_context_projection(_analyze_positioning(snapshot, created_at=created_at), projection)
+
+
+def _analyze_positioning(snapshot: dict[str, Any], *, created_at: datetime | None = None) -> AgentOutput:
     """Analyze already-loaded positioning (CFTC COT) snapshot data without mutating inputs."""
 
     created_at = created_at or datetime.now(timezone.utc)
@@ -127,9 +145,7 @@ def analyze_positioning(snapshot: dict[str, Any], *, created_at: datetime | None
 
     if producer_net is not None and swap_net is not None:
         data_points_available += 2
-        key_findings.append(
-            f"Producer/Merchant net position: {producer_net:,.0f} contracts."
-        )
+        key_findings.append(f"Producer/Merchant net position: {producer_net:,.0f} contracts.")
         key_findings.append(f"Swap Dealer net position: {swap_net:,.0f} contracts.")
     else:
         data_points_missing += 1
@@ -172,30 +188,23 @@ def analyze_positioning(snapshot: dict[str, Any], *, created_at: datetime | None
             )
             if noncomm_net > 200000:
                 risk_points.append(
-                    f"Speculative net long is extreme ({noncomm_net:,.0f}); "
-                    f"crowded longs increase reversal risk."
+                    f"Speculative net long is extreme ({noncomm_net:,.0f}); crowded longs increase reversal risk."
                 )
                 confidence -= 0.04
         else:
-            key_findings.append(
-                f"Speculators (Managed Money) are net short {abs(noncomm_net):,.0f} contracts."
-            )
+            key_findings.append(f"Speculators (Managed Money) are net short {abs(noncomm_net):,.0f} contracts.")
     else:
         data_points_missing += 1
 
     # Direction context
     if commercial_direction == "increasing_short":
-        key_findings.append(
-            "Commercial aggregate proxy is becoming more net short week-over-week — bearish momentum."
-        )
+        key_findings.append("Commercial aggregate proxy is becoming more net short week-over-week — bearish momentum.")
         if bias is AgentBias.BEARISH:
             confidence += 0.05
         elif bias is not AgentBias.UNAVAILABLE:
             risk_points.append("Commercial shorts increasing despite non-bearish bias; monitor closely.")
     elif commercial_direction == "increasing_long":
-        key_findings.append(
-            "Commercial aggregate proxy is becoming more net long week-over-week — bullish momentum."
-        )
+        key_findings.append("Commercial aggregate proxy is becoming more net long week-over-week — bullish momentum.")
         if bias is AgentBias.BULLISH:
             confidence += 0.05
         elif bias is not AgentBias.UNAVAILABLE:
@@ -215,9 +224,7 @@ def analyze_positioning(snapshot: dict[str, Any], *, created_at: datetime | None
             "elevated reversal risk."
         )
         confidence -= 0.06
-        key_findings.append(
-            "Commercial aggregate proxy is at a 52-week extreme — contrarian signal."
-        )
+        key_findings.append("Commercial aggregate proxy is at a 52-week extreme — contrarian signal.")
 
     # Open interest
     if total_oi is not None and total_oi > 0:
@@ -233,8 +240,7 @@ def analyze_positioning(snapshot: dict[str, Any], *, created_at: datetime | None
         status = AgentStatus.PARTIAL
         confidence -= 0.10 * data_points_missing
         invalid_conditions.append(
-            f"Partial positioning data: {data_points_missing} fields missing "
-            f"({data_points_available} available)."
+            f"Partial positioning data: {data_points_missing} fields missing ({data_points_available} available)."
         )
 
     if not key_findings:
@@ -305,3 +311,13 @@ def _summary(bias: AgentBias, status: AgentStatus, confidence: float) -> str:
 
 def _clamp(value: float, lower: float, upper: float) -> float:
     return max(lower, min(upper, round(value, 2)))
+
+
+def _bind_context_projection(output: AgentOutput, projection: "ConsumerProjection | None") -> AgentOutput:
+    if projection is None:
+        return output
+    from apps.analysis.context_bundle import consume_projection_for_agent_output
+
+    return AgentOutput.model_validate(
+        consume_projection_for_agent_output(projection, output, expected_consumer="positioning")
+    )

--- a/apps/analysis/agents/risk.py
+++ b/apps/analysis/agents/risk.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import ValidationError
 
 from apps.analysis.agents.schemas import AgentBias, AgentOutput, AgentStatus, DataCategory
+
+if TYPE_CHECKING:
+    from apps.analysis.context_bundle import ConsumerProjection
 
 _AGENT_NAME = "risk_agent"
 _MODULE = "risk"
@@ -38,6 +42,28 @@ _BIAS_ALIASES = {
 
 
 def analyze_risk(
+    snapshot: dict[str, Any],
+    *,
+    macro_output: AgentOutput | dict[str, Any] | None,
+    options_output: AgentOutput | dict[str, Any] | None,
+    created_at: datetime | None = None,
+    context_projection: "ConsumerProjection | Mapping[str, Any] | None" = None,
+) -> AgentOutput:
+    from apps.analysis.context_bundle import validate_consumer_projection
+
+    projection = validate_consumer_projection(context_projection, "risk") if context_projection is not None else None
+    return _bind_context_projection(
+        _analyze_risk(
+            snapshot,
+            macro_output=macro_output,
+            options_output=options_output,
+            created_at=created_at,
+        ),
+        projection,
+    )
+
+
+def _analyze_risk(
     snapshot: dict[str, Any],
     *,
     macro_output: AgentOutput | dict[str, Any] | None,
@@ -196,7 +222,9 @@ def _input_snapshot_ids(
     return ids
 
 
-def _source_refs(snapshot: dict[str, Any], macro: AgentOutput | None, options: AgentOutput | None) -> list[dict[str, Any]]:
+def _source_refs(
+    snapshot: dict[str, Any], macro: AgentOutput | None, options: AgentOutput | None
+) -> list[dict[str, Any]]:
     refs: list[dict[str, Any]] = []
     snapshot_refs = snapshot.get("source_refs")
     if isinstance(snapshot_refs, list):
@@ -308,3 +336,11 @@ def _summary(bias: AgentBias, status: AgentStatus, confidence: float) -> str:
 
 def _clamp(value: float, lower: float, upper: float) -> float:
     return max(lower, min(upper, round(value, 2)))
+
+
+def _bind_context_projection(output: AgentOutput, projection: "ConsumerProjection | None") -> AgentOutput:
+    if projection is None:
+        return output
+    from apps.analysis.context_bundle import consume_projection_for_agent_output
+
+    return AgentOutput.model_validate(consume_projection_for_agent_output(projection, output, expected_consumer="risk"))

--- a/apps/analysis/agents/technical.py
+++ b/apps/analysis/agents/technical.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from apps.analysis.agents.schemas import AgentBias, AgentOutput, AgentStatus, DataCategory
+
+if TYPE_CHECKING:
+    from apps.analysis.context_bundle import ConsumerProjection
 
 _AGENT_NAME = "technical_agent"
 _MODULE = "technical"
@@ -11,8 +15,20 @@ _VERSION = "1.0"
 
 
 def analyze_technical(
-    snapshot: dict[str, Any], *, created_at: datetime | None = None
+    snapshot: dict[str, Any],
+    *,
+    created_at: datetime | None = None,
+    context_projection: "ConsumerProjection | Mapping[str, Any] | None" = None,
 ) -> AgentOutput:
+    from apps.analysis.context_bundle import validate_consumer_projection
+
+    projection = (
+        validate_consumer_projection(context_projection, "technical") if context_projection is not None else None
+    )
+    return _bind_context_projection(_analyze_technical(snapshot, created_at=created_at), projection)
+
+
+def _analyze_technical(snapshot: dict[str, Any], *, created_at: datetime | None = None) -> AgentOutput:
     """Analyze the technical snapshot section of an already-loaded analysis snapshot.
 
     Works on ``snapshot["technical"]`` — a dict with ``status`` and
@@ -128,13 +144,7 @@ def analyze_technical(
         confidence -= 0.08
 
     # Gold cross: price above both MAs is extra bullish
-    if (
-        ma20 is not None
-        and ma50 is not None
-        and price is not None
-        and price > ma20
-        and price > ma50
-    ):
+    if ma20 is not None and ma50 is not None and price is not None and price > ma20 and price > ma50:
         score += 1
         key_findings.append("Gold cross pattern: price above both MA20 and MA50 — bullish reinforcement.")
 
@@ -181,9 +191,7 @@ def analyze_technical(
 
     # ── Data quality: approximations reduce confidence ────────────────────
     if ma20 is not None or ma50 is not None:
-        key_findings.append(
-            "Note: MAs are approximated from Perf.1M/Perf.3M; precise levels require historical data."
-        )
+        key_findings.append("Note: MAs are approximated from Perf.1M/Perf.3M; precise levels require historical data.")
         confidence -= 0.03
 
     # ── Final bias and confidence ──────────────────────────────────────────
@@ -260,12 +268,19 @@ def _bias_from_score(score: int) -> AgentBias:
 
 def _summary(bias: AgentBias, status: AgentStatus, confidence: float) -> str:
     if status is AgentStatus.PARTIAL:
-        return (
-            f"技术面只读视图 {bias.value}（输入不完整）；"
-            f"confidence {confidence:.2f}."
-        )
+        return f"技术面只读视图 {bias.value}（输入不完整）；confidence {confidence:.2f}."
     return f"技术面只读视图 {bias.value}；确信度 {confidence:.2f}。"
 
 
 def _clamp(value: float, lower: float, upper: float) -> float:
     return max(lower, min(upper, round(value, 2)))
+
+
+def _bind_context_projection(output: AgentOutput, projection: "ConsumerProjection | None") -> AgentOutput:
+    if projection is None:
+        return output
+    from apps.analysis.context_bundle import consume_projection_for_agent_output
+
+    return AgentOutput.model_validate(
+        consume_projection_for_agent_output(projection, output, expected_consumer="technical")
+    )

--- a/apps/analysis/context_bundle/__init__.py
+++ b/apps/analysis/context_bundle/__init__.py
@@ -14,16 +14,38 @@ from .schemas import (
     EvidenceCursor,
     EvidenceItem,
 )
+from .projection import (
+    CONSUMER_PROJECTION_SCHEMA_VERSION,
+    CONSUMER_EVIDENCE_TYPES,
+    ConsumerProjection,
+    bind_projection_to_agent_output,
+    build_consumer_projection,
+    consume_projection_for_agent_output,
+    consumer_projection_payload,
+    consumer_projection_summary,
+    project_context_bundle,
+    validate_consumer_projection,
+)
 
 __all__ = [
     "CONTEXT_BUNDLE_SCHEMA_VERSION",
+    "CONSUMER_EVIDENCE_TYPES",
+    "CONSUMER_PROJECTION_SCHEMA_VERSION",
     "LEGACY_CONTEXT_BUNDLE_SCHEMA_VERSION",
     "SCOPED_CONTEXT_BUNDLE_SCHEMA_VERSION",
     "AnalysisContextBundle",
     "ContextBlock",
     "ContextBundleBudgetExceeded",
+    "ConsumerProjection",
     "EvidenceCursor",
     "EvidenceItem",
     "assemble_context_bundle",
+    "bind_projection_to_agent_output",
+    "build_consumer_projection",
+    "consume_projection_for_agent_output",
+    "consumer_projection_payload",
+    "consumer_projection_summary",
+    "project_context_bundle",
     "select_incremental_evidence",
+    "validate_consumer_projection",
 ]

--- a/apps/analysis/context_bundle/projection.py
+++ b/apps/analysis/context_bundle/projection.py
@@ -1,0 +1,413 @@
+"""Typed, replay-safe consumer projections for ContextBundle v3.
+
+This module is intentionally pure: it does not select data, invoke agents, or
+claim that a consumer used the projection.  It only creates and validates the
+explicit hand-off boundary that callers may pass to a domain consumer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from apps.analysis.context_bundle.schemas import (
+    CONTEXT_BUNDLE_SCHEMA_VERSION,
+    AnalysisContextBundle,
+)
+from apps.analysis.evidence_delta.schemas import EvidenceDeltaDecision
+from apps.analysis.state.hashing import content_hash
+
+
+CONSUMER_PROJECTION_SCHEMA_VERSION = "analysis_context_consumer_projection.v1"
+ConsumerName = Literal[
+    "macro",
+    "options",
+    "risk",
+    "technical",
+    "positioning",
+    "news",
+    "market_odds",
+    "fact_review",
+    "coordinator",
+]
+
+# This is a consumer relevance allowlist, not a claim about any provider or
+# source.  In particular, ``news`` means retained material-event evidence; it
+# does not grant or emulate a Jin10 integration.
+CONSUMER_EVIDENCE_TYPES: dict[str, frozenset[str]] = {
+    "macro": frozenset({"macro_metric", "material_event"}),
+    "options": frozenset({"options_regime", "key_level_event"}),
+    "risk": frozenset({"macro_metric", "key_level_event", "options_regime", "material_event"}),
+    "technical": frozenset({"key_level_event"}),
+    "positioning": frozenset({"material_event"}),
+    "news": frozenset({"material_event"}),
+    "market_odds": frozenset({"material_event"}),
+    "fact_review": frozenset({"macro_metric", "key_level_event", "options_regime", "material_event"}),
+    "coordinator": frozenset({"macro_metric", "key_level_event", "options_regime", "material_event"}),
+}
+
+
+class _StrictFrozenModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, allow_inf_nan=False)
+
+
+class ConsumerProjectionIdentity(_StrictFrozenModel):
+    bundle_id: str = Field(min_length=1)
+    content_hash: str = Field(min_length=64, max_length=64)
+    run_id: str = Field(min_length=1)
+    asset: str = Field(min_length=1)
+    canonical_state_id: str = Field(min_length=1)
+    state_scope: Literal["intraday", "daily_close", "weekly_fundamental"]
+    source_refs: list[dict[str, Any]] = Field(default_factory=list)
+
+    @field_validator("content_hash")
+    @classmethod
+    def _hash_is_sha256(cls, value: str) -> str:
+        value = value.strip().lower()
+        if len(value) != 64 or any(char not in "0123456789abcdef" for char in value):
+            raise ValueError("content_hash must be a lowercase SHA-256 digest")
+        return value
+
+
+class ConsumerProjection(_StrictFrozenModel):
+    """A filtered, independently re-validatable ContextBundle v3 hand-off."""
+
+    schema_version: Literal["analysis_context_consumer_projection.v1"] = CONSUMER_PROJECTION_SCHEMA_VERSION
+    consumer: ConsumerName
+    projection_hash: str = Field(min_length=64, max_length=64)
+    identity_payload: ConsumerProjectionIdentity
+    canonical_state: dict[str, Any]
+    retained_evidence: list[dict[str, Any]] = Field(default_factory=list)
+    retained_source_refs: list[dict[str, Any]] = Field(default_factory=list)
+    accepted_facts: list[dict[str, Any]] = Field(default_factory=list)
+    decision: EvidenceDeltaDecision
+    decision_id: str = Field(min_length=1)
+    selection_decisions: list[dict[str, Any]] = Field(default_factory=list)
+    selection_trace: dict[str, Any]
+    freshness: dict[str, Any] = Field(default_factory=dict)
+    deferred_queue: list[dict[str, Any]] = Field(default_factory=list)
+    processed_above_frontier: dict[str, list[dict[str, Any]]] = Field(default_factory=dict)
+    freshness_sla_seconds: dict[str, int] = Field(default_factory=dict)
+    default_freshness_sla_seconds: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def _validate_projection(self) -> "ConsumerProjection":
+        identity = self.identity_payload
+        if self.decision_id != self.decision.decision_id:
+            raise ValueError("decision_id does not match decision")
+        if (
+            self.decision.asset != identity.asset
+            or self.decision.state_scope != identity.state_scope
+            or self.decision.canonical_state_id != identity.canonical_state_id
+        ):
+            raise ValueError("decision identity does not match projection identity")
+        if (
+            self.canonical_state.get("asset") != identity.asset
+            or self.canonical_state.get("state_scope") != identity.state_scope
+        ):
+            raise ValueError("canonical state does not match projection identity")
+        allowed = CONSUMER_EVIDENCE_TYPES[self.consumer]
+        evidence_keys: set[tuple[str, str]] = set()
+        for item in self.retained_evidence:
+            key = _evidence_key(item)
+            if key in evidence_keys:
+                raise ValueError("retained evidence must be unique by source and evidence_id")
+            evidence_keys.add(key)
+            if _evidence_type(item) not in allowed:
+                raise ValueError("retained evidence is not allowed for consumer")
+        for fact in self.accepted_facts:
+            if fact.get("quality_status") != "accepted":
+                raise ValueError("projection may carry accepted facts only")
+        ref_keys = {_source_ref_key(item) for item in self.retained_source_refs}
+        if len(ref_keys) != len(self.retained_source_refs):
+            raise ValueError("retained source refs must be source-aware and unique")
+        if {_source_ref_key(item) for item in identity.source_refs} != ref_keys:
+            raise ValueError("identity source refs do not match retained source refs")
+        expected_hash = compute_consumer_projection_hash(self)
+        if self.projection_hash != expected_hash:
+            raise ValueError("projection_hash does not match projection content")
+        return self
+
+
+def project_context_bundle(
+    bundle: AnalysisContextBundle | Mapping[str, Any], *, consumer: ConsumerName
+) -> ConsumerProjection:
+    """Build a consumer-specific projection from an authentic v3 bundle.
+
+    Typed input is dumped and model-validated again so a caller cannot bypass
+    nested validation with ``model_copy`` or mutated mutable sub-values.
+    """
+
+    if consumer not in CONSUMER_EVIDENCE_TYPES:
+        raise ValueError(f"unsupported context bundle consumer: {consumer}")
+    normalized = _revalidate_bundle(bundle)
+    canonical_state = _block_payload(normalized, "canonical_state")
+    # A v3 daily-close Bundle may legitimately carry the backward-compatible
+    # AnalysisState v1 document, whose payload predates scoped state. The
+    # projection boundary makes the enclosing v3 scope explicit for consumers.
+    canonical_state.setdefault("state_scope", normalized.state_scope)
+    delta_evidence = _block_payload(normalized, "delta_evidence")
+    facts = _block_payload(normalized, "facts")
+    allowed = CONSUMER_EVIDENCE_TYPES[consumer]
+    retained_evidence = [item for item in delta_evidence if _evidence_type(item) in allowed]
+    accepted_facts = [item for item in facts if isinstance(item, dict) and item.get("quality_status") == "accepted"]
+    retained_source_refs = _source_aware_refs(retained_evidence, accepted_facts)
+    identity = {
+        "bundle_id": normalized.bundle_id,
+        "content_hash": normalized.content_hash,
+        "run_id": normalized.run_id,
+        "asset": normalized.asset,
+        "canonical_state_id": normalized.canonical_state_id,
+        "state_scope": normalized.state_scope,
+        "source_refs": retained_source_refs,
+    }
+    payload: dict[str, Any] = {
+        "schema_version": CONSUMER_PROJECTION_SCHEMA_VERSION,
+        "consumer": consumer,
+        "identity_payload": identity,
+        "canonical_state": canonical_state,
+        "retained_evidence": retained_evidence,
+        "retained_source_refs": retained_source_refs,
+        "accepted_facts": accepted_facts,
+        "decision": normalized.evidence_delta_decision,
+        "decision_id": normalized.evidence_delta_decision["decision_id"],
+        "selection_decisions": normalized.selection_decisions,
+        "selection_trace": normalized.selection_trace,
+        "freshness": normalized.freshness,
+        "deferred_queue": normalized.deferred_queue,
+        "processed_above_frontier": normalized.processed_above_frontier,
+        "freshness_sla_seconds": normalized.freshness_sla_seconds,
+        "default_freshness_sla_seconds": normalized.default_freshness_sla_seconds,
+    }
+    payload["projection_hash"] = compute_consumer_projection_hash(payload)
+    return ConsumerProjection.model_validate(payload)
+
+
+# A short alias makes the intended boundary easy to discover for future callers.
+build_consumer_projection = project_context_bundle
+
+
+def validate_consumer_projection(
+    projection: ConsumerProjection | Mapping[str, Any], expected_consumer: ConsumerName
+) -> ConsumerProjection:
+    """Revalidate an untrusted projection and bind it to one named consumer."""
+
+    if expected_consumer not in CONSUMER_EVIDENCE_TYPES:
+        raise ValueError(f"unsupported context bundle consumer: {expected_consumer}")
+    payload = projection.model_dump(mode="json") if isinstance(projection, BaseModel) else dict(projection)
+    validated = ConsumerProjection.model_validate(payload)
+    if validated.consumer != expected_consumer:
+        raise ValueError("projection consumer does not match expected consumer")
+    return validated
+
+
+def bind_projection_to_agent_output(
+    projection: ConsumerProjection | Mapping[str, Any],
+    agent_output: Mapping[str, Any] | BaseModel,
+    *,
+    expected_consumer: ConsumerName | None = None,
+) -> Mapping[str, Any] | BaseModel:
+    """Attach exact bundle identity to an output without claiming consumption.
+
+    The caller remains responsible for actually using the projection.  This
+    helper only makes that caller-owned hand-off auditable in all three output
+    lineage locations.
+    """
+
+    validated = validate_consumer_projection(projection, expected_consumer or _projection_consumer(projection))
+    values = agent_output.model_dump(mode="json") if isinstance(agent_output, BaseModel) else dict(agent_output)
+    values = deepcopy(values)
+    identity = validated.identity_payload.model_dump(mode="json")
+    input_ids = dict(values.get("input_snapshot_ids") or {})
+    input_ids["context_bundle_id"] = identity["bundle_id"]
+    input_ids["context_bundle_hash"] = identity["content_hash"]
+    input_ids["context_bundle_run_id"] = identity["run_id"]
+    input_ids["context_bundle_projection_hash"] = validated.projection_hash
+    input_ids["canonical_state_id"] = identity["canonical_state_id"]
+    input_ids["state_scope"] = identity["state_scope"]
+    input_ids["retained_evidence_ids"] = _retained_evidence_identities(validated)
+    input_ids["evidence_delta_decision_id"] = validated.decision_id
+    values["input_snapshot_ids"] = input_ids
+    input_payload = dict(values.get("input_payload") or {})
+    input_payload["context_bundle_identity"] = identity
+    input_payload["context_bundle_consumer"] = validated.consumer
+    values["input_payload"] = input_payload
+    refs = list(values.get("source_refs") or [])
+    lineage_ref = {"source": "analysis_context_bundle", "identity": identity}
+    if lineage_ref not in refs:
+        refs.append(lineage_ref)
+    values["source_refs"] = refs
+    if isinstance(agent_output, BaseModel):
+        return type(agent_output).model_validate(values)
+    return values
+
+
+def consumer_projection_payload(
+    projection: ConsumerProjection | Mapping[str, Any],
+    *,
+    expected_consumer: ConsumerName,
+) -> dict[str, Any]:
+    """Return the bounded typed content a consumer actually receives."""
+
+    return validate_consumer_projection(projection, expected_consumer).model_dump(mode="json")
+
+
+def consumer_projection_summary(projection: ConsumerProjection) -> dict[str, Any]:
+    return {
+        "decision_id": projection.decision_id,
+        "decision_action": projection.decision.recommended_action.value,
+        "state_scope": projection.identity_payload.state_scope,
+        "retained_evidence_count": len(projection.retained_evidence),
+        "retained_refs": list(projection.retained_source_refs),
+        "accepted_fact_count": len(projection.accepted_facts),
+        "accepted_fact_refs": [
+            {
+                "source": item.get("source"),
+                "figure_fact_id": item.get("figure_fact_id"),
+            }
+            for item in projection.accepted_facts
+        ],
+    }
+
+
+def consume_projection_for_agent_output(
+    projection: ConsumerProjection | Mapping[str, Any],
+    agent_output: Mapping[str, Any] | BaseModel,
+    *,
+    expected_consumer: ConsumerName,
+) -> Mapping[str, Any] | BaseModel:
+    """Apply one typed projection as bounded analysis context and safety policy."""
+
+    validated = validate_consumer_projection(projection, expected_consumer)
+    values = agent_output.model_dump(mode="json") if isinstance(agent_output, BaseModel) else dict(agent_output)
+    values = deepcopy(values)
+    input_payload = dict(values.get("input_payload") or {})
+    input_payload["context_bundle_summary"] = consumer_projection_summary(validated)
+    input_payload["context_bundle_projection"] = validated.model_dump(mode="json")
+    values["input_payload"] = input_payload
+
+    retained_refs = [dict(item) for item in validated.retained_source_refs]
+    evidence_refs = list(values.get("evidence_refs") or [])
+    for ref in retained_refs:
+        if ref not in evidence_refs:
+            evidence_refs.append(ref)
+    values["evidence_refs"] = evidence_refs
+
+    if validated.decision.recommended_action.value == "manual_review":
+        if values.get("status") == "success":
+            values["status"] = "partial"
+        values["confidence"] = min(float(values.get("confidence") or 0.0), 0.35)
+        risk_points = list(values.get("risk_points") or [])
+        reason = "ContextBundle evidence delta requires manual review."
+        if reason not in risk_points:
+            risk_points.append(reason)
+        values["risk_points"] = risk_points
+        invalid_conditions = list(values.get("invalid_conditions") or [])
+        invalid = "Directional promotion is blocked until the ContextBundle review is resolved."
+        if invalid not in invalid_conditions:
+            invalid_conditions.append(invalid)
+        values["invalid_conditions"] = invalid_conditions
+
+    bound = bind_projection_to_agent_output(
+        validated,
+        values,
+        expected_consumer=expected_consumer,
+    )
+    if isinstance(agent_output, BaseModel):
+        return type(agent_output).model_validate(bound)
+    return bound
+
+
+def compute_consumer_projection_hash(value: ConsumerProjection | Mapping[str, Any]) -> str:
+    payload = value.model_dump(mode="json") if isinstance(value, BaseModel) else dict(value)
+    payload.pop("projection_hash", None)
+    return content_hash(payload, exclude_keys=frozenset())
+
+
+def _revalidate_bundle(bundle: AnalysisContextBundle | Mapping[str, Any]) -> AnalysisContextBundle:
+    payload = bundle.model_dump(mode="json") if isinstance(bundle, BaseModel) else dict(bundle)
+    validated = AnalysisContextBundle.model_validate(payload)
+    if validated.schema_version != CONTEXT_BUNDLE_SCHEMA_VERSION:
+        raise ValueError("consumer projection requires analysis_context_bundle.v3")
+    canonical_state = _block_payload(validated, "canonical_state")
+    canonical_scope = canonical_state.get("state_scope")
+    if canonical_state.get("asset") != validated.asset or (
+        canonical_scope is not None and canonical_scope != validated.state_scope
+    ):
+        raise ValueError("canonical state identity does not match bundle")
+    return validated
+
+
+def _block_payload(bundle: AnalysisContextBundle, name: str) -> Any:
+    block = next((item for item in bundle.blocks if item.name == name), None)
+    if block is None:
+        raise ValueError(f"bundle is missing {name} block")
+    return deepcopy(block.payload)
+
+
+def _evidence_type(item: Any) -> str:
+    if not isinstance(item, dict) or not isinstance(item.get("payload"), dict):
+        raise ValueError("retained evidence must contain a payload")
+    evidence_type = item["payload"].get("evidence_type")
+    if not isinstance(evidence_type, str) or not evidence_type:
+        raise ValueError("retained evidence payload requires evidence_type")
+    return evidence_type
+
+
+def _evidence_key(item: Any) -> tuple[str, str]:
+    if not isinstance(item, dict):
+        raise ValueError("retained evidence must be an object")
+    source, evidence_id = item.get("source"), item.get("evidence_id")
+    if not isinstance(source, str) or not source.strip() or not isinstance(evidence_id, str) or not evidence_id.strip():
+        raise ValueError("retained evidence requires source and evidence_id")
+    return source, evidence_id
+
+
+def _source_aware_refs(evidence: list[dict[str, Any]], facts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    refs: list[dict[str, Any]] = []
+    for item in [*evidence, *facts]:
+        source = item.get("source")
+        evidence_id = item.get("evidence_id") or item.get("figure_fact_id")
+        if (
+            not isinstance(source, str)
+            or not source.strip()
+            or not isinstance(evidence_id, str)
+            or not evidence_id.strip()
+        ):
+            raise ValueError("retained evidence/fact requires source-aware identity")
+        ref = dict(item.get("source_ref") or {})
+        ref["source"] = source
+        ref["evidence_id"] = evidence_id
+        refs.append(ref)
+    refs.sort(key=lambda item: _source_ref_key(item))
+    if len({_source_ref_key(item) for item in refs}) != len(refs):
+        raise ValueError("retained source references must be unique by source and evidence_id")
+    return refs
+
+
+def _source_ref_key(item: Any) -> tuple[str, str]:
+    if not isinstance(item, dict):
+        raise ValueError("source ref must be an object")
+    source, evidence_id = item.get("source"), item.get("evidence_id")
+    if not isinstance(source, str) or not source.strip() or not isinstance(evidence_id, str) or not evidence_id.strip():
+        raise ValueError("source refs require source and evidence_id")
+    return source, evidence_id
+
+
+def _projection_consumer(projection: ConsumerProjection | Mapping[str, Any]) -> ConsumerName:
+    consumer = projection.consumer if isinstance(projection, ConsumerProjection) else projection.get("consumer")
+    if consumer not in CONSUMER_EVIDENCE_TYPES:
+        raise ValueError("projection has unsupported consumer")
+    return consumer
+
+
+def _retained_evidence_identities(projection: ConsumerProjection) -> list[dict[str, str]]:
+    """Return source-aware evidence identity; IDs alone are not globally unique."""
+
+    return [
+        {"source": source, "evidence_id": evidence_id}
+        for source, evidence_id in sorted(_evidence_key(item) for item in projection.retained_evidence)
+    ]

--- a/apps/runtime/artifact_registry.py
+++ b/apps/runtime/artifact_registry.py
@@ -54,6 +54,9 @@ _ARTIFACT_QUALITY_METADATA_KEYS = frozenset(
         "output_mode",
     }
 )
+_CONTEXT_BUNDLE_ARTIFACT_FAMILY = "analysis_context_bundle"
+_CONTEXT_BUNDLE_SCHEMA_VERSION = "analysis_context_bundle.v3"
+_CONTEXT_BUNDLE_SELECTOR_LIMIT = 128
 
 
 def _artifact_run(db: Session, *, step: TaskStep) -> TaskRun | None:
@@ -88,8 +91,7 @@ def _validate_run_artifact_lineage(*, run_id: str, step: TaskStep) -> uuid.UUID:
 
     if step.task_run_id != run_uuid:
         raise ValueError(
-            "run artifact lineage conflict: "
-            f"run_id={run_id} does not match step.task_run_id={step.task_run_id}"
+            f"run artifact lineage conflict: run_id={run_id} does not match step.task_run_id={step.task_run_id}"
         )
     return run_uuid
 
@@ -155,7 +157,9 @@ def _validate_artifact_snapshot_lineage(
         return
 
     if artifact.artifact_type in _SNAPSHOT_BOUND_ARTIFACT_TYPES:
-        artifact_snapshot = input_snapshot_ids.get("analysis_snapshot") if isinstance(input_snapshot_ids, dict) else None
+        artifact_snapshot = (
+            input_snapshot_ids.get("analysis_snapshot") if isinstance(input_snapshot_ids, dict) else None
+        )
         if isinstance(artifact_snapshot, str) and artifact_snapshot and artifact_snapshot != run.snapshot_id:
             raise ValueError(
                 "run artifact lineage conflict: "
@@ -232,6 +236,7 @@ def register_artifact(
     source_refs: list[dict[str, Any]] | None = None,
     input_snapshot_ids: dict[str, Any] | None = None,
     metadata: dict[str, Any] | None = None,
+    registry_artifact_id: uuid.UUID | None = None,
     require_canonical_path: bool = True,
     storage: LocalFileSystemArtifactStorage | None = None,
 ) -> RunArtifact | None:
@@ -244,7 +249,9 @@ def register_artifact(
     if not _run_artifacts_available(db):
         return None
 
-    run_uuid = _validate_run_artifact_lineage(run_id=run_id, step=step) if step is not None else _coerce_run_uuid(run_id)
+    run_uuid = (
+        _validate_run_artifact_lineage(run_id=run_id, step=step) if step is not None else _coerce_run_uuid(run_id)
+    )
     _validate_artifact_source_refs(source_refs)
     run = _artifact_run(db, step=step) if step is not None else _artifact_run_by_id(db, run_id=run_uuid)
     if run is None:
@@ -282,6 +289,7 @@ def register_artifact(
         source_refs=source_refs,
         input_snapshot_ids=input_snapshot_ids,
         metadata=metadata,
+        registry_artifact_id=registry_artifact_id,
         storage=effective_storage,
         require_canonical_path=require_canonical_path,
         flush=True,
@@ -335,6 +343,7 @@ def register_step_artifacts(
             source_refs=source_refs,
             input_snapshot_ids=input_snapshot_ids,
             metadata=_artifact_quality_metadata(raw_artifact),
+            registry_artifact_id=None,
             storage=storage,
             require_canonical_path=False,
             flush=False,
@@ -366,6 +375,219 @@ def list_run_artifacts(db: Session, run_id: str) -> list[ArtifactRef]:
         )
         for row in rows
     ]
+
+
+def select_context_bundle_artifact_for_run(
+    db: Session,
+    *,
+    run_id: str,
+    storage_root: str | Path,
+) -> dict[str, Any] | None:
+    """Return the one validated ContextBundle descriptor registered for ``run_id``.
+
+    The registry row is only an index.  This read boundary revalidates its
+    metadata, immutable file hash, and Bundle payload before returning an
+    explicit recovery descriptor.  Multiple Bundle rows for one run are an
+    authority conflict, never a "latest" choice.
+    """
+
+    if not _run_artifacts_available(db):
+        return None
+    run_uuid = _coerce_run_uuid(run_id)
+    rows = (
+        db.query(RunArtifact)
+        .filter(RunArtifact.run_id == run_uuid)
+        .order_by(RunArtifact.created_at.asc(), RunArtifact.artifact_id.asc())
+        .all()
+    )
+    candidates = [row for row in rows if _is_context_bundle_row(row)]
+    if not candidates:
+        return None
+    if len(candidates) != 1:
+        raise ValueError("TaskRun has ambiguous ContextBundle registry artifacts")
+    return _validated_context_bundle_descriptor(
+        candidates[0],
+        storage_root=storage_root,
+        expected_run_id=run_id,
+    )
+
+
+def select_previous_context_bundle_artifact(
+    db: Session,
+    *,
+    current_run_id: str,
+    asset: str,
+    state_scope: str,
+    canonical_state_id: str,
+    cutoff_at: datetime | None,
+    storage_root: str | Path,
+) -> dict[str, Any] | None:
+    """Return the latest validated prior Bundle for one canonical-state lineage.
+
+    Portable SQL JSON predicates first restrict the scan to the requested
+    registry lineage. The bounded matching-candidate scan is stable; exceeding
+    it fails closed rather than silently selecting from an incomplete set.
+    """
+
+    if not _run_artifacts_available(db):
+        return None
+    current_run_uuid = _coerce_run_uuid(current_run_id)
+    normalized_asset = str(asset).strip()
+    normalized_scope = str(state_scope).strip()
+    normalized_state_id = str(canonical_state_id).strip()
+    if not all((normalized_asset, normalized_scope, normalized_state_id)):
+        raise ValueError("ContextBundle selector lineage is incomplete")
+    if cutoff_at is not None and (cutoff_at.tzinfo is None or cutoff_at.utcoffset() is None):
+        raise ValueError("ContextBundle selector cutoff_at must be timezone-aware")
+
+    rows = (
+        db.query(RunArtifact)
+        .filter(
+            RunArtifact.artifact_type == ArtifactType.structured_json.value,
+            RunArtifact.run_id != current_run_uuid,
+            RunArtifact.artifact_metadata["artifact_family"].as_string() == _CONTEXT_BUNDLE_ARTIFACT_FAMILY,
+            RunArtifact.artifact_metadata["asset"].as_string() == normalized_asset,
+            RunArtifact.artifact_metadata["state_scope"].as_string() == normalized_scope,
+            RunArtifact.artifact_metadata["canonical_state_id"].as_string() == normalized_state_id,
+        )
+        .order_by(RunArtifact.created_at.desc(), RunArtifact.artifact_id.desc())
+        .limit(_CONTEXT_BUNDLE_SELECTOR_LIMIT + 1)
+        .all()
+    )
+    if len(rows) > _CONTEXT_BUNDLE_SELECTOR_LIMIT:
+        raise ValueError("ContextBundle selector candidate limit exceeded")
+
+    candidates: list[tuple[datetime, datetime, dict[str, Any]]] = []
+    for row in rows:
+        if not _is_context_bundle_row(row):  # pragma: no cover - SQL predicate
+            continue
+        metadata = row.artifact_metadata
+        if not isinstance(metadata, dict):  # guarded by _is_context_bundle_row
+            continue
+        descriptor = _validated_context_bundle_descriptor(
+            row,
+            storage_root=storage_root,
+            expected_asset=normalized_asset,
+            expected_state_scope=normalized_scope,
+            expected_canonical_state_id=normalized_state_id,
+        )
+        bundle_cutoff_at = _context_bundle_cutoff_at(
+            descriptor,
+            storage_root=storage_root,
+        )
+        if cutoff_at is not None and bundle_cutoff_at > cutoff_at:
+            continue
+        created_at = row.created_at
+        if created_at.tzinfo is None or created_at.utcoffset() is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        candidates.append((bundle_cutoff_at, created_at.astimezone(timezone.utc), descriptor))
+
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: (item[0], item[1], item[2]["file_path"]), reverse=True)
+    latest = candidates[0]
+    if len(candidates) > 1 and candidates[1][:2] == latest[:2]:
+        raise ValueError("ContextBundle selector latest candidate is ambiguous")
+    return latest[2]
+
+
+def _is_context_bundle_row(row: RunArtifact) -> bool:
+    metadata = row.artifact_metadata
+    return isinstance(metadata, dict) and metadata.get("artifact_family") == _CONTEXT_BUNDLE_ARTIFACT_FAMILY
+
+
+def _validated_context_bundle_descriptor(
+    row: RunArtifact,
+    *,
+    storage_root: str | Path,
+    expected_run_id: str | None = None,
+    expected_asset: str | None = None,
+    expected_state_scope: str | None = None,
+    expected_canonical_state_id: str | None = None,
+) -> dict[str, Any]:
+    """Revalidate one registry row and reconstruct its recovery descriptor."""
+
+    from apps.output.context_bundle import load_context_bundle
+
+    metadata = row.artifact_metadata
+    if not isinstance(metadata, dict) or metadata.get("artifact_family") != _CONTEXT_BUNDLE_ARTIFACT_FAMILY:
+        raise ValueError("ContextBundle registry artifact family is invalid")
+    required = {
+        "bundle_id": str(metadata.get("bundle_id") or "").strip(),
+        "content_hash": str(metadata.get("content_hash") or "").strip(),
+        "run_id": str(metadata.get("run_id") or "").strip(),
+        "canonical_state_id": str(metadata.get("canonical_state_id") or "").strip(),
+        "schema_version": str(metadata.get("schema_version") or "").strip(),
+        "asset": str(metadata.get("asset") or "").strip(),
+        "state_scope": str(metadata.get("state_scope") or "").strip(),
+    }
+    if any(not value for value in required.values()) or not _is_lowercase_sha256(required["content_hash"]):
+        raise ValueError("ContextBundle registry metadata identity is incomplete")
+    if required["schema_version"] != _CONTEXT_BUNDLE_SCHEMA_VERSION:
+        raise ValueError("ContextBundle registry schema version is unsupported")
+    if required["run_id"] != str(row.run_id):
+        raise ValueError("ContextBundle registry metadata run_id conflicts with row")
+    if expected_run_id is not None and required["run_id"] != str(expected_run_id):
+        raise ValueError("ContextBundle registry run_id does not match selector")
+    for key, expected in (
+        ("asset", expected_asset),
+        ("state_scope", expected_state_scope),
+        ("canonical_state_id", expected_canonical_state_id),
+    ):
+        if expected is not None and required[key] != expected:
+            raise ValueError(f"ContextBundle registry {key} does not match selector")
+    if _artifact_type_value(row.artifact_type) != ArtifactType.structured_json.value:
+        raise ValueError("ContextBundle registry artifact_type is invalid")
+    file_path = str(row.file_path or "").strip()
+    file_sha256 = str(row.sha256 or "").strip()
+    if not file_path or not _is_lowercase_sha256(file_sha256):
+        raise ValueError("ContextBundle registry file identity is incomplete")
+    storage = LocalFileSystemArtifactStorage(root=Path(storage_root).resolve())
+    actual_file_sha256 = storage.compute_sha256(file_path)
+    if actual_file_sha256 is None or actual_file_sha256 != file_sha256:
+        raise ValueError("ContextBundle registry file hash mismatch")
+    bundle = load_context_bundle(storage_root=storage_root, storage_relative_path=file_path)
+    if (
+        bundle.schema_version != _CONTEXT_BUNDLE_SCHEMA_VERSION
+        or bundle.bundle_id != required["bundle_id"]
+        or bundle.content_hash != required["content_hash"]
+        or bundle.run_id != required["run_id"]
+        or bundle.asset != required["asset"]
+        or bundle.state_scope != required["state_scope"]
+        or bundle.canonical_state_id != required["canonical_state_id"]
+    ):
+        raise ValueError("ContextBundle registry payload identity conflicts with metadata")
+    return {
+        "artifact_id": required["bundle_id"],
+        "artifact_type": ArtifactType.structured_json.value,
+        "file_path": file_path,
+        "sha256": file_sha256,
+        "content_type": row.content_type or "application/json",
+        "source_refs": list(row.source_refs_data or []),
+        "metadata": dict(metadata),
+    }
+
+
+def _context_bundle_cutoff_at(
+    descriptor: dict[str, Any],
+    *,
+    storage_root: str | Path,
+) -> datetime:
+    from apps.output.context_bundle import load_context_bundle
+
+    bundle = load_context_bundle(
+        storage_root=storage_root,
+        storage_relative_path=str(descriptor["file_path"]),
+    )
+    return bundle.cutoff_at.astimezone(timezone.utc)
+
+
+def _is_lowercase_sha256(value: str) -> bool:
+    return len(value) == 64 and all(char in "0123456789abcdef" for char in value)
+
+
+def _artifact_type_value(value: Any) -> str:
+    return str(value.value) if isinstance(value, ArtifactType) else str(value)
 
 
 def _collect_artifacts(
@@ -415,11 +637,7 @@ def _collect_artifacts(
 
 
 def _artifact_quality_metadata(raw_artifact: dict[str, Any]) -> dict[str, Any] | None:
-    metadata = {
-        key: raw_artifact[key]
-        for key in _ARTIFACT_QUALITY_METADATA_KEYS
-        if key in raw_artifact
-    }
+    metadata = {key: raw_artifact[key] for key in _ARTIFACT_QUALITY_METADATA_KEYS if key in raw_artifact}
     nested = raw_artifact.get("metadata")
     if isinstance(nested, dict):
         for key in _ARTIFACT_QUALITY_METADATA_KEYS:
@@ -439,6 +657,7 @@ def _persist_run_artifact(
     source_refs: list[dict[str, Any]] | None,
     input_snapshot_ids: dict[str, Any] | None,
     metadata: dict[str, Any] | None,
+    registry_artifact_id: uuid.UUID | None,
     storage: LocalFileSystemArtifactStorage,
     require_canonical_path: bool,
     flush: bool,
@@ -462,6 +681,7 @@ def _persist_run_artifact(
         require_canonical_path=require_canonical_path,
     )
     row = RunArtifact(
+        artifact_id=registry_artifact_id or uuid.uuid4(),
         run_id=run_uuid,
         task_id=task_id,
         artifact_type=artifact.artifact_type,
@@ -558,8 +778,7 @@ def _extract_path_metadata(
     if path_run_id != str(run_id):
         if require_canonical_path:
             raise ValueError(
-                "canonical artifact path violation: "
-                f"path run_id={path_run_id} does not match registry run_id={run_id}"
+                f"canonical artifact path violation: path run_id={path_run_id} does not match registry run_id={run_id}"
             )
         return {
             "layer": layer,

--- a/apps/worker/artifact_registration.py
+++ b/apps/worker/artifact_registration.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
 
 import json
+import logging
+import uuid
+from contextlib import nullcontext
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from sqlalchemy import inspect
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session as DBSession
 
-from apps.runtime.artifact_registry import register_step_artifacts
+from apps.runtime.artifact_registry import register_artifact, register_step_artifacts
+from apps.runtime.artifact_storage import LocalFileSystemArtifactStorage
+from apps.output.context_bundle import load_context_bundle
+from database.models.execution import RunArtifact
+
+logger = logging.getLogger(__name__)
 
 _ARTIFACT_CONTENT_TYPES = {
     ".md": "text/markdown",
@@ -49,24 +59,43 @@ def register_composite_output_artifacts(
     steps: list[Any],
     composite_outputs: dict[str, Any],
     analysis_snapshot: dict[str, Any] | None = None,
+    storage_root: Path | None = None,
 ) -> None:
     report_step = next((step for step in steps if step.name == "report_render"), None)
     if report_step is None:
         return
 
+    bundle_descriptor = composite_outputs.get("context_bundle_registry_artifact")
+    if isinstance(bundle_descriptor, dict):
+        try:
+            transaction = db.begin_nested() if callable(getattr(db, "begin_nested", None)) else nullcontext()
+            with transaction:
+                row = register_context_bundle_artifact(
+                    db,
+                    run_id=run_id,
+                    step=report_step,
+                    descriptor=bundle_descriptor,
+                    storage_root=storage_root,
+                )
+            composite_outputs["context_bundle_registry_status"] = {
+                "status": "registered" if row is not None else "skipped_unavailable",
+                "bundle_id": (bundle_descriptor.get("metadata") or {}).get("bundle_id"),
+            }
+        except Exception as exc:
+            logger.exception("ContextBundle registry failed; continuing legacy report/card registration")
+            composite_outputs["context_bundle_registry_status"] = {
+                "status": "failed",
+                "bundle_id": (bundle_descriptor.get("metadata") or {}).get("bundle_id"),
+                "reason": f"{type(exc).__name__}:{str(exc)[:200]}",
+            }
+
     report_result = composite_outputs.get("report_result") if isinstance(composite_outputs, dict) else None
     card_result = composite_outputs.get("card_result") if isinstance(composite_outputs, dict) else None
     card = composite_outputs.get("strategy_card") if isinstance(composite_outputs, dict) else None
     report_agent_result = (
-        composite_outputs.get("report_render_agent_result")
-        if isinstance(composite_outputs, dict)
-        else None
+        composite_outputs.get("report_render_agent_result") if isinstance(composite_outputs, dict) else None
     )
-    agent_loop_decision = (
-        composite_outputs.get("agent_loop_decision")
-        if isinstance(composite_outputs, dict)
-        else None
-    )
+    agent_loop_decision = composite_outputs.get("agent_loop_decision") if isinstance(composite_outputs, dict) else None
     publish_allowed = bool(getattr(agent_loop_decision, "publish_allowed", False))
     output_mode = "accepted" if publish_allowed else "observe"
     report_artifact_label = "final_report" if publish_allowed else "observation_report"
@@ -145,6 +174,217 @@ def register_composite_output_artifacts(
     )
 
 
+def register_context_bundle_artifact(
+    db: DBSession,
+    *,
+    run_id: str,
+    step: Any,
+    descriptor: dict[str, Any],
+    storage_root: Path | None = None,
+) -> RunArtifact | None:
+    """Register one immutable ContextBundle identity for a TaskRun.
+
+    This writer is deliberately run-scoped.  Cross-run recovery must use the
+    read selectors in ``apps.runtime.artifact_registry`` instead of guessing a
+    registry row here.
+    """
+
+    if str(getattr(step, "task_run_id", "")) != str(run_id):
+        raise ValueError("context bundle registry run_id does not match step.task_run_id")
+
+    try:
+        bind = db.connection()
+    except Exception:
+        return None
+    if not inspect(bind).has_table("run_artifacts"):
+        return None
+
+    metadata = descriptor.get("metadata")
+    if not isinstance(metadata, dict) or metadata.get("artifact_family") != "analysis_context_bundle":
+        raise ValueError("context bundle registry descriptor has invalid metadata")
+    required = {
+        "bundle_id": str(descriptor.get("artifact_id") or "").strip(),
+        "content_hash": str(metadata.get("content_hash") or "").strip(),
+        "run_id": str(metadata.get("run_id") or "").strip(),
+        "canonical_state_id": str(metadata.get("canonical_state_id") or "").strip(),
+        "schema_version": str(metadata.get("schema_version") or "").strip(),
+        "asset": str(metadata.get("asset") or "").strip(),
+        "state_scope": str(metadata.get("state_scope") or "").strip(),
+    }
+    if (
+        any(not value for value in required.values())
+        or required["run_id"] != run_id
+        or not _is_lowercase_sha256(required["content_hash"])
+    ):
+        raise ValueError("context bundle registry descriptor identity is incomplete")
+    if required["schema_version"] != "analysis_context_bundle.v3":
+        raise ValueError("context bundle registry descriptor schema version is unsupported")
+    if str(descriptor.get("artifact_type") or "") != "structured_json":
+        raise ValueError("context bundle registry descriptor artifact type is invalid")
+    file_path = str(descriptor.get("file_path") or "").strip()
+    file_sha256 = str(descriptor.get("sha256") or "").strip()
+    if not file_path or not _is_lowercase_sha256(file_sha256):
+        raise ValueError("context bundle registry descriptor file identity is incomplete")
+    storage = LocalFileSystemArtifactStorage(root=Path(storage_root).resolve()) if storage_root else None
+    effective_storage = storage or LocalFileSystemArtifactStorage()
+    actual_file_sha256 = effective_storage.compute_sha256(file_path)
+    if actual_file_sha256 is None:
+        raise ValueError("context bundle registry artifact file does not exist")
+    if actual_file_sha256 != file_sha256:
+        raise ValueError("context bundle registry descriptor sha256 does not match file")
+    bundle = load_context_bundle(
+        storage_root=storage_root or effective_storage.root,
+        storage_relative_path=file_path,
+    )
+    if (
+        bundle.schema_version != required["schema_version"]
+        or bundle.bundle_id != required["bundle_id"]
+        or bundle.content_hash != required["content_hash"]
+        or bundle.run_id != required["run_id"]
+        or bundle.asset != required["asset"]
+        or bundle.state_scope != required["state_scope"]
+        or bundle.canonical_state_id != required["canonical_state_id"]
+    ):
+        raise ValueError("context bundle registry descriptor payload identity conflicts")
+
+    registry_row_id = uuid.uuid5(
+        uuid.NAMESPACE_URL,
+        f"finance-agent:run-context-bundle:{run_id}",
+    )
+    existing_rows = db.query(RunArtifact).filter(RunArtifact.run_id == step.task_run_id).all()
+    existing = [
+        row
+        for row in existing_rows
+        if isinstance(row.artifact_metadata, dict)
+        and row.artifact_metadata.get("artifact_family") == "analysis_context_bundle"
+    ]
+    if len(existing) > 1:
+        raise ValueError("TaskRun already has multiple ContextBundle registry artifacts")
+    if existing:
+        return _validate_registered_context_bundle_row(
+            existing[0],
+            registry_row_id=registry_row_id,
+            file_path=file_path,
+            file_sha256=file_sha256,
+            required=required,
+        )
+    try:
+        with db.begin_nested():
+            row = register_artifact(
+                db,
+                run_id=run_id,
+                step=step,
+                artifact_id=required["bundle_id"],
+                artifact_type="structured_json",
+                file_path=file_path,
+                sha256=file_sha256,
+                content_type=str(descriptor.get("content_type") or "application/json"),
+                source_refs=_context_bundle_registry_source_refs(
+                    descriptor.get("source_refs"), bundle_id=required["bundle_id"]
+                ),
+                input_snapshot_ids={
+                    "analysis_context_bundle": {
+                        "bundle_id": required["bundle_id"],
+                        "content_hash": required["content_hash"],
+                        "canonical_state_id": required["canonical_state_id"],
+                    }
+                },
+                metadata=dict(metadata),
+                registry_artifact_id=registry_row_id,
+                require_canonical_path=False,
+                storage=effective_storage,
+            )
+            if row is None:  # pragma: no cover - table availability checked above
+                raise ValueError("ContextBundle registry unexpectedly became unavailable")
+            return _validate_registered_context_bundle_row(
+                row,
+                registry_row_id=registry_row_id,
+                file_path=file_path,
+                file_sha256=file_sha256,
+                required=required,
+            )
+    except IntegrityError:
+        # The deterministic primary key serializes concurrent registration for
+        # one run without a schema migration. Re-read and apply the exact same
+        # identity checks; a conflicting winner still fails closed.
+        winner = db.get(RunArtifact, registry_row_id)
+        if winner is None:
+            raise
+        return _validate_registered_context_bundle_row(
+            winner,
+            registry_row_id=registry_row_id,
+            file_path=file_path,
+            file_sha256=file_sha256,
+            required=required,
+        )
+
+
+def _validate_registered_context_bundle_row(
+    row: RunArtifact,
+    *,
+    registry_row_id: uuid.UUID,
+    file_path: str,
+    file_sha256: str,
+    required: dict[str, str],
+) -> RunArtifact:
+    row_metadata = row.artifact_metadata or {}
+    if (
+        row.artifact_id != registry_row_id
+        or row.file_path != file_path
+        or str(row.sha256 or "").lower() != file_sha256
+        or str(getattr(row.artifact_type, "value", row.artifact_type) or "") != "structured_json"
+        or not isinstance(row_metadata, dict)
+        or row_metadata.get("artifact_family") != "analysis_context_bundle"
+        or str(row_metadata.get("bundle_id") or "") != required["bundle_id"]
+        or str(row_metadata.get("content_hash") or "") != required["content_hash"]
+        or str(row_metadata.get("run_id") or "") != required["run_id"]
+        or str(row_metadata.get("canonical_state_id") or "") != required["canonical_state_id"]
+        or str(row_metadata.get("schema_version") or "") != required["schema_version"]
+        or str(row_metadata.get("asset") or "") != required["asset"]
+        or str(row_metadata.get("state_scope") or "") != required["state_scope"]
+    ):
+        raise ValueError("TaskRun ContextBundle identity conflicts with registered artifact")
+    return row
+
+
+def _is_lowercase_sha256(value: str) -> bool:
+    return len(value) == 64 and all(char in "0123456789abcdef" for char in value)
+
+
+def _context_bundle_registry_source_refs(raw_refs: Any, *, bundle_id: str) -> list[dict[str, Any]]:
+    refs: list[dict[str, Any]] = []
+    for raw_ref in raw_refs if isinstance(raw_refs, list) else []:
+        if not isinstance(raw_ref, dict):
+            continue
+        ref = dict(raw_ref)
+        if not any(ref.get(key) for key in ("source", "source_name", "source_id", "source_key", "source_ref")):
+            ref["source"] = "analysis_context_bundle_evidence"
+        if not any(
+            ref.get(key)
+            for key in (
+                "article_id",
+                "captured_at",
+                "data_date",
+                "endpoint",
+                "file_path",
+                "raw_path",
+                "ref",
+                "report_date",
+                "sha256",
+                "snapshot_id",
+                "source_ref",
+                "source_type",
+                "source_url",
+                "status",
+                "symbol",
+                "url",
+            )
+        ):
+            ref["ref"] = f"context_bundle:{bundle_id}"
+        refs.append(ref)
+    return refs or [{"source": "analysis_context_bundle", "ref": f"context_bundle:{bundle_id}"}]
+
+
 def register_run_support_artifacts(
     db: DBSession,
     *,
@@ -203,7 +443,9 @@ def coerce_lineage_source_refs(raw: Any) -> list[dict[str, Any]] | None:
         if not isinstance(item, dict):
             continue
         normalized = dict(item)
-        identity = _first_lineage_ref_value(normalized, ("source_ref", "source_id", "source_name", "source", "source_key"))
+        identity = _first_lineage_ref_value(
+            normalized, ("source_ref", "source_id", "source_name", "source", "source_key")
+        )
         trace_detail = _first_lineage_ref_value(
             normalized,
             (

--- a/apps/worker/composite_analysis_pipeline.py
+++ b/apps/worker/composite_analysis_pipeline.py
@@ -31,6 +31,7 @@ from apps.analysis.agents.source_health import (
 )
 from apps.analysis.agents.risk import analyze_risk
 from apps.analysis.agents.technical import analyze_technical
+from apps.analysis.context_bundle import ConsumerProjection, project_context_bundle
 from apps.analysis.strategy.card import build_strategy_card
 from apps.gold_runtime_orchestration import build_gold_runtime_execution_summary
 from apps.output.final_report import write_final_report, write_strategy_card
@@ -47,6 +48,18 @@ from apps.worker.composite_state_shadow import (
 )
 
 logger = logging.getLogger(__name__)
+
+_CONTEXT_BUNDLE_CONSUMERS = {
+    "macro_liquidity_agent": "macro",
+    "cme_options_agent": "options",
+    "risk_agent": "risk",
+    "technical_agent": "technical",
+    "positioning_agent": "positioning",
+    "news_agent": "news",
+    "market_odds_agent": "market_odds",
+    "fact_review_agent": "fact_review",
+    "coordinator_agent": "coordinator",
+}
 
 
 def _safe_requested_state_scope(shadow_input: dict[str, Any] | None) -> str | None:
@@ -95,6 +108,7 @@ def run_composite_analysis_pipeline(
     context_mode = resolve_analysis_context_mode(analysis_context_mode)
     shadow_runtime = None
     shadow_trace = None
+    consumer_projections: dict[str, ConsumerProjection] = {}
     if context_mode == STATE_DELTA_CONTEXT_MODE:
         try:
             if state_shadow_input is None:
@@ -105,6 +119,13 @@ def run_composite_analysis_pipeline(
                 created_at=created_at,
                 shadow_input=state_shadow_input,
             )
+            consumer_projections = {
+                agent_name: project_context_bundle(
+                    shadow_runtime.bundle,
+                    consumer=consumer_name,  # type: ignore[arg-type]
+                )
+                for agent_name, consumer_name in _CONTEXT_BUNDLE_CONSUMERS.items()
+            }
             shadow_trace = execute_composite_state_shadow(
                 runtime=shadow_runtime,
                 analyzer=state_delta_analyzer,
@@ -112,6 +133,7 @@ def run_composite_analysis_pipeline(
         except Exception as exc:
             logger.exception("State-delta shadow setup failed; continuing legacy output")
             shadow_runtime = None
+            consumer_projections = {}
             failure_kind = type(exc).__name__
             review_item = build_state_delta_setup_failure_review_item(
                 run_id=run_id,
@@ -131,6 +153,16 @@ def run_composite_analysis_pipeline(
             }
     elif context_mode != LEGACY_CONTEXT_MODE:  # pragma: no cover - resolver exhaustiveness
         raise ValueError(f"unsupported context mode: {context_mode}")
+    if consumer_projections:
+        _reject_state_delta_prebuilt_outputs(
+            macro_output_prebuilt=macro_output_prebuilt,
+            options_output_prebuilt=options_output_prebuilt,
+            risk_output_prebuilt=risk_output_prebuilt,
+            technical_output_prebuilt=technical_output_prebuilt,
+            positioning_output_prebuilt=positioning_output_prebuilt,
+            news_output_prebuilt=news_output_prebuilt,
+            coordinator_output_prebuilt=coordinator_output_prebuilt,
+        )
     gold_macro_overview = gold_macro_overview_from_snapshot(snapshot)
     source_health = source_health_from_snapshot(snapshot, gold_macro_overview=gold_macro_overview)
     canonical_run_dir = storage_root / "analysis" / "gold_mainlines" / str(trade_date) / run_id
@@ -144,12 +176,20 @@ def run_composite_analysis_pipeline(
     macro_output = (
         macro_output_prebuilt
         if macro_output_prebuilt is not None
-        else analyze_macro_liquidity(snapshot, created_at=created_at)
+        else analyze_macro_liquidity(
+            snapshot,
+            created_at=created_at,
+            context_projection=consumer_projections.get("macro_liquidity_agent"),
+        )
     )
     options_output = (
         options_output_prebuilt
         if options_output_prebuilt is not None
-        else analyze_cme_options(snapshot, created_at=created_at)
+        else analyze_cme_options(
+            snapshot,
+            created_at=created_at,
+            context_projection=consumer_projections.get("cme_options_agent"),
+        )
     )
     risk_output = (
         risk_output_prebuilt
@@ -159,22 +199,41 @@ def run_composite_analysis_pipeline(
             macro_output=macro_output,
             options_output=options_output,
             created_at=created_at,
+            context_projection=consumer_projections.get("risk_agent"),
         )
     )
     technical_output = (
         technical_output_prebuilt
         if technical_output_prebuilt is not None
-        else analyze_technical(snapshot, created_at=created_at)
+        else analyze_technical(
+            snapshot,
+            created_at=created_at,
+            context_projection=consumer_projections.get("technical_agent"),
+        )
     )
     positioning_output = (
         positioning_output_prebuilt
         if positioning_output_prebuilt is not None
-        else analyze_positioning(snapshot, created_at=created_at)
+        else analyze_positioning(
+            snapshot,
+            created_at=created_at,
+            context_projection=consumer_projections.get("positioning_agent"),
+        )
     )
     news_output = (
-        news_output_prebuilt if news_output_prebuilt is not None else analyze_news(snapshot, created_at=created_at)
+        news_output_prebuilt
+        if news_output_prebuilt is not None
+        else analyze_news(
+            snapshot,
+            created_at=created_at,
+            context_projection=consumer_projections.get("news_agent"),
+        )
     )
-    market_odds_output = analyze_market_odds(snapshot, created_at=created_at)
+    market_odds_output = analyze_market_odds(
+        snapshot,
+        created_at=created_at,
+        context_projection=consumer_projections.get("market_odds_agent"),
+    )
     domain_outputs = [
         macro_output,
         options_output,
@@ -188,6 +247,7 @@ def run_composite_analysis_pipeline(
         domain_outputs,
         snapshot_id=str(snapshot_id),
         created_at=created_at,
+        context_projection=consumer_projections.get("fact_review_agent"),
     )
     reviewed_outputs = [*domain_outputs, fact_review_output]
     pre_coordinator_quality_gate_decision = evaluate_quality_gate(
@@ -218,7 +278,22 @@ def run_composite_analysis_pipeline(
             news_output=news_output,
             market_odds_output=market_odds_output,
             created_at=created_at,
+            context_projection=consumer_projections.get("coordinator_agent"),
         )
+    )
+    verified_bundle_consumers = _verified_bundle_consumers(
+        outputs={
+            "macro_liquidity_agent": macro_output,
+            "cme_options_agent": options_output,
+            "risk_agent": risk_output,
+            "technical_agent": technical_output,
+            "positioning_agent": positioning_output,
+            "news_agent": news_output,
+            "market_odds_agent": market_odds_output,
+            "fact_review_agent": fact_review_output,
+            "coordinator_agent": coordinator_output,
+        },
+        projections=consumer_projections,
     )
     post_coordinator_gate_inputs = [*reviewed_outputs, coordinator_output]
     raw_post_coordinator_quality_gate_decision = evaluate_quality_gate(
@@ -313,9 +388,7 @@ def run_composite_analysis_pipeline(
 
     output_mode = "accepted" if agent_loop_decision.publish_allowed else "observe"
     report_artifact_type = "final_report" if agent_loop_decision.publish_allowed else "observation_report"
-    strategy_artifact_type = (
-        "strategy_card" if agent_loop_decision.publish_allowed else "observation_strategy_card"
-    )
+    strategy_artifact_type = "strategy_card" if agent_loop_decision.publish_allowed else "observation_strategy_card"
     report_result = write_final_report(
         storage_root=storage_root,
         markdown=markdown,
@@ -430,17 +503,7 @@ def run_composite_analysis_pipeline(
             shadow_trace,
             legacy_coordinator=selected_coordinator,
             agent_loop_decision=agent_loop_decision,
-            consumer_names=[
-                "macro_liquidity_agent",
-                "cme_options_agent",
-                "risk_agent",
-                "technical_agent",
-                "positioning_agent",
-                "news_agent",
-                "market_odds_agent",
-                "fact_review_agent",
-                "coordinator_agent",
-            ],
+            consumer_names=verified_bundle_consumers,
         )
         summaries["state_delta_shadow"] = {
             "step": "state_delta_shadow",
@@ -478,13 +541,60 @@ def run_composite_analysis_pipeline(
     }
     if finalized_shadow is not None:
         composite_outputs["state_delta_shadow"] = finalized_shadow
+    if shadow_runtime is not None:
+        composite_outputs["context_bundle_registry_artifact"] = shadow_runtime.artifact.registry_artifact
 
     return summaries, composite_outputs
 
 
-def report_coordinator_output(
-    *, primary: Any, fallback_execution: Any, agent_loop_decision: Any
-) -> Any:
+def _reject_state_delta_prebuilt_outputs(**outputs: Any) -> None:
+    bypassed = sorted(name for name, output in outputs.items() if output is not None)
+    if bypassed:
+        raise ValueError("state_delta_context forbids unverified prebuilt Agent outputs: " + ", ".join(bypassed))
+
+
+def _verified_bundle_consumers(
+    *,
+    outputs: dict[str, Any],
+    projections: dict[str, ConsumerProjection],
+) -> list[str]:
+    if not projections:
+        return []
+    verified: list[str] = []
+    for agent_name, projection in projections.items():
+        output = outputs.get(agent_name)
+        input_ids = getattr(output, "input_snapshot_ids", None)
+        input_payload = getattr(output, "input_payload", None)
+        if not isinstance(input_ids, dict) or not isinstance(input_payload, dict):
+            raise ValueError(f"{agent_name} did not return auditable ContextBundle lineage")
+        identity = projection.identity_payload
+        expected = {
+            "context_bundle_id": identity.bundle_id,
+            "context_bundle_hash": identity.content_hash,
+            "context_bundle_run_id": identity.run_id,
+            "context_bundle_projection_hash": projection.projection_hash,
+            "canonical_state_id": identity.canonical_state_id,
+            "state_scope": identity.state_scope,
+            "retained_evidence_ids": [
+                {"source": item["source"], "evidence_id": item["evidence_id"]}
+                for item in sorted(
+                    projection.retained_evidence,
+                    key=lambda item: (item["source"], item["evidence_id"]),
+                )
+            ],
+            "evidence_delta_decision_id": projection.decision_id,
+        }
+        if any(input_ids.get(key) != value for key, value in expected.items()):
+            raise ValueError(f"{agent_name} ContextBundle lineage does not match its projection")
+        if input_payload.get("context_bundle_consumer") != projection.consumer:
+            raise ValueError(f"{agent_name} did not acknowledge its typed projection")
+        if input_payload.get("context_bundle_projection") != projection.model_dump(mode="json"):
+            raise ValueError(f"{agent_name} did not consume its exact typed projection")
+        verified.append(agent_name)
+    return verified
+
+
+def report_coordinator_output(*, primary: Any, fallback_execution: Any, agent_loop_decision: Any) -> Any:
     accepted = agent_loop_decision.accepted_output
     if accepted.source == "primary":
         if primary.agent_name != accepted.agent_name or primary.snapshot_id != accepted.snapshot_id:
@@ -541,24 +651,16 @@ def validated_rendered_outputs(
     root = storage_root.resolve()
     for artifact_type, result, paths in expected:
         if result.get("artifact_type") != artifact_type:
-            raise RuntimeError(
-                f"accepted output materialization requires artifact_type={artifact_type}"
-            )
+            raise RuntimeError(f"accepted output materialization requires artifact_type={artifact_type}")
         if not paths:
-            raise RuntimeError(
-                f"accepted output materialization produced no {artifact_type} paths"
-            )
+            raise RuntimeError(f"accepted output materialization produced no {artifact_type} paths")
         canonical_root = (root / "outputs" / artifact_type).resolve()
         for raw_path in paths:
             path = Path(raw_path).resolve()
             if not path.is_relative_to(canonical_root):
-                raise RuntimeError(
-                    f"accepted {artifact_type} path is outside canonical storage: {raw_path}"
-                )
+                raise RuntimeError(f"accepted {artifact_type} path is outside canonical storage: {raw_path}")
             if not path.is_file() or path.stat().st_size <= 0:
-                raise RuntimeError(
-                    f"accepted {artifact_type} artifact is not materialized: {raw_path}"
-                )
+                raise RuntimeError(f"accepted {artifact_type} artifact is not materialized: {raw_path}")
     return rendered
 
 
@@ -605,11 +707,7 @@ def validated_gold_agent_execution(
     news = snapshot.get("news") if isinstance(snapshot.get("news"), dict) else {}
     data = news.get("data") if isinstance(news.get("data"), dict) else {}
     execution = data.get("gold_agent_execution") if isinstance(data.get("gold_agent_execution"), dict) else {}
-    raw_declared = (
-        execution.get("declared_agents")
-        if isinstance(execution.get("declared_agents"), list)
-        else []
-    )
+    raw_declared = execution.get("declared_agents") if isinstance(execution.get("declared_agents"), list) else []
     raw_materialized = (
         execution.get("materialized_stage_envelopes")
         if isinstance(execution.get("materialized_stage_envelopes"), list)
@@ -648,7 +746,11 @@ def validated_gold_agent_execution(
 def gold_macro_overview_from_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
     news_data = snapshot.get("news", {}).get("data") if isinstance(snapshot.get("news"), dict) else None
     context_section = snapshot.get("gold_analysis_context")
-    context_data = context_section.get("data") if isinstance(context_section, dict) and isinstance(context_section.get("data"), dict) else {}
+    context_data = (
+        context_section.get("data")
+        if isinstance(context_section, dict) and isinstance(context_section.get("data"), dict)
+        else {}
+    )
     context_metadata = {
         "status": context_data.get("status") or (context_section or {}).get("status"),
         "baseline_kind": context_data.get("baseline_kind"),

--- a/apps/worker/composite_state_shadow.py
+++ b/apps/worker/composite_state_shadow.py
@@ -75,7 +75,26 @@ def prepare_composite_state_shadow(
     canonical_payload = shadow_input["canonical_state"]
     if isinstance(canonical_payload, dict) and "schema_version" not in canonical_payload:
         canonical_payload = {**canonical_payload, "schema_version": "1.0"}
-    previous_state = parse_analysis_state_document(canonical_payload)
+    requested_state = parse_analysis_state_document(canonical_payload)
+    canonical_state_id = str(shadow_input["canonical_state_id"])
+    recovery_descriptor = shadow_input.get("context_bundle_artifact")
+    if recovery_descriptor is not None:
+        bundle, artifact = _recover_context_bundle(
+            storage_root=storage_root,
+            descriptor=recovery_descriptor,
+            expected_run_id=run_id,
+            asset=requested_state.asset,
+            state_scope=state_scope,
+            canonical_state_id=canonical_state_id,
+        )
+        canonical_block = next(block for block in bundle.blocks if block.name == "canonical_state")
+        previous_state = parse_analysis_state_document(canonical_block.payload)
+        if previous_state.model_dump(mode="json") != requested_state.model_dump(mode="json"):
+            raise ValueError("recovered context bundle canonical state does not match shadow input")
+        cutoff_at = bundle.cutoff_at
+    else:
+        previous_state = requested_state
+        cutoff_at = _datetime_value(shadow_input.get("cutoff_at") or created_at)
     if isinstance(previous_state, AnalysisStateDocumentV11):
         if previous_state.state_scope != state_scope:
             raise ValueError("shadow canonical state belongs to a different state_scope")
@@ -89,47 +108,48 @@ def prepare_composite_state_shadow(
         session = str(shadow_input.get("expected_session") or "daily_close").strip()
         if not session:
             raise ValueError("shadow session must not be blank")
-    confirmed_facts = []
-    delta_facts = []
-    for raw_fact in shadow_input.get("figure_facts") or []:
-        confirmed = project_confirmed_evidence(raw_fact)
-        if confirmed is not None:
-            confirmed_facts.append(confirmed.model_dump(mode="json"))
-            delta_facts.append(
-                adapt_figure_fact(
-                    confirmed.model_dump(mode="json"),
-                    observed_at=_datetime_value(shadow_input.get("cutoff_at") or created_at),
+    if recovery_descriptor is None:
+        confirmed_facts = []
+        delta_facts = []
+        for raw_fact in shadow_input.get("figure_facts") or []:
+            confirmed = project_confirmed_evidence(raw_fact)
+            if confirmed is not None:
+                confirmed_facts.append(confirmed.model_dump(mode="json"))
+                delta_facts.append(
+                    adapt_figure_fact(
+                        confirmed.model_dump(mode="json"),
+                        observed_at=cutoff_at,
+                    )
                 )
-            )
-    cutoff_at = _datetime_value(shadow_input.get("cutoff_at") or created_at)
-    assembled_at = _datetime_value(shadow_input.get("assembled_at") or created_at)
+        assembled_at = _datetime_value(shadow_input.get("assembled_at") or created_at)
+        recovery = _recovery_inputs(
+            storage_root=storage_root,
+            shadow_input=shadow_input,
+            current_run_id=run_id,
+            asset=previous_state.asset,
+            state_scope=state_scope,
+            canonical_state_id=canonical_state_id,
+        )
+        bundle = assemble_context_bundle(
+            run_id=run_id,
+            asset=previous_state.asset,
+            state_scope=state_scope,
+            canonical_state_id=canonical_state_id,
+            canonical_state=previous_state.model_dump(mode="json"),
+            evidence=list(shadow_input.get("evidence") or []),
+            evidence_cursors=dict(shadow_input.get("evidence_cursors") or {}),
+            cutoff_at=cutoff_at,
+            assembled_at=assembled_at,
+            facts=confirmed_facts,
+            delta_facts=delta_facts,
+            **recovery,
+            expected_session=shadow_input.get("expected_session"),
+            max_alignment_seconds=int(shadow_input.get("max_alignment_seconds") or 86_400),
+            budget_tokens=int(shadow_input.get("budget_tokens") or 15_000),
+        )
+        artifact = write_context_bundle(storage_root=storage_root, bundle=bundle)
     if isinstance(previous_state, AnalysisStateDocumentV1):
         trade_date = cutoff_at.date()
-    recovery = _recovery_inputs(
-        storage_root=storage_root,
-        shadow_input=shadow_input,
-        asset=previous_state.asset,
-        state_scope=state_scope,
-        canonical_state_id=str(shadow_input["canonical_state_id"]),
-    )
-    bundle = assemble_context_bundle(
-        run_id=run_id,
-        asset=previous_state.asset,
-        state_scope=state_scope,
-        canonical_state_id=str(shadow_input["canonical_state_id"]),
-        canonical_state=previous_state.model_dump(mode="json"),
-        evidence=list(shadow_input.get("evidence") or []),
-        evidence_cursors=dict(shadow_input.get("evidence_cursors") or {}),
-        cutoff_at=cutoff_at,
-        assembled_at=assembled_at,
-        facts=confirmed_facts,
-        delta_facts=delta_facts,
-        **recovery,
-        expected_session=shadow_input.get("expected_session"),
-        max_alignment_seconds=int(shadow_input.get("max_alignment_seconds") or 86_400),
-        budget_tokens=int(shadow_input.get("budget_tokens") or 15_000),
-    )
-    artifact = write_context_bundle(storage_root=storage_root, bundle=bundle)
     delta_block = next(block for block in bundle.blocks if block.name == "delta_evidence")
     facts_block = next(block for block in bundle.blocks if block.name == "facts")
     available_refs = [
@@ -211,9 +231,7 @@ def execute_composite_state_shadow(
     try:
         raw_candidate = analyzer(runtime.bundle)
         candidate_payload = (
-            raw_candidate.model_dump(mode="json")
-            if isinstance(raw_candidate, BaseModel)
-            else raw_candidate
+            raw_candidate.model_dump(mode="json") if isinstance(raw_candidate, BaseModel) else raw_candidate
         )
         candidate = TransitionCandidate.model_validate(candidate_payload)
         review = review_transition_candidate_scoped(
@@ -241,9 +259,7 @@ def execute_composite_state_shadow(
         "status": "candidate_accepted_shadow_only",
         "model_invocation": "executed",
         "shadow_review_status": "accepted",
-        "transition_diff": [
-            change.model_dump(mode="json") for change in review.transition.changes
-        ],
+        "transition_diff": [change.model_dump(mode="json") for change in review.transition.changes],
         "shadow_core_thesis": review.next_state.core_thesis,
         "review_hash": review.next_state_content_hash,
         "analyzer_latency_ms": max(0, round((perf_counter() - started) * 1000)),
@@ -263,9 +279,7 @@ def finalize_composite_state_shadow(
     bundle_id = trace.get("bundle_id")
     return {
         **trace,
-        "bundle_consumers": {
-            name: bundle_id for name in consumer_names if bundle_id
-        },
+        "bundle_consumers": {name: bundle_id for name in consumer_names if bundle_id},
         "conclusion_diff": {
             "legacy": legacy_summary,
             "shadow": shadow_summary,
@@ -310,27 +324,40 @@ def _recovery_inputs(
     *,
     storage_root: Path,
     shadow_input: dict[str, Any],
+    current_run_id: str,
     asset: str,
     state_scope: StateScope,
     canonical_state_id: str,
 ) -> dict[str, Any]:
+    previous_descriptor = shadow_input.get("previous_context_bundle_artifact")
     previous_bundle_path = shadow_input.get("previous_bundle_path")
-    if previous_bundle_path is None:
-        return {
-            field: shadow_input[field]
-            for field in _RECOVERY_FIELDS
-            if field in shadow_input
-        }
+    if previous_descriptor is not None and previous_bundle_path is not None:
+        raise ValueError("previous_context_bundle_artifact cannot be combined with previous_bundle_path")
+    if previous_descriptor is None and previous_bundle_path is None:
+        return {field: shadow_input[field] for field in _RECOVERY_FIELDS if field in shadow_input}
     ambiguous = [field for field in _RECOVERY_FIELDS if field in shadow_input]
     if ambiguous:
         raise ValueError(
-            "previous_bundle_path cannot be combined with explicit recovery fields: "
-            + ", ".join(ambiguous)
+            "previous context bundle cannot be combined with explicit recovery fields: " + ", ".join(ambiguous)
         )
-    previous = load_context_bundle(
-        storage_root=storage_root,
-        storage_relative_path=str(previous_bundle_path),
-    )
+    if previous_descriptor is not None:
+        previous, _artifact = _recover_context_bundle(
+            storage_root=storage_root,
+            descriptor=previous_descriptor,
+            expected_run_id=None,
+            asset=asset,
+            state_scope=state_scope,
+            canonical_state_id=canonical_state_id,
+        )
+        if previous.run_id == current_run_id:
+            raise ValueError("previous context bundle must belong to a different run")
+    else:
+        # Backward-compatible explicit test/canary injection. Production runtime
+        # recovery uses the validated RunArtifact descriptor boundary above.
+        previous = load_context_bundle(
+            storage_root=storage_root,
+            storage_relative_path=str(previous_bundle_path),
+        )
     if previous.schema_version != "analysis_context_bundle.v3":
         raise ValueError("previous context bundle must use analysis_context_bundle.v3")
     if (
@@ -352,12 +379,67 @@ def _recovery_inputs(
         "previous_semantic_hashes": hashes,
         "deferred_queue": tuple(previous.deferred_queue),
         "processed_above_frontier": {
-            source: tuple(pointers)
-            for source, pointers in previous.processed_above_frontier.items()
+            source: tuple(pointers) for source, pointers in previous.processed_above_frontier.items()
         },
         "freshness_sla_seconds": dict(previous.freshness_sla_seconds),
         "default_freshness_sla_seconds": previous.default_freshness_sla_seconds,
     }
+
+
+def _recover_context_bundle(
+    *,
+    storage_root: Path,
+    descriptor: Any,
+    expected_run_id: str | None,
+    asset: str,
+    state_scope: StateScope,
+    canonical_state_id: str,
+) -> tuple[AnalysisContextBundle, ContextBundleWriteResult]:
+    if not isinstance(descriptor, dict):
+        raise ValueError("context bundle recovery requires an explicit registry descriptor")
+    file_path = str(descriptor.get("file_path") or "").strip()
+    metadata = descriptor.get("metadata")
+    if not file_path or not isinstance(metadata, dict):
+        raise ValueError("context bundle recovery descriptor is incomplete")
+    bundle = load_context_bundle(
+        storage_root=storage_root,
+        storage_relative_path=file_path,
+    )
+    expected = {
+        "artifact_family": "analysis_context_bundle",
+        "schema_version": "analysis_context_bundle.v3",
+        "bundle_id": bundle.bundle_id,
+        "content_hash": bundle.content_hash,
+        "run_id": bundle.run_id,
+        "asset": asset,
+        "state_scope": state_scope,
+        "canonical_state_id": canonical_state_id,
+    }
+    for key, value in expected.items():
+        if str(metadata.get(key) or "") != str(value):
+            raise ValueError(f"context bundle recovery identity mismatch: {key}")
+    if expected_run_id is not None and bundle.run_id != expected_run_id:
+        raise ValueError("context bundle payload run_id does not match runtime")
+    if bundle.asset != asset or bundle.state_scope != state_scope:
+        raise ValueError("context bundle payload scope identity does not match runtime")
+    if bundle.canonical_state_id != canonical_state_id:
+        raise ValueError("context bundle canonical identity does not match runtime")
+    if str(descriptor.get("artifact_id") or "") != bundle.bundle_id:
+        raise ValueError("context bundle artifact_id does not match bundle_id")
+    expected_file_hash = str(descriptor.get("sha256") or "").strip().lower()
+    absolute_path = (Path(storage_root).resolve() / file_path).resolve()
+    if not absolute_path.is_relative_to(Path(storage_root).resolve()):
+        raise ValueError("context bundle recovery path escapes storage root")
+    actual_file_hash = hashlib.sha256(absolute_path.read_bytes()).hexdigest()
+    if expected_file_hash != actual_file_hash:
+        raise ValueError("context bundle recovery file hash mismatch")
+    return bundle, ContextBundleWriteResult(
+        storage_relative_path=file_path,
+        content_hash=bundle.content_hash,
+        file_sha256=actual_file_hash,
+        written=False,
+        registry_artifact=dict(descriptor),
+    )
 
 
 def build_state_delta_review_item(
@@ -381,8 +463,7 @@ def build_state_delta_review_item(
         "severity": severity,
         "reason": reason,
         "impact_modules": impact_modules or ["analysis_state", "state_delta_shadow"],
-        "suggested_action": suggested_action
-        or "Review conflicting or unverified evidence before transition analysis.",
+        "suggested_action": suggested_action or "Review conflicting or unverified evidence before transition analysis.",
         "status": "pending",
         "evidence_refs": evidence_refs or [],
     }
@@ -408,11 +489,7 @@ def build_state_delta_setup_failure_review_item(
 
 def _manual_review_item(runtime: CompositeStateShadowRuntime) -> dict[str, Any]:
     decision = runtime.evidence_delta_decision
-    evidence_refs = [
-        ref.model_dump(mode="json")
-        for item in decision.evaluated_items
-        for ref in item.evidence_refs
-    ]
+    evidence_refs = [ref.model_dump(mode="json") for item in decision.evaluated_items for ref in item.evidence_refs]
     return build_state_delta_review_item(
         run_id=runtime.run_id,
         review_id=f"evidence_delta:{decision.decision_id}",

--- a/apps/worker/runner.py
+++ b/apps/worker/runner.py
@@ -31,6 +31,10 @@ from apps.premarket import (
     sort_premarket_steps,
 )
 from apps.runtime.state_machine import derive_task_run_status, transition_task_run, transition_task_step
+from apps.runtime.artifact_registry import (
+    select_context_bundle_artifact_for_run,
+    select_previous_context_bundle_artifact,
+)
 from apps.worker.artifact_registration import (
     coerce_lineage_input_snapshot_ids as _coerce_lineage_input_snapshot_ids,
     coerce_lineage_source_refs as _coerce_lineage_source_refs,
@@ -44,6 +48,11 @@ from apps.worker.artifact_registration import (
 from apps.worker.composite_analysis_pipeline import (
     accepted_coordinator_output as _accepted_coordinator_output,
     run_composite_analysis_pipeline as _run_composite_analysis_pipeline,
+)
+from apps.worker.composite_state_shadow import (
+    STATE_DELTA_CONTEXT_MODE,
+    StateDeltaAnalyzer,
+    resolve_analysis_context_mode,
 )
 from apps.worker.db_persistence import (
     db_persist_agent_outputs as _db_persist_agent_outputs,
@@ -133,6 +142,9 @@ def run_premarket(
     *,
     storage_root: Path = Path("./storage"),
     product: str = "OG",
+    analysis_context_mode: str | None = None,
+    state_shadow_input: dict[str, Any] | None = None,
+    state_delta_analyzer: StateDeltaAnalyzer | None = None,
 ) -> TaskStatus:
     """Execute the premarket pipeline.
 
@@ -191,9 +203,7 @@ def run_premarket(
             default=str,
         )
         # ── T1.6: compute input_hash for idempotency ────────────────
-        step.input_hash = hashlib.sha256(
-            step.input_json.encode("utf-8")
-        ).hexdigest()
+        step.input_hash = hashlib.sha256(step.input_json.encode("utf-8")).hexdigest()
         step.retry_count = 0
 
         # ── T1.4: check upstream failure/blocking → block this step ──────
@@ -360,7 +370,11 @@ def run_premarket(
         pre_analysis_gate = _load_pre_analysis_gate(storage_root=storage_root, analysis_snapshot=analysis_snapshot)
         if _pre_analysis_gate_blocks(pre_analysis_gate):
             had_partial_summary = True
-            blocked_outputs = pre_analysis_gate.get("blocked_outputs") if isinstance(pre_analysis_gate.get("blocked_outputs"), list) else []
+            blocked_outputs = (
+                pre_analysis_gate.get("blocked_outputs")
+                if isinstance(pre_analysis_gate.get("blocked_outputs"), list)
+                else []
+            )
             macro_state.step_summaries["pre_analysis_gate"] = {
                 "step": "pre_analysis_gate",
                 "status": "blocked",
@@ -386,11 +400,22 @@ def run_premarket(
                 }
             try:
                 composite_created_at = datetime.now(timezone.utc)
+                resolved_shadow_input = state_shadow_input
+                if resolve_analysis_context_mode(analysis_context_mode) == STATE_DELTA_CONTEXT_MODE:
+                    resolved_shadow_input = _resolve_state_shadow_registry_inputs(
+                        db=db,
+                        run_id=run_id,
+                        storage_root=storage_root,
+                        state_shadow_input=state_shadow_input,
+                    )
                 composite_summaries, composite_outputs = _run_composite_analysis_pipeline(
                     storage_root=storage_root,
                     snapshot=analysis_snapshot,
                     run_id=run_id,
                     created_at=composite_created_at,
+                    analysis_context_mode=analysis_context_mode,
+                    state_shadow_input=resolved_shadow_input,
+                    state_delta_analyzer=state_delta_analyzer,
                 )
                 macro_state.step_summaries.update(composite_summaries)
 
@@ -408,9 +433,7 @@ def run_premarket(
                     agent_loop_decision = composite_outputs.get("agent_loop_decision")
                     publish_allowed = bool(getattr(agent_loop_decision, "publish_allowed", False))
                     if publish_allowed:
-                        _db_persist_final_result(
-                            db, analysis_snapshot, composite_outputs, snapshot_db_id
-                        )
+                        _db_persist_final_result(db, analysis_snapshot, composite_outputs, snapshot_db_id)
                     else:
                         _ensure_review_items(
                             db,
@@ -439,7 +462,14 @@ def run_premarket(
                     steps=ordered_steps,
                     composite_outputs=composite_outputs,
                     analysis_snapshot=analysis_snapshot,
+                    storage_root=storage_root,
                 )
+                bundle_registry_status = composite_outputs.get("context_bundle_registry_status")
+                if isinstance(bundle_registry_status, dict):
+                    macro_state.step_summaries["context_bundle_registry"] = {
+                        "step": "context_bundle_registry",
+                        **bundle_registry_status,
+                    }
                 if bool(getattr(composite_outputs.get("agent_loop_decision"), "publish_allowed", False)):
                     try:
                         _register_composite_report_registry_entries(
@@ -449,7 +479,9 @@ def run_premarket(
                             analysis_snapshot=analysis_snapshot,
                         )
                     except Exception as db_exc:
-                        logger.exception("Report registry persist of composite analysis outputs failed (file artifacts are safe)")
+                        logger.exception(
+                            "Report registry persist of composite analysis outputs failed (file artifacts are safe)"
+                        )
                         macro_state.step_summaries["db_persist_composite_report_registry"] = {
                             "step": "db_persist_composite_report_registry",
                             "status": "failed",
@@ -463,7 +495,7 @@ def run_premarket(
                     "status": "failed",
                     "error": str(exc),
                     "partial_summary": "Composite analysis pipeline failed after analysis snapshot was persisted; "
-                                      "no final report or strategy card was written.",
+                    "no final report or strategy card was written.",
                 }
 
     # Persist step summaries and run provenance as durable artifacts
@@ -538,6 +570,71 @@ def run_premarket(
     transition_task_run(db, task, final_status, source="worker", reason="step_rollup")
     db.commit()
     return final_status
+
+
+def _resolve_state_shadow_registry_inputs(
+    *,
+    db: DBSession,
+    run_id: str,
+    storage_root: Path,
+    state_shadow_input: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Resolve restart/prior Bundle authority from RunArtifact, never a path scan."""
+
+    if state_shadow_input is None:
+        return None
+    resolved = dict(state_shadow_input)
+    for field in (
+        "context_bundle_artifact",
+        "previous_context_bundle_artifact",
+        "previous_bundle_path",
+    ):
+        resolved.pop(field, None)
+
+    same_run = select_context_bundle_artifact_for_run(
+        db,
+        run_id=run_id,
+        storage_root=storage_root,
+    )
+    if same_run is not None:
+        resolved["context_bundle_artifact"] = same_run
+        return resolved
+
+    canonical_state = resolved.get("canonical_state")
+    asset = str(canonical_state.get("asset") or "").strip() if isinstance(canonical_state, dict) else ""
+    state_scope = str(resolved.get("state_scope") or "").strip()
+    canonical_state_id = str(resolved.get("canonical_state_id") or "").strip()
+    if not all((asset, state_scope, canonical_state_id)):
+        return resolved
+    previous = select_previous_context_bundle_artifact(
+        db,
+        current_run_id=run_id,
+        asset=asset,
+        state_scope=state_scope,
+        canonical_state_id=canonical_state_id,
+        cutoff_at=_optional_aware_datetime(resolved.get("cutoff_at")),
+        storage_root=storage_root,
+    )
+    if previous is not None:
+        for field in (
+            "previous_semantic_hashes",
+            "deferred_queue",
+            "processed_above_frontier",
+            "freshness_sla_seconds",
+            "default_freshness_sla_seconds",
+        ):
+            resolved.pop(field, None)
+        resolved["previous_context_bundle_artifact"] = previous
+    return resolved
+
+
+def _optional_aware_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    parsed = value if isinstance(value, datetime) else datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("state shadow cutoff_at must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
 
 
 def _load_pre_analysis_gate(*, storage_root: Path, analysis_snapshot: dict[str, Any]) -> dict[str, Any]:

--- a/tests/analysis/test_context_bundle_agent_consumers.py
+++ b/tests/analysis/test_context_bundle_agent_consumers.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+import pytest
+
+from apps.analysis.agents import macro_liquidity
+from apps.analysis.agents.cme_options import analyze_cme_options
+from apps.analysis.agents.coordinator import coordinate_agent_outputs
+from apps.analysis.agents.fact_review import build_runtime_fact_review_agent_output
+from apps.analysis.agents.macro_liquidity import (
+    analyze_macro_liquidity,
+    build_macro_liquidity_structured_payload,
+)
+from apps.analysis.agents.market_odds import analyze_market_odds
+from apps.analysis.agents.news import analyze_news
+from apps.analysis.agents.positioning import analyze_positioning
+from apps.analysis.agents.risk import analyze_risk
+from apps.analysis.agents.technical import analyze_technical
+from apps.analysis.context_bundle import project_context_bundle
+from tests.analysis.test_context_bundle import NOW as BUNDLE_NOW
+from tests.analysis.test_context_bundle import _bundle, _evidence
+from tests.analysis.test_context_bundle_projection import _projection_bundle
+
+
+NOW = datetime(2026, 7, 26, tzinfo=timezone.utc)
+
+
+def _projection(consumer: str):
+    return project_context_bundle(_projection_bundle(), consumer=consumer)  # type: ignore[arg-type]
+
+
+def _snapshot() -> dict[str, Any]:
+    return {"snapshot_id": "consumer-test", "source_refs": []}
+
+
+def _assert_bound(output: Any, projection: Any) -> None:
+    assert output.input_snapshot_ids["context_bundle_id"] == projection.identity_payload.bundle_id
+    assert output.input_snapshot_ids["context_bundle_hash"] == projection.identity_payload.content_hash
+    assert output.input_snapshot_ids["canonical_state_id"] == projection.identity_payload.canonical_state_id
+    assert output.input_snapshot_ids["state_scope"] == projection.identity_payload.state_scope
+    assert output.input_snapshot_ids["evidence_delta_decision_id"] == projection.decision_id
+    summary = output.input_payload["context_bundle_summary"]
+    assert summary["decision_id"] == projection.decision_id
+    assert summary["decision_action"] == projection.decision.recommended_action.value
+    assert summary["retained_refs"] == projection.retained_source_refs
+    assert summary["accepted_fact_count"] == len(projection.accepted_facts)
+    assert output.input_payload["context_bundle_projection"] == projection.model_dump(mode="json")
+
+
+@pytest.mark.parametrize(
+    ("consumer", "invoke"),
+    [
+        (
+            "macro",
+            lambda projection: analyze_macro_liquidity(_snapshot(), created_at=NOW, context_projection=projection),
+        ),
+        ("options", lambda projection: analyze_cme_options(_snapshot(), created_at=NOW, context_projection=projection)),
+        (
+            "risk",
+            lambda projection: analyze_risk(
+                _snapshot(),
+                macro_output=analyze_macro_liquidity(_snapshot(), created_at=NOW),
+                options_output=analyze_cme_options(_snapshot(), created_at=NOW),
+                created_at=NOW,
+                context_projection=projection,
+            ),
+        ),
+        ("technical", lambda projection: analyze_technical(_snapshot(), created_at=NOW, context_projection=projection)),
+        (
+            "positioning",
+            lambda projection: analyze_positioning(_snapshot(), created_at=NOW, context_projection=projection),
+        ),
+        ("news", lambda projection: analyze_news(_snapshot(), created_at=NOW, context_projection=projection)),
+        (
+            "market_odds",
+            lambda projection: analyze_market_odds(_snapshot(), created_at=NOW, context_projection=projection),
+        ),
+        (
+            "fact_review",
+            lambda projection: build_runtime_fact_review_agent_output(
+                [analyze_macro_liquidity(_snapshot(), created_at=NOW)],
+                snapshot_id="consumer-test",
+                created_at=NOW,
+                context_projection=projection,
+            ),
+        ),
+        (
+            "coordinator",
+            lambda projection: coordinate_agent_outputs(
+                _snapshot(),
+                macro_output=analyze_macro_liquidity(_snapshot(), created_at=NOW),
+                options_output=analyze_cme_options(_snapshot(), created_at=NOW),
+                risk_output=analyze_risk(
+                    _snapshot(),
+                    macro_output=analyze_macro_liquidity(_snapshot(), created_at=NOW),
+                    options_output=analyze_cme_options(_snapshot(), created_at=NOW),
+                    created_at=NOW,
+                ),
+                created_at=NOW,
+                context_projection=projection,
+            ),
+        ),
+    ],
+)
+def test_agent_consumers_validate_and_bind_exact_projection(
+    consumer: str,
+    invoke: Callable[[Any], Any],
+) -> None:
+    projection = _projection(consumer)
+
+    _assert_bound(invoke(projection), projection)
+
+
+def test_agent_consumer_rejects_wrong_consumer_and_tamper_before_work() -> None:
+    wrong = _projection("options")
+    with pytest.raises(ValueError, match="expected consumer"):
+        analyze_macro_liquidity(_snapshot(), context_projection=wrong)
+
+    tampered = _projection("technical").model_dump(mode="json")
+    tampered["identity_payload"]["bundle_id"] = "tampered"
+    with pytest.raises(ValueError, match="projection_hash"):
+        analyze_technical(_snapshot(), context_projection=tampered)
+
+
+def test_macro_projection_enters_structured_prompt_payload() -> None:
+    projection = _projection("macro")
+    snapshot = {
+        "snapshot_id": "macro-projection",
+        "trade_date": "2026-07-26",
+        "macro": {"status": "available", "data": {"indicators": {}}},
+    }
+
+    payload = build_macro_liquidity_structured_payload(
+        snapshot,
+        context_projection=projection,
+    )
+
+    assert payload["context_bundle_summary"]["decision_id"] == projection.decision_id
+    assert payload["context_bundle_summary"]["retained_refs"] == projection.retained_source_refs
+    assert payload["context_bundle_projection"] == projection.model_dump(mode="json")
+
+
+def test_non_macro_consumer_uses_projection_content_and_manual_review_policy() -> None:
+    evidence = _evidence(
+        "macro",
+        "dxy-unverified",
+        business_time=BUNDLE_NOW,
+        ingested_at=BUNDLE_NOW,
+    )
+    evidence["payload"] = {
+        "evidence_type": "macro_metric",
+        "asset": "XAUUSD",
+        "source_quality": "unverified",
+        "metric": "dxy",
+        "current_value": 101.0,
+        "previous_value": 100.0,
+        "unit": "index",
+    }
+    projection = project_context_bundle(
+        _bundle(evidence=[evidence], facts=[]),
+        consumer="risk",
+    )
+    output = analyze_risk(
+        _snapshot(),
+        macro_output=analyze_macro_liquidity(_snapshot(), created_at=NOW),
+        options_output=analyze_cme_options(_snapshot(), created_at=NOW),
+        created_at=NOW,
+        context_projection=projection,
+    )
+
+    consumed = output.input_payload["context_bundle_projection"]
+    assert consumed["retained_evidence"][0]["payload"]["current_value"] == 101.0
+    assert consumed["decision"]["recommended_action"] == "manual_review"
+    assert output.confidence <= 0.35
+    assert "ContextBundle evidence delta requires manual review." in output.risk_points
+    assert projection.retained_source_refs[0] in output.evidence_refs
+
+
+def test_macro_invocation_chain_carries_projection(monkeypatch: pytest.MonkeyPatch) -> None:
+    projection = _projection("macro")
+    received: dict[str, Any] = {}
+
+    def fake_invoke(snapshot: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        received["projection"] = kwargs["context_projection"]
+        return {"markdown": "", "prompt_version": "test", "skipped": True}
+
+    monkeypatch.setattr(macro_liquidity, "invoke_macro_liquidity_llm", fake_invoke)
+    output = macro_liquidity.analyze_macro_liquidity(
+        {
+            "snapshot_id": "macro-invocation",
+            "macro": {"status": "available", "data": {"indicators": {}}},
+        },
+        created_at=NOW,
+        context_projection=projection,
+    )
+
+    assert received["projection"] == projection
+    _assert_bound(output, projection)
+
+
+def test_legacy_agent_call_does_not_add_context_bundle_lineage() -> None:
+    output = analyze_technical(_snapshot(), created_at=NOW)
+
+    assert "context_bundle_id" not in output.input_snapshot_ids
+    assert output.input_payload is None or "context_bundle_summary" not in output.input_payload

--- a/tests/analysis/test_context_bundle_projection.py
+++ b/tests/analysis/test_context_bundle_projection.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from apps.analysis.context_bundle import (
+    bind_projection_to_agent_output,
+    project_context_bundle,
+    validate_consumer_projection,
+)
+from tests.analysis.test_context_bundle import NOW, _bundle, _evidence
+
+
+def _projection_bundle():
+    macro = _evidence("macro", "shared-id", business_time=NOW, ingested_at=NOW)
+    macro["payload"] = {
+        "evidence_type": "macro_metric",
+        "asset": "XAUUSD",
+        "source_quality": "official",
+        "metric": "dxy",
+        "current_value": 101.0,
+        "previous_value": 100.0,
+        "unit": "index",
+    }
+    technical = _evidence("technical", "shared-id", business_time=NOW, ingested_at=NOW + timedelta(minutes=1))
+    technical["payload"] = {
+        "evidence_type": "key_level_event",
+        "asset": "XAUUSD",
+        "source_quality": "official",
+        "level_id": "support-1",
+        "level_role": "support",
+        "level_value": 4000.0,
+        "observed_value": 4001.0,
+        "event": "touch",
+        "confirmation_status": "confirmed",
+    }
+    options = _evidence("options", "options-1", business_time=NOW, ingested_at=NOW + timedelta(minutes=2))
+    options["payload"] = {
+        "evidence_type": "options_regime",
+        "asset": "XAUUSD",
+        "source_quality": "official",
+        "regime_id": "gamma-1",
+        "event": "wall_migration",
+        "change_pct": 10.0,
+        "confirmation_status": "confirmed",
+    }
+    material_event = _evidence("news", "event-1", business_time=NOW, ingested_at=NOW + timedelta(minutes=3))
+    return _bundle(evidence=[macro, technical, options, material_event])
+
+
+@pytest.mark.parametrize(
+    "consumer",
+    [
+        "macro",
+        "options",
+        "risk",
+        "technical",
+        "positioning",
+        "news",
+        "market_odds",
+        "fact_review",
+        "coordinator",
+    ],
+)
+def test_all_consumers_receive_a_valid_typed_projection(consumer: str) -> None:
+    projection = project_context_bundle(_projection_bundle(), consumer=consumer)  # type: ignore[arg-type]
+
+    assert validate_consumer_projection(projection, consumer).consumer == consumer
+    assert projection.identity_payload.state_scope == "daily_close"
+    assert projection.decision_id == projection.decision.decision_id
+    assert projection.selection_trace
+    assert projection.freshness_sla_seconds is not None
+    assert projection.canonical_state["state_scope"] == "daily_close"
+
+
+def test_projection_filters_by_consumer_and_keeps_source_aware_duplicate_ids() -> None:
+    projection = project_context_bundle(_projection_bundle(), consumer="risk")
+
+    assert {item["payload"]["evidence_type"] for item in projection.retained_evidence} == {
+        "macro_metric",
+        "key_level_event",
+        "options_regime",
+        "material_event",
+    }
+    assert {(ref["source"], ref["evidence_id"]) for ref in projection.retained_source_refs} >= {
+        ("macro", "shared-id"),
+        ("technical", "shared-id"),
+    }
+    assert projection.identity_payload.source_refs == projection.retained_source_refs
+
+
+@pytest.mark.parametrize(
+    ("consumer", "expected_types"),
+    [
+        ("macro", {"macro_metric", "material_event"}),
+        ("options", {"options_regime", "key_level_event"}),
+        ("risk", {"macro_metric", "key_level_event", "options_regime", "material_event"}),
+        ("technical", {"key_level_event"}),
+        ("positioning", {"material_event"}),
+        ("news", {"material_event"}),
+        ("market_odds", {"material_event"}),
+        ("fact_review", {"macro_metric", "key_level_event", "options_regime", "material_event"}),
+        ("coordinator", {"macro_metric", "key_level_event", "options_regime", "material_event"}),
+    ],
+)
+def test_projection_consumer_allowlist_matches_runtime_contract(consumer: str, expected_types: set[str]) -> None:
+    projection = project_context_bundle(_projection_bundle(), consumer=consumer)  # type: ignore[arg-type]
+
+    assert {item["payload"]["evidence_type"] for item in projection.retained_evidence} == expected_types
+
+
+def test_projection_revalidation_rejects_nested_tamper_fake_identity_and_wrong_consumer() -> None:
+    projection = project_context_bundle(_projection_bundle(), consumer="macro")
+    tampered = projection.model_dump(mode="json")
+    tampered["canonical_state"]["asset"] = "GC"
+    with pytest.raises(ValueError, match="canonical state"):
+        validate_consumer_projection(tampered, "macro")
+
+    fake_identity = projection.model_dump(mode="json")
+    fake_identity["identity_payload"]["bundle_id"] = "fake-bundle"
+    with pytest.raises(ValueError, match="projection_hash"):
+        validate_consumer_projection(fake_identity, "macro")
+
+    with pytest.raises(ValueError, match="expected consumer"):
+        validate_consumer_projection(projection, "options")
+
+
+def test_projection_binding_carries_exact_identity_without_claiming_consumption() -> None:
+    projection = project_context_bundle(_projection_bundle(), consumer="technical")
+    bound = bind_projection_to_agent_output(
+        projection,
+        {"input_snapshot_ids": {}, "input_payload": {}, "source_refs": []},
+        expected_consumer="technical",
+    )
+
+    input_ids = bound["input_snapshot_ids"]
+    assert input_ids["context_bundle_id"] == projection.identity_payload.bundle_id
+    assert input_ids["context_bundle_hash"] == projection.identity_payload.content_hash
+    assert input_ids["canonical_state_id"] == projection.identity_payload.canonical_state_id
+    assert input_ids["state_scope"] == projection.identity_payload.state_scope
+    assert input_ids["evidence_delta_decision_id"] == projection.decision_id
+    assert input_ids["context_bundle_run_id"] == projection.identity_payload.run_id
+    assert input_ids["retained_evidence_ids"] == [{"source": "technical", "evidence_id": "shared-id"}]
+    assert bound["input_payload"]["context_bundle_identity"] == projection.identity_payload.model_dump(mode="json")
+    assert bound["source_refs"][0]["identity"] == projection.identity_payload.model_dump(mode="json")
+    assert "consumed" not in bound["input_payload"]

--- a/tests/worker/test_composite_state_shadow.py
+++ b/tests/worker/test_composite_state_shadow.py
@@ -174,6 +174,65 @@ def test_provider_metadata_removal_rebuilds_same_bundle_and_recovers_artifact(tm
     assert replay.artifact.written is False
 
 
+def test_same_run_restart_recovers_exact_registered_bundle_descriptor(tmp_path) -> None:
+    first = prepare_composite_state_shadow(
+        storage_root=tmp_path,
+        run_id="run-registry-restart",
+        created_at=NOW,
+        shadow_input=_shadow_input(evidence=[_evidence()]),
+    )
+    restart_input = _shadow_input(evidence=[_macro_evidence(current=101.0)])
+    restart_input["context_bundle_artifact"] = first.artifact.registry_artifact
+
+    recovered = prepare_composite_state_shadow(
+        storage_root=tmp_path,
+        run_id="run-registry-restart",
+        created_at=NOW + timedelta(hours=1),
+        shadow_input=restart_input,
+    )
+
+    assert recovered.bundle.bundle_id == first.bundle.bundle_id
+    assert recovered.bundle.content_hash == first.bundle.content_hash
+    assert recovered.evidence_delta_decision == first.evidence_delta_decision
+    assert recovered.artifact.written is False
+    assert recovered.artifact.registry_artifact == first.artifact.registry_artifact
+
+
+def test_same_run_restart_rejects_wrong_run_and_tampered_descriptor(tmp_path) -> None:
+    first = prepare_composite_state_shadow(
+        storage_root=tmp_path,
+        run_id="run-registry-source",
+        created_at=NOW,
+        shadow_input=_shadow_input(),
+    )
+    wrong_run_input = _shadow_input()
+    wrong_run_input["context_bundle_artifact"] = first.artifact.registry_artifact
+    with pytest.raises(ValueError, match="run_id does not match runtime"):
+        prepare_composite_state_shadow(
+            storage_root=tmp_path,
+            run_id="run-registry-other",
+            created_at=NOW,
+            shadow_input=wrong_run_input,
+        )
+
+    tampered = {
+        **first.artifact.registry_artifact,
+        "metadata": {
+            **first.artifact.registry_artifact["metadata"],
+            "content_hash": "0" * 64,
+        },
+    }
+    tampered_input = _shadow_input()
+    tampered_input["context_bundle_artifact"] = tampered
+    with pytest.raises(ValueError, match="identity mismatch: content_hash"):
+        prepare_composite_state_shadow(
+            storage_root=tmp_path,
+            run_id="run-registry-source",
+            created_at=NOW,
+            shadow_input=tampered_input,
+        )
+
+
 def test_shadow_candidate_is_reviewed_and_all_consumers_share_bundle(tmp_path) -> None:
     runtime = prepare_composite_state_shadow(
         storage_root=tmp_path,
@@ -229,9 +288,7 @@ def test_shadow_analyzer_failure_is_contained_as_needs_review(tmp_path) -> None:
         ([_macro_evidence(current=101.0, source_quality="unverified")], "manual_review", 0),
     ],
 )
-def test_evidence_delta_action_is_the_only_analyzer_gate(
-    tmp_path, evidence, expected_action, expected_calls
-) -> None:
+def test_evidence_delta_action_is_the_only_analyzer_gate(tmp_path, evidence, expected_action, expected_calls) -> None:
     runtime = prepare_composite_state_shadow(
         storage_root=tmp_path,
         run_id="run-decision-gate",
@@ -268,9 +325,7 @@ def test_duplicate_evidence_skips_analyzer_from_recovered_semantic_hash(tmp_path
         shadow_input=_shadow_input(evidence=[evidence]),
     )
     replay_input = _shadow_input(evidence=[evidence])
-    replay_input["previous_semantic_hashes"] = dict(
-        first.evidence_delta_decision.semantic_hashes
-    )
+    replay_input["previous_semantic_hashes"] = dict(first.evidence_delta_decision.semantic_hashes)
     replay = prepare_composite_state_shadow(
         storage_root=tmp_path,
         run_id="run-duplicate",
@@ -324,9 +379,7 @@ def test_accepted_figure_fact_enters_facts_and_evidence_delta_decision(tmp_path)
 
     facts_block = next(block for block in runtime.bundle.blocks if block.name == "facts")
     assert facts_block.payload[0]["figure_fact_id"] == fact.figure_fact_id
-    assert [item.evidence_type for item in runtime.evidence_delta_decision.evaluated_items] == [
-        "figure_fact"
-    ]
+    assert [item.evidence_type for item in runtime.evidence_delta_decision.evaluated_items] == ["figure_fact"]
     assert runtime.evidence_delta_decision.recommended_action.value == "update_context_only"
 
 
@@ -350,6 +403,37 @@ def test_explicit_prior_bundle_recovers_delta_and_selection_state(tmp_path) -> N
     replay = prepare_composite_state_shadow(
         storage_root=tmp_path,
         run_id="run-replay",
+        created_at=NOW + timedelta(hours=1),
+        shadow_input=next_input,
+    )
+
+    assert replay.bundle.freshness_sla_seconds == {"macro": 123}
+    assert replay.bundle.default_freshness_sla_seconds == 456
+    assert replay.evidence_delta_decision.recommended_action.value == "no_op"
+    assert replay.bundle.deferred_queue == first.bundle.deferred_queue
+    assert replay.bundle.processed_above_frontier == first.bundle.processed_above_frontier
+
+
+def test_registered_prior_bundle_recovers_delta_and_selection_state(tmp_path) -> None:
+    first_input = _shadow_input(evidence=[_macro_evidence(current=100.3)])
+    first_input.update(
+        {
+            "freshness_sla_seconds": {"macro": 123},
+            "default_freshness_sla_seconds": 456,
+        }
+    )
+    first = prepare_composite_state_shadow(
+        storage_root=tmp_path,
+        run_id="run-registered-prior",
+        created_at=NOW,
+        shadow_input=first_input,
+    )
+    next_input = _shadow_input(evidence=[_macro_evidence(current=100.3)])
+    next_input["previous_context_bundle_artifact"] = first.artifact.registry_artifact
+
+    replay = prepare_composite_state_shadow(
+        storage_root=tmp_path,
+        run_id="run-registered-replay",
         created_at=NOW + timedelta(hours=1),
         shadow_input=next_input,
     )
@@ -421,9 +505,7 @@ def test_manual_review_trace_persists_through_worker_boundary(tmp_path) -> None:
         storage_root=tmp_path,
         run_id="run-review-persistence",
         created_at=NOW,
-        shadow_input=_shadow_input(
-            evidence=[_macro_evidence(current=101.0, source_quality="unverified")]
-        ),
+        shadow_input=_shadow_input(evidence=[_macro_evidence(current=101.0, source_quality="unverified")]),
     )
     review = execute_composite_state_shadow(runtime=runtime, analyzer=None)["review_items"][0]
     engine = create_engine(f"sqlite:///{tmp_path / 'review-items.db'}")

--- a/tests/worker/test_context_bundle_artifact_registration.py
+++ b/tests/worker/test_context_bundle_artifact_registration.py
@@ -1,0 +1,537 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from uuid import NAMESPACE_URL, uuid4, uuid5
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import apps.worker.artifact_registration as artifact_registration
+from apps.analysis.context_bundle import assemble_context_bundle
+from apps.output.context_bundle import write_context_bundle
+from apps.runtime.artifact_registry import (
+    select_context_bundle_artifact_for_run,
+    select_previous_context_bundle_artifact,
+)
+from apps.worker.artifact_registration import (
+    register_composite_output_artifacts,
+    register_context_bundle_artifact,
+)
+from apps.worker.runner import _resolve_state_shadow_registry_inputs
+from database.models.execution import RunArtifact, ensure_execution_tables
+from database.models.task import StepStatus, TaskRun, TaskStep, TaskStatus, ensure_task_tables
+
+
+NOW = datetime(2026, 7, 26, 8, tzinfo=UTC)
+
+
+def _assert_descriptor_identity(selected: dict, expected: dict) -> None:
+    for key in (
+        "artifact_family",
+        "schema_version",
+        "bundle_id",
+        "content_hash",
+        "asset",
+        "state_scope",
+        "run_id",
+        "canonical_state_id",
+    ):
+        assert selected["metadata"][key] == expected["metadata"][key]
+
+
+def _session(*, execution_tables: bool = True):
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    ensure_task_tables(engine)
+    if execution_tables:
+        ensure_execution_tables(engine)
+    return sessionmaker(bind=engine, expire_on_commit=False)()
+
+
+def _run_step(db):
+    run = TaskRun(name="premarket", status=TaskStatus.pending, snapshot_id="snapshot-79")
+    db.add(run)
+    db.flush()
+    step = TaskStep(task_run_id=run.id, name="report_render", status=StepStatus.success)
+    db.add(step)
+    db.flush()
+    return run, step
+
+
+def _valid_descriptor(
+    tmp_path,
+    *,
+    run_id: str,
+    cutoff_at: datetime = NOW,
+    asset: str = "XAUUSD",
+    state_scope: str = "daily_close",
+    canonical_state_id: str = "state-79",
+) -> dict:
+    bundle = assemble_context_bundle(
+        run_id=run_id,
+        asset=asset,
+        state_scope=state_scope,
+        canonical_state_id=canonical_state_id,
+        canonical_state={"asset": asset, "state_scope": state_scope, "core_thesis": "等待确认"},
+        evidence=[],
+        evidence_cursors={},
+        cutoff_at=cutoff_at,
+        assembled_at=cutoff_at + timedelta(minutes=1),
+        expected_session="daily_close",
+    )
+    return write_context_bundle(storage_root=tmp_path, bundle=bundle).registry_artifact
+
+
+def _register_valid_bundle(
+    db,
+    tmp_path,
+    *,
+    cutoff_at: datetime = NOW,
+    asset: str = "XAUUSD",
+    state_scope: str = "daily_close",
+    canonical_state_id: str = "state-79",
+):
+    run, step = _run_step(db)
+    descriptor = _valid_descriptor(
+        tmp_path,
+        run_id=str(run.id),
+        cutoff_at=cutoff_at,
+        asset=asset,
+        state_scope=state_scope,
+        canonical_state_id=canonical_state_id,
+    )
+    row = register_context_bundle_artifact(
+        db, run_id=str(run.id), step=step, descriptor=descriptor, storage_root=tmp_path
+    )
+    db.flush()
+    return run, step, descriptor, row
+
+
+def test_context_bundle_registry_is_exactly_once_and_idempotent(tmp_path) -> None:
+    db = _session()
+    run, step = _run_step(db)
+    descriptor = _valid_descriptor(tmp_path, run_id=str(run.id))
+
+    first = register_context_bundle_artifact(
+        db, run_id=str(run.id), step=step, descriptor=descriptor, storage_root=tmp_path
+    )
+    replay = register_context_bundle_artifact(
+        db, run_id=str(run.id), step=step, descriptor=descriptor, storage_root=tmp_path
+    )
+    db.commit()
+
+    rows = db.query(RunArtifact).filter(RunArtifact.run_id == run.id).all()
+    assert first is not None and replay is not None
+    assert first.artifact_id == replay.artifact_id
+    assert first.artifact_id == uuid5(
+        NAMESPACE_URL,
+        f"finance-agent:run-context-bundle:{run.id}",
+    )
+    assert len(rows) == 1
+    assert str(rows[0].artifact_id) != descriptor["metadata"]["bundle_id"]
+    assert rows[0].sha256 == descriptor["sha256"]
+    assert rows[0].artifact_metadata["bundle_id"] == descriptor["metadata"]["bundle_id"]
+
+
+def test_context_bundle_registry_rejects_conflicting_replay(tmp_path) -> None:
+    db = _session()
+    run, step = _run_step(db)
+    descriptor = _valid_descriptor(tmp_path, run_id=str(run.id))
+    register_context_bundle_artifact(db, run_id=str(run.id), step=step, descriptor=descriptor, storage_root=tmp_path)
+
+    with pytest.raises(ValueError, match="descriptor payload identity conflicts"):
+        register_context_bundle_artifact(
+            db,
+            run_id=str(run.id),
+            step=step,
+            descriptor={**descriptor, "metadata": {**descriptor["metadata"], "content_hash": "b" * 64}},
+            storage_root=tmp_path,
+        )
+
+
+def test_context_bundle_registry_rejects_generic_artifact_dedupe_collision(tmp_path) -> None:
+    db = _session()
+    run, step = _run_step(db)
+    descriptor = _valid_descriptor(tmp_path, run_id=str(run.id))
+    db.add(
+        RunArtifact(
+            run_id=run.id,
+            task_id=step.id,
+            artifact_type="structured_json",
+            file_path=descriptor["file_path"],
+            sha256=descriptor["sha256"],
+            artifact_metadata={"artifact_family": "unrelated_output"},
+        )
+    )
+    db.flush()
+
+    with pytest.raises(ValueError, match="identity conflicts"):
+        register_context_bundle_artifact(
+            db,
+            run_id=str(run.id),
+            step=step,
+            descriptor=descriptor,
+            storage_root=tmp_path,
+        )
+
+
+@pytest.mark.parametrize("conflicting_winner", [False, True])
+def test_context_bundle_registry_validates_concurrent_insert_winner(
+    tmp_path, monkeypatch, conflicting_winner: bool
+) -> None:
+    db = _session()
+    run, step = _run_step(db)
+    descriptor = _valid_descriptor(tmp_path, run_id=str(run.id))
+    registry_id = uuid5(NAMESPACE_URL, f"finance-agent:run-context-bundle:{run.id}")
+    metadata = dict(descriptor["metadata"])
+    if conflicting_winner:
+        metadata["content_hash"] = "f" * 64
+    winner = RunArtifact(
+        artifact_id=registry_id,
+        run_id=run.id,
+        task_id=step.id,
+        artifact_type="structured_json",
+        file_path=descriptor["file_path"],
+        sha256=descriptor["sha256"],
+        artifact_metadata=metadata,
+    )
+
+    def lose_concurrent_insert(*args, **kwargs):
+        raise IntegrityError("INSERT", {}, RuntimeError("duplicate primary key"))
+
+    monkeypatch.setattr(artifact_registration, "register_artifact", lose_concurrent_insert)
+    monkeypatch.setattr(db, "get", lambda model, identity: winner if identity == registry_id else None)
+
+    if conflicting_winner:
+        with pytest.raises(ValueError, match="identity conflicts"):
+            register_context_bundle_artifact(
+                db,
+                run_id=str(run.id),
+                step=step,
+                descriptor=descriptor,
+                storage_root=tmp_path,
+            )
+    else:
+        assert (
+            register_context_bundle_artifact(
+                db,
+                run_id=str(run.id),
+                step=step,
+                descriptor=descriptor,
+                storage_root=tmp_path,
+            )
+            is winner
+        )
+
+
+def test_context_bundle_registration_rejects_step_lineage_and_invalid_payload(tmp_path) -> None:
+    db = _session()
+    run, step = _run_step(db)
+    descriptor = _valid_descriptor(tmp_path, run_id=str(run.id))
+
+    with pytest.raises(ValueError, match="step.task_run_id"):
+        register_context_bundle_artifact(
+            db,
+            run_id=str(uuid4()),
+            step=step,
+            descriptor=descriptor,
+            storage_root=tmp_path,
+        )
+
+    tampered = {**descriptor, "sha256": "A" * 64}
+    with pytest.raises(ValueError, match="file identity is incomplete"):
+        register_context_bundle_artifact(db, run_id=str(run.id), step=step, descriptor=tampered, storage_root=tmp_path)
+
+
+def test_context_bundle_registry_is_compatible_when_table_is_absent(tmp_path) -> None:
+    db = _session(execution_tables=False)
+    run, step = _run_step(db)
+    assert (
+        register_context_bundle_artifact(
+            db,
+            run_id=str(run.id),
+            step=step,
+            descriptor=_valid_descriptor(tmp_path, run_id=str(run.id)),
+            storage_root=tmp_path,
+        )
+        is None
+    )
+
+
+def test_same_run_selector_returns_validated_descriptor_and_rejects_tampering(tmp_path) -> None:
+    db = _session()
+    run, _step, descriptor, row = _register_valid_bundle(db, tmp_path)
+
+    selected = select_context_bundle_artifact_for_run(db, run_id=str(run.id), storage_root=tmp_path)
+    _assert_descriptor_identity(selected, descriptor)
+    assert selected["sha256"] == descriptor["sha256"]
+
+    path = tmp_path / row.file_path
+    path.write_text(path.read_text(encoding="utf-8").replace("XAUUSD", "XAUUSZ", 1), encoding="utf-8")
+    with pytest.raises(ValueError, match="file hash mismatch"):
+        select_context_bundle_artifact_for_run(db, run_id=str(run.id), storage_root=tmp_path)
+
+
+def test_same_run_selector_rejects_metadata_payload_identity_conflict(tmp_path) -> None:
+    db = _session()
+    run, _step, _descriptor_value, row = _register_valid_bundle(db, tmp_path)
+    row.artifact_metadata = {**row.artifact_metadata, "content_hash": "0" * 64}
+    db.flush()
+
+    with pytest.raises(ValueError, match="payload identity conflicts"):
+        select_context_bundle_artifact_for_run(db, run_id=str(run.id), storage_root=tmp_path)
+
+
+def test_same_run_selector_rejects_multiple_bundle_rows(tmp_path) -> None:
+    db = _session()
+    run, step, _descriptor_one, _row = _register_valid_bundle(db, tmp_path)
+    descriptor_two = _valid_descriptor(tmp_path, run_id=str(run.id), cutoff_at=NOW + timedelta(minutes=2))
+    second = RunArtifact(
+        run_id=run.id,
+        task_id=step.id,
+        artifact_type="structured_json",
+        file_path=descriptor_two["file_path"],
+        sha256=descriptor_two["sha256"],
+        artifact_metadata=descriptor_two["metadata"],
+    )
+    db.add(second)
+    db.flush()
+    with pytest.raises(ValueError, match="ambiguous ContextBundle"):
+        select_context_bundle_artifact_for_run(db, run_id=str(run.id), storage_root=tmp_path)
+
+
+def test_worker_registry_input_resolver_distinguishes_restart_and_prior_run(tmp_path) -> None:
+    db = _session()
+    prior, _step, prior_descriptor, _row = _register_valid_bundle(db, tmp_path)
+    canonical_input = {
+        "state_scope": "daily_close",
+        "canonical_state_id": "state-79",
+        "canonical_state": {"asset": "XAUUSD"},
+        "cutoff_at": NOW + timedelta(hours=1),
+        "previous_bundle_path": "caller-must-not-be-authority.json",
+    }
+
+    restart = _resolve_state_shadow_registry_inputs(
+        db=db,
+        run_id=str(prior.id),
+        storage_root=tmp_path,
+        state_shadow_input=canonical_input,
+    )
+    _assert_descriptor_identity(restart["context_bundle_artifact"], prior_descriptor)
+    assert "previous_bundle_path" not in restart
+
+    current, _current_step = _run_step(db)
+    previous = _resolve_state_shadow_registry_inputs(
+        db=db,
+        run_id=str(current.id),
+        storage_root=tmp_path,
+        state_shadow_input=canonical_input,
+    )
+    _assert_descriptor_identity(previous["previous_context_bundle_artifact"], prior_descriptor)
+    assert "context_bundle_artifact" not in previous
+
+
+@pytest.mark.parametrize(
+    "field, value", [("asset", "EURUSD"), ("state_scope", "intraday"), ("canonical_state_id", "other-state")]
+)
+def test_previous_selector_excludes_wrong_lineage(tmp_path, field, value) -> None:
+    db = _session()
+    current, _ = _run_step(db)
+    kwargs = {field: value}
+    _register_valid_bundle(db, tmp_path, **kwargs)
+    assert (
+        select_previous_context_bundle_artifact(
+            db,
+            current_run_id=str(current.id),
+            asset="XAUUSD",
+            state_scope="daily_close",
+            canonical_state_id="state-79",
+            cutoff_at=NOW + timedelta(hours=1),
+            storage_root=tmp_path,
+        )
+        is None
+    )
+
+
+def test_previous_selector_excludes_current_run_and_returns_none_without_match(tmp_path) -> None:
+    db = _session()
+    run, _step, descriptor, _row = _register_valid_bundle(db, tmp_path)
+    assert (
+        select_previous_context_bundle_artifact(
+            db,
+            current_run_id=str(run.id),
+            asset="XAUUSD",
+            state_scope="daily_close",
+            canonical_state_id="state-79",
+            cutoff_at=NOW + timedelta(hours=1),
+            storage_root=tmp_path,
+        )
+        is None
+    )
+    selected = select_context_bundle_artifact_for_run(db, run_id=str(run.id), storage_root=tmp_path)
+    _assert_descriptor_identity(selected, descriptor)
+
+
+def test_previous_selector_excludes_bundles_after_cutoff(tmp_path) -> None:
+    db = _session()
+    current, _ = _run_step(db)
+    _register_valid_bundle(db, tmp_path, cutoff_at=NOW + timedelta(hours=1))
+    assert (
+        select_previous_context_bundle_artifact(
+            db,
+            current_run_id=str(current.id),
+            asset="XAUUSD",
+            state_scope="daily_close",
+            canonical_state_id="state-79",
+            cutoff_at=NOW,
+            storage_root=tmp_path,
+        )
+        is None
+    )
+
+
+def test_previous_selector_ignores_more_than_limit_unrelated_structured_artifacts(tmp_path) -> None:
+    db = _session()
+    current, _ = _run_step(db)
+    _prior, _step, descriptor, _row = _register_valid_bundle(db, tmp_path)
+    for index in range(129):
+        db.add(
+            RunArtifact(
+                run_id=uuid4(),
+                artifact_type="structured_json",
+                file_path=f"outputs/unrelated/{index}.json",
+                artifact_metadata={"artifact_family": "unrelated"},
+            )
+        )
+    db.flush()
+
+    selected = select_previous_context_bundle_artifact(
+        db,
+        current_run_id=str(current.id),
+        asset="XAUUSD",
+        state_scope="daily_close",
+        canonical_state_id="state-79",
+        cutoff_at=NOW + timedelta(hours=1),
+        storage_root=tmp_path,
+    )
+    _assert_descriptor_identity(selected, descriptor)
+
+
+def test_previous_selector_returns_latest_and_fails_closed_on_ambiguous_latest(tmp_path) -> None:
+    db = _session()
+    current, _ = _run_step(db)
+    older, _step, older_descriptor, _ = _register_valid_bundle(db, tmp_path, cutoff_at=NOW - timedelta(hours=2))
+    latest, latest_step, latest_descriptor, latest_row = _register_valid_bundle(
+        db, tmp_path, cutoff_at=NOW - timedelta(hours=1)
+    )
+
+    selected = select_previous_context_bundle_artifact(
+        db,
+        current_run_id=str(current.id),
+        asset="XAUUSD",
+        state_scope="daily_close",
+        canonical_state_id="state-79",
+        cutoff_at=NOW,
+        storage_root=tmp_path,
+    )
+    _assert_descriptor_identity(selected, latest_descriptor)
+    assert selected["metadata"]["bundle_id"] != older_descriptor["metadata"]["bundle_id"]
+
+    duplicate = RunArtifact(
+        run_id=latest.id,
+        task_id=latest_step.id,
+        artifact_type="structured_json",
+        file_path=latest_descriptor["file_path"],
+        sha256=latest_descriptor["sha256"],
+        artifact_metadata=latest_descriptor["metadata"],
+        created_at=latest_row.created_at,
+    )
+    db.add(duplicate)
+    db.flush()
+    with pytest.raises(ValueError, match="latest candidate is ambiguous"):
+        select_previous_context_bundle_artifact(
+            db,
+            current_run_id=str(current.id),
+            asset="XAUUSD",
+            state_scope="daily_close",
+            canonical_state_id="state-79",
+            cutoff_at=NOW,
+            storage_root=tmp_path,
+        )
+
+
+def test_bundle_registry_failure_does_not_skip_legacy_artifact_registration(monkeypatch) -> None:
+    registered = []
+
+    def fail_bundle(*args, **kwargs):
+        raise ValueError("conflicting bundle identity")
+
+    def capture_legacy(*args, **kwargs):
+        registered.append(kwargs)
+        return []
+
+    monkeypatch.setattr("apps.worker.artifact_registration.register_context_bundle_artifact", fail_bundle)
+    monkeypatch.setattr("apps.worker.artifact_registration.register_step_artifacts", capture_legacy)
+    outputs = {
+        "context_bundle_registry_artifact": {"metadata": {"bundle_id": "bundle-conflict"}},
+        "report_result": {"paths": ["outputs/final_report/report.md"]},
+        "card_result": {"paths": ["outputs/strategy_card/card.json"]},
+        "agent_loop_decision": SimpleNamespace(publish_allowed=True),
+    }
+
+    register_composite_output_artifacts(
+        SimpleNamespace(), run_id="run-79", steps=[SimpleNamespace(name="report_render")], composite_outputs=outputs
+    )
+
+    assert outputs["context_bundle_registry_status"] == {
+        "status": "failed",
+        "bundle_id": "bundle-conflict",
+        "reason": "ValueError:conflicting bundle identity",
+    }
+    assert len(registered) == 1
+
+
+def test_nested_transaction_rolls_back_bundle_failure_and_legacy_registration_survives(tmp_path, monkeypatch) -> None:
+    db = _session()
+    run, step = _run_step(db)
+    legacy_calls = []
+
+    def capture_legacy(*args, **kwargs):
+        legacy_calls.append(kwargs)
+        return []
+
+    def write_then_fail(db, **_kwargs):
+        db.add(
+            RunArtifact(
+                run_id=run.id,
+                task_id=step.id,
+                artifact_type="structured_json",
+                file_path="outputs/context_bundles/failed.json",
+            )
+        )
+        db.flush()
+        raise ValueError("forced nested failure")
+
+    monkeypatch.setattr("apps.worker.artifact_registration.register_step_artifacts", capture_legacy)
+    monkeypatch.setattr("apps.worker.artifact_registration.register_context_bundle_artifact", write_then_fail)
+    outputs = {
+        "context_bundle_registry_artifact": {"metadata": {"bundle_id": "bad"}},
+        "report_result": {"paths": ["outputs/final_report/report.md"]},
+        "card_result": {"paths": ["outputs/strategy_card/card.json"]},
+        "agent_loop_decision": SimpleNamespace(publish_allowed=False),
+    }
+    register_composite_output_artifacts(
+        db, run_id=str(run.id), steps=[step], composite_outputs=outputs, storage_root=tmp_path
+    )
+    db.commit()
+    assert outputs["context_bundle_registry_status"]["status"] == "failed"
+    assert db.get(TaskRun, run.id) is not None
+    assert db.query(RunArtifact).filter(RunArtifact.run_id == run.id).count() == 0
+    assert len(legacy_calls) == 1

--- a/tests/worker/test_premarket_composite_output_integration.py
+++ b/tests/worker/test_premarket_composite_output_integration.py
@@ -149,6 +149,32 @@ def _make_rich_snapshot(
     }
 
 
+def _make_noop_state_shadow_input() -> dict:
+    return {
+        "state_scope": "daily_close",
+        "canonical_state_id": "state-shadow-root",
+        "canonical_state": {
+            "asset": "XAUUSD",
+            "as_of": (_CREATED_AT - timedelta(hours=1)).isoformat(),
+            "market_stage": "direction_decision",
+            "core_thesis": "等待突破",
+            "net_bias": "mixed_bullish",
+            "dominant_drivers": [],
+            "key_levels": [{"price": 3300, "role": "support"}],
+            "scenario_states": [],
+            "unresolved_items": [],
+            "invalidation_conditions": [],
+            "evidence_cursors": {},
+            "input_snapshot_ids": {"market": "market-shadow-1"},
+            "source_refs": [{"snapshot_id": "market-shadow-1"}],
+        },
+        "evidence": [],
+        "evidence_cursors": {},
+        "cutoff_at": _CREATED_AT.isoformat(),
+        "assembled_at": _CREATED_AT.isoformat(),
+    }
+
+
 def test_composite_state_delta_shadow_shares_one_bundle_without_canonical_write(
     tmp_path: Path,
 ) -> None:
@@ -240,9 +266,7 @@ def test_composite_state_delta_shadow_shares_one_bundle_without_canonical_write(
 
     shadow = outputs["state_delta_shadow"]
     assert summaries["state_delta_shadow"]["status"] == "success"
-    assert summaries["state_delta_shadow"]["shadow_status"] == (
-        "candidate_accepted_shadow_only"
-    )
+    assert summaries["state_delta_shadow"]["shadow_status"] == ("candidate_accepted_shadow_only")
     assert shadow["production_canonical_write_allowed"] is False
     assert shadow["shadow_review_status"] == "accepted"
     bundle_ids = set(shadow["bundle_consumers"].values())
@@ -258,8 +282,74 @@ def test_composite_state_delta_shadow_shares_one_bundle_without_canonical_write(
         "fact_review_agent",
         "coordinator_agent",
     ):
-        assert "analysis_context_bundle" not in outputs["agents"][name].input_snapshot_ids
+        agent_output = outputs["agents"][name]
+        lineage = agent_output.input_snapshot_ids
+        assert lineage["context_bundle_id"] == shadow["bundle_id"]
+        assert lineage["context_bundle_hash"] == shadow["bundle_content_hash"]
+        assert lineage["canonical_state_id"] == shadow["canonical_state_id"]
+        assert lineage["state_scope"] == "daily_close"
+        assert "retained_evidence_ids" in lineage
+        assert lineage["evidence_delta_decision_id"] == shadow["evidence_delta_decision_id"]
+        assert (
+            agent_output.input_payload["context_bundle_summary"]["decision_id"] == shadow["evidence_delta_decision_id"]
+        )
+    assert outputs["context_bundle_registry_artifact"]["metadata"]["bundle_id"] == shadow["bundle_id"]
     assert (tmp_path / shadow["bundle_path"]).is_file()
+
+
+def test_state_delta_pipeline_rejects_consumer_bypass_and_prebuilt_outputs(tmp_path: Path, monkeypatch) -> None:
+    from apps.worker import composite_analysis_pipeline as pipeline
+
+    original = pipeline.analyze_market_odds
+
+    def bypass_projection(snapshot, *, created_at=None, context_projection=None):
+        assert context_projection is not None
+        return original(snapshot, created_at=created_at)
+
+    monkeypatch.setattr(pipeline, "analyze_market_odds", bypass_projection)
+    with pytest.raises(ValueError, match="market_odds_agent did not return auditable"):
+        pipeline.run_composite_analysis_pipeline(
+            storage_root=tmp_path,
+            snapshot=_make_rich_snapshot(run_id="run-consumer-bypass"),
+            run_id="run-consumer-bypass",
+            created_at=_CREATED_AT,
+            analysis_context_mode="state_delta_context",
+            state_shadow_input=_make_noop_state_shadow_input(),
+        )
+
+    def forge_projection_content(snapshot, *, created_at=None, context_projection=None):
+        assert context_projection is not None
+        output = original(
+            snapshot,
+            created_at=created_at,
+            context_projection=context_projection,
+        )
+        input_payload = dict(output.input_payload)
+        input_payload["context_bundle_projection"] = {"forged": True}
+        return output.model_copy(update={"input_payload": input_payload})
+
+    monkeypatch.setattr(pipeline, "analyze_market_odds", forge_projection_content)
+    with pytest.raises(ValueError, match="did not consume its exact typed projection"):
+        pipeline.run_composite_analysis_pipeline(
+            storage_root=tmp_path,
+            snapshot=_make_rich_snapshot(run_id="run-consumer-forgery"),
+            run_id="run-consumer-forgery",
+            created_at=_CREATED_AT,
+            analysis_context_mode="state_delta_context",
+            state_shadow_input=_make_noop_state_shadow_input(),
+        )
+
+    monkeypatch.setattr(pipeline, "analyze_market_odds", original)
+    with pytest.raises(ValueError, match="forbids unverified prebuilt Agent outputs"):
+        pipeline.run_composite_analysis_pipeline(
+            storage_root=tmp_path,
+            snapshot=_make_rich_snapshot(run_id="run-prebuilt-bypass"),
+            run_id="run-prebuilt-bypass",
+            created_at=_CREATED_AT,
+            macro_output_prebuilt=object(),
+            analysis_context_mode="state_delta_context",
+            state_shadow_input=_make_noop_state_shadow_input(),
+        )
 
 
 def test_composite_manual_review_keeps_review_item_and_skips_transition_analyzer(
@@ -355,8 +445,7 @@ def test_composite_shadow_setup_failure_does_not_break_legacy_outputs(tmp_path: 
     assert outputs["state_delta_shadow"]["production_canonical_write_allowed"] is False
     review = outputs["state_delta_shadow"]["review_items"][0]
     assert review == {
-        "review_id": "state_delta_setup:run-shadow-setup-failure:"
-        "78a572444077af19",
+        "review_id": "state_delta_setup:run-shadow-setup-failure:78a572444077af19",
         "run_id": "run-shadow-setup-failure",
         "source_module": "state_delta_shadow",
         "source_step_id": "state_delta_shadow_setup",
@@ -452,9 +541,9 @@ def test_composite_analysis_pipeline_writes_final_report_and_strategy_card(tmp_p
     assert json.loads(source_health_path.read_text(encoding="utf-8")) == outputs["source_health"]
     persisted_gate = json.loads(quality_gate_result_path.read_text(encoding="utf-8"))
     assert persisted_gate["publish_allowed"] is outputs["agent_loop_decision"].publish_allowed
-    assert persisted_gate["quality_gate_decision"] == outputs[
-        "post_coordinator_quality_gate_decision"
-    ].model_dump(mode="json")
+    assert persisted_gate["quality_gate_decision"] == outputs["post_coordinator_quality_gate_decision"].model_dump(
+        mode="json"
+    )
 
     assert "strategy_card" in summaries
     assert summaries["strategy_card"]["status"] == "success"
@@ -564,9 +653,7 @@ def test_composite_runtime_summary_merges_seven_gold_agents_with_report_render(
             "gold_agent_execution": {
                 "snapshot_id": execution["snapshot_id"],
                 "declared_agents": execution["declared_agents"],
-                "materialized_stage_envelopes": execution[
-                    "materialized_stage_envelopes"
-                ],
+                "materialized_stage_envelopes": execution["materialized_stage_envelopes"],
                 "executed_agents": execution["executed_agents"],
                 "artifact_paths": execution["artifact_paths"],
             }
@@ -593,9 +680,7 @@ def test_composite_runtime_summary_merges_seven_gold_agents_with_report_render(
         "report_render_agent",
     ]
     assert runtime["materialized_stage_envelopes"] == runtime["declared_agents"]
-    assert set(runtime["agent_artifact_refs"]) == set(
-        runtime["materialized_stage_envelopes"]
-    )
+    assert set(runtime["agent_artifact_refs"]) == set(runtime["materialized_stage_envelopes"])
 
 
 def test_composite_analysis_pipeline_returns_final_report_quality_gate_metadata(tmp_path: Path) -> None:
@@ -823,10 +908,7 @@ def test_composite_analysis_pipeline_synthesizes_from_coordinator_after_post_gat
     assert summaries["final_report"]["publish_allowed"] is False
     assert composite_outputs["strategy_card"].bias.value == "neutral"
     assert "No strong conclusion" in composite_outputs["strategy_card"].scenario_summary
-    assert (
-        composite_outputs["observe_outputs"]["final_report_paths"]
-        == summaries["final_report"]["paths"]
-    )
+    assert composite_outputs["observe_outputs"]["final_report_paths"] == summaries["final_report"]["paths"]
     assert composite_outputs["gold_runtime_summary"]["accepted_outputs"] == {}
 
 
@@ -885,9 +967,10 @@ def test_composite_analysis_pipeline_post_gate_can_reject_coordinator_after_pre_
     assert summaries["final_report"]["quality_gate_decision"]["action"] == "block_publish"
     assert summaries["final_report"]["publish_allowed"] is False
     assert composite_outputs["agent_loop_decision"].accepted_output.source == "none"
-    assert composite_outputs["agents"]["fallback_synthesis_agent"].input_payload["fallback_of"][
-        "agent_name"
-    ] == "coordinator_agent"
+    assert (
+        composite_outputs["agents"]["fallback_synthesis_agent"].input_payload["fallback_of"]["agent_name"]
+        == "coordinator_agent"
+    )
 
 
 def test_composite_analysis_pipeline_executes_cme_options_reparse_when_gate_requires_reparse(


### PR DESCRIPTION
## Summary\n\n- build immutable typed projections for all nine domain consumers from one AnalysisContextBundle\n- require each Agent to consume and return the exact bounded projection identity and content\n- register and recover the Bundle through validated RunArtifact authority with deterministic concurrent identity\n- preserve legacy default mode and keep canonical materialization/CAS/canary activation out of scope\n\n## Acceptance evidence\n\n- projection and consumer tests: 35 passed\n- Bundle selection and domain Agent tests: 41 passed\n- shadow and registry tests: 39 passed\n- hardened registry tests: 20 passed\n- composite output integration: 31 passed\n- composite DB integration: 9 passed\n- architecture guards: 38 passed\n- Ruff and git diff check passed\n\n## Boundaries\n\n- no AnalysisState schema or migration changes\n- no production canary activation\n- no canonical materialization or CAS changes\n- no frontend, production data, secrets, or environment changes\n\nCloses #79