### PR TITLE
docs: enforce linear public release review

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -1,0 +1,52 @@
+# Public Release PR Checklist
+
+Use this checklist for every pull request targeting the public `main` branch.
+It is a review gate, not evidence that publication, deployment, or runtime
+activation has already happened.
+
+## Scope and history
+
+- [ ] This PR is linked to exactly one Issue: `Closes #<issue-number>`.
+- [ ] Any exception to the one-PR/one-Issue rule names the linked Issues, the
+  approving maintainer, and the reason.
+- [ ] The PR is based on the current public `main` and preserves history from
+  baseline `f4499c3`.
+- [ ] The PR does not replace a published snapshot or force-push `main`.
+
+## Required CI
+
+All of the following checks are green for the reviewed head commit:
+
+- [ ] `Backend contracts`
+- [ ] `Analysis Memory PostgreSQL`
+- [ ] `Frontend contracts`
+- [ ] `Gold Policy core`
+
+## Public-content review
+
+- [ ] The diff contains no local runtime data or generated reports. The
+  `storage/raw`, `storage/parsed`, `storage/features`, and `storage/outputs`
+  trees contain no runtime files except tracked `.gitkeep` placeholders.
+- [ ] The diff contains no private or local paths, browser profiles, cookies,
+  login state, keys, tokens, webhooks, internal collaboration references, or
+  private operational material.
+- [ ] Secret and local-path scans pass for the complete PR diff.
+- [ ] The changed files are limited to the linked Issue and do not bundle the
+  next roadmap slice.
+
+## Delivery state
+
+Record evidence separately and leave unperformed states unchecked:
+
+- [ ] Code merged — merge commit or squash SHA: ______
+- [ ] CI green for the merged commit — run URL: ______
+- [ ] Public repository publication confirmed — remote SHA: ______
+- [ ] Deployment completed — environment/evidence: ______
+- [ ] Runtime activation verified — probe/artifact evidence: ______
+
+Publication, deployment, and runtime activation must not be inferred from code
+merge or CI success.
+
+## One-PR/one-Issue exception
+
+`None` or: Issue links, approving maintainer, and written rationale.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,55 @@
+<!-- Complete every applicable item. This is a review gate, not a claim that
+publication, deployment, or runtime activation has happened. -->
+
+## Issue and outcome
+
+Closes #
+
+Outcome:
+
+- [ ] This PR is linked to exactly one Issue.
+- [ ] Any exception names all linked Issues, the approving maintainer, and the
+  reason below.
+
+## Scope and history
+
+- [ ] This branch started from the current public `main` and preserves history
+  from baseline `f4499c3`.
+- [ ] This PR does not replace a published snapshot or force-push `main`.
+- [ ] The diff is limited to the linked Issue and excludes the next roadmap
+  slice.
+
+## Required CI
+
+- [ ] `Backend contracts`
+- [ ] `Analysis Memory PostgreSQL`
+- [ ] `Frontend contracts`
+- [ ] `Gold Policy core`
+
+## Public-content review
+
+- [ ] No local runtime data or generated reports are included.
+- [ ] `storage/raw`, `storage/parsed`, `storage/features`, and `storage/outputs`
+  contain no runtime files except tracked `.gitkeep` placeholders.
+- [ ] No private/local paths, browser profiles, cookies, login state, keys,
+  tokens, webhooks, internal collaboration references, or private operational
+  material are included.
+- [ ] Secret and local-path scans pass for the complete PR diff.
+
+## Verification evidence
+
+Commands, tests, API/page/artifact evidence, and results:
+
+## Delivery state
+
+Record facts only; leave unperformed states unchecked.
+
+- [ ] Code merged — SHA: ______
+- [ ] CI green for merged commit — run URL: ______
+- [ ] Public repository publication confirmed — remote SHA: ______
+- [ ] Deployment completed — evidence: ______
+- [ ] Runtime activation verified — evidence: ______
+
+## One-PR/one-Issue exception
+
+`None` or: Issue links, approving maintainer, and written rationale.


### PR DESCRIPTION
## What changed

- Added a public release checklist for every pull request targeting `main`.
- Added a pull request template that records Issue scope, required CI, public-content review, verification evidence, and delivery state.
- Established `f4499c3` as the immutable public baseline for subsequent linear PR history.

## Why

Previous public releases could replace a large snapshot, which made incremental review and rollback difficult. This PR introduces the repository-facing review controls for the new linear release workflow.

## Impact

- Future public changes must be scoped to one Issue unless a written exception is approved.
- The four established CI checks must be green before merge.
- Code merge, CI, publication, deployment, and runtime activation are recorded separately.
- Runtime data, private paths, credentials, and internal operational material are explicitly excluded.

## Verification

- `git diff --check public/main...HEAD`
- `git merge-base public/main HEAD` -> `f4499c3`
- `git rev-list --left-right --count public/main...HEAD` -> `0 1`
- Public storage contains only tracked `.gitkeep` placeholders.
- Diff-sensitive scan found no credential or private-path value; keyword matches were checklist policy text only.

## Delivery state

- [x] Candidate commit created: `e98b747`
- [x] Candidate branch pushed
- [x] Required PR CI green — Actions run `31662081898`
- [ ] Code merged
- [ ] Deployment completed
- [ ] Runtime activation verified

Closes #109
